### PR TITLE
Add PRD breakdown with 25 mini-plan docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,8 +13,8 @@ CodeCompress is an MCP (Model Context Protocol) server that indexes codebases an
 
 ```bash
 # Restore, build, and run all tests
-dotnet build CodeCompress.sln
-dotnet test CodeCompress.sln
+dotnet build CodeCompress.slnx
+dotnet test CodeCompress.slnx
 
 # Run a specific test project
 dotnet test tests/CodeCompress.Core.Tests

--- a/README.md
+++ b/README.md
@@ -1,0 +1,194 @@
+# CodeCompress
+
+**Intelligent Code Index MCP Server for AI Agents**
+
+CodeCompress is a lightweight [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that indexes your codebase and gives AI agents instant, surgical access to code symbols — no more scanning every file at the start of each conversation.
+
+## The Problem
+
+Every time an AI coding agent (Claude Code, Cursor, etc.) starts a new session, it has zero memory of your codebase. It compensates by reading through your source files to build understanding before doing any real work. As your project grows, this gets painful:
+
+- **30–150k+ tokens wasted** per session just loading context
+- **2–5 minutes of latency** before the agent starts being productive
+- **Sub-agents duplicate the work**, each independently scanning the same files
+- **Scales linearly** — bigger codebase = longer wait, every single time
+
+## The Solution
+
+CodeCompress maintains a persistent index of your codebase — symbols, types, dependencies, API surfaces — in a local SQLite database. AI agents query the index via MCP tools to get exactly what they need:
+
+- `project_outline` returns your entire API surface in ~3–8k tokens (regardless of codebase size)
+- `get_symbol` retrieves a single function's source code by byte offset
+- `search_symbols` finds symbols by name, signature, or documentation
+- `changes_since` shows what changed since a named snapshot
+
+**Result: 80–90% reduction in token consumption for context loading.**
+
+## Supported Languages
+
+| Language | Status |
+|----------|--------|
+| Luau (Roblox) | Phase 1 — MVP |
+| C# / .NET | Phase 2 |
+| Python, TypeScript, Go, Rust | Planned |
+
+Adding a new language requires implementing a single `ILanguageParser` interface — no changes to storage, indexing, or MCP tools.
+
+## Installation
+
+### Prerequisites
+
+- [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0) or later
+
+### From Source
+
+```bash
+git clone https://github.com/MCrank/code-compress.git
+cd code-compress
+dotnet build CodeCompress.slnx
+```
+
+### As a Global Tool (coming soon)
+
+```bash
+dotnet tool install -g codecompress
+```
+
+## Setup
+
+### Claude Code
+
+Add to your Claude Code settings (`.claude/settings.json` or project-level):
+
+```json
+{
+  "mcpServers": {
+    "codecompress": {
+      "command": "dotnet",
+      "args": ["run", "--project", "/path/to/code-compress/src/CodeCompress.Server"],
+      "env": {}
+    }
+  }
+}
+```
+
+If installed as a global tool:
+
+```json
+{
+  "mcpServers": {
+    "codecompress": {
+      "command": "codecompress",
+      "args": [],
+      "env": {}
+    }
+  }
+}
+```
+
+### Other MCP Clients
+
+CodeCompress uses stdio transport by default. Any MCP-compatible client can connect by launching the server process and communicating over stdin/stdout.
+
+## Usage
+
+Once configured, AI agents can call these tools automatically. You can also use them directly via the optional CLI.
+
+### Index Your Project
+
+```
+index_project(path: "/home/user/my-project")
+```
+
+First run does a full index. Subsequent runs are incremental — only re-parses files that changed (detected via SHA-256 hashing).
+
+### Get a Project Overview
+
+```
+project_outline(path: "/home/user/my-project")
+```
+
+Returns a compressed summary of every module's public API surface — function signatures, types, and dependencies — in a fraction of the tokens it would take to read the files directly.
+
+### Look Up a Specific Symbol
+
+```
+get_symbol(path: "/home/user/my-project", symbol_name: "CombatService:ProcessAttack")
+```
+
+Retrieves the full source code of a single function using byte-offset seeking. Reads only the exact bytes needed.
+
+### Track Changes Between Sessions
+
+```
+snapshot_create(path: "/home/user/my-project", label: "before-refactor")
+# ... make changes ...
+changes_since(path: "/home/user/my-project", snapshot_label: "before-refactor")
+```
+
+Shows exactly what files and symbols were added, modified, or removed since the snapshot.
+
+### Search Across Your Codebase
+
+```
+search_symbols(path: "/home/user/my-project", query: "damage OR health", kind: "function")
+search_text(path: "/home/user/my-project", query: "TODO", glob: "*.luau")
+```
+
+Full-text search powered by SQLite FTS5.
+
+### Explore Dependencies
+
+```
+dependency_graph(path: "/home/user/my-project", root_file: "src/server/Services/CombatService.luau")
+```
+
+Shows who requires/imports a file and what it depends on.
+
+## Available MCP Tools
+
+| Tool | Description |
+|------|-------------|
+| `index_project` | Index a project directory (incremental by default) |
+| `snapshot_create` | Create a named snapshot for delta tracking |
+| `invalidate_cache` | Force full re-index on next run |
+| `project_outline` | Compressed API surface of the entire project |
+| `get_symbol` | Retrieve full source of a single symbol |
+| `get_symbols` | Batch retrieve multiple symbols |
+| `get_module_api` | Complete public API of a single module |
+| `search_symbols` | Full-text search across symbol names and signatures |
+| `search_text` | Raw text search across file contents |
+| `changes_since` | Delta report against a named snapshot |
+| `file_tree` | Annotated project file tree |
+| `dependency_graph` | Import/require dependency graph |
+
+## How It Works
+
+```
+AI Agent  ←— MCP Protocol (stdio) —→  CodeCompress Server
+                                            │
+                                       Tool Router
+                                            │
+                                       Index Engine
+                                        ├── Language Parsers (Luau, C#, ...)
+                                        └── SQLite Store (~/.codecompress/)
+```
+
+1. **Indexing** — CodeCompress walks your source files, hashes each one (SHA-256), and runs the appropriate language parser to extract symbols (functions, classes, types, constants) and dependencies (imports/requires).
+2. **Storage** — Everything is stored in a local SQLite database at `~/.codecompress/`. Each project gets its own database file.
+3. **Querying** — AI agents call MCP tools to get compressed outlines, look up specific symbols, search across the codebase, or check what changed since their last session.
+4. **Incremental Updates** — On re-index, only files whose content hash changed are re-parsed. Unchanged files are skipped entirely.
+
+## Security
+
+CodeCompress is designed with security in mind:
+
+- **Read-only** — never modifies your source files
+- **Path traversal prevention** — all file paths are canonicalized and validated against the project root
+- **SQL injection prevention** — all queries use parameterized statements
+- **Prompt injection safeguards** — tool outputs are structured data; raw input is never echoed into freeform text
+- **Local only** — no network calls, no telemetry, your code never leaves your machine
+
+## License
+
+MIT

--- a/docs/01-project-scaffold/001-solution-structure.md
+++ b/docs/01-project-scaffold/001-solution-structure.md
@@ -1,0 +1,146 @@
+# 001 — Solution Structure and Project Scaffold
+
+## Summary
+
+Create the foundational project scaffold for CodeCompress, a .NET 10 / C# 14 MCP server that indexes codebases and provides AI agents with compressed, surgical access to code symbols. This plan establishes the solution file, SDK pinning, shared build configuration, central package management, code style enforcement, and the top-level directory layout. Every subsequent plan depends on this one.
+
+## Dependencies
+
+None. This is the first feature in the project.
+
+## Scope
+
+### 1. Solution File
+
+- `CodeCompress.slnx` at the repository root.
+- Initially empty (no project references yet — those come in 01-002).
+
+### 2. global.json
+
+- Pin .NET SDK to `10.0.100`.
+- Set `rollForward` to `latestFeature` so patch/feature-band updates are picked up automatically while staying on the 10.0.x line.
+
+```json
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestFeature"
+  }
+}
+```
+
+### 3. Directory.Build.props
+
+Shared MSBuild properties imported automatically by every project in the repo:
+
+| Property                  | Value          | Rationale                                      |
+|---------------------------|----------------|-------------------------------------------------|
+| `TargetFramework`         | `net10.0`      | .NET 10 target                                  |
+| `LangVersion`             | `14`           | C# 14 language features                         |
+| `Nullable`                | `enable`       | Nullable reference types enforced everywhere     |
+| `ImplicitUsings`          | `enable`       | Reduce boilerplate `using` directives            |
+| `TreatWarningsAsErrors`   | `true`         | Zero-warning policy                              |
+| `AnalysisLevel`           | `latest-all`   | Maximum analyzer coverage                        |
+| `EnforceCodeStyleInBuild` | `true`         | Style violations break the build                 |
+
+Additionally, include a `PackageReference` to `SonarAnalyzer.CSharp` with `PrivateAssets="all"` so static analysis is applied to every project without repeating the reference.
+
+### 4. Directory.Packages.props (Central Package Management)
+
+Enable `ManagePackageVersionsInternally` and declare all package versions in one place. Individual `.csproj` files will reference packages without version numbers.
+
+| Package                            | Version (latest stable) | Purpose                              |
+|------------------------------------|-------------------------|--------------------------------------|
+| `ModelContextProtocol`             | 0.2.0-preview.2         | MCP SDK — server hosting, tools      |
+| `Microsoft.Data.Sqlite`            | 10.0.0                  | SQLite access with FTS5              |
+| `Microsoft.Extensions.Hosting`     | 10.0.0                  | Generic host for DI, logging         |
+| `SonarAnalyzer.CSharp`            | 10.6.0.109712           | Static analysis                      |
+| `TUnit`                           | 0.15.8                  | Testing framework                    |
+| `NSubstitute`                     | 5.3.0                   | Mocking                              |
+| `Verify`                          | 28.7.1                  | Snapshot testing                     |
+
+> **Note:** Versions listed above are representative. Resolve to the actual latest stable at time of implementation.
+
+### 5. .editorconfig
+
+Root `.editorconfig` enforcing the project's C# conventions:
+
+- **Naming rules:**
+  - PascalCase for public/internal members (methods, properties, classes, etc.)
+  - `_camelCase` for private fields (prefixed with underscore)
+  - `I` prefix for interfaces
+- **Formatting:**
+  - Allman (next-line) brace style
+  - 4-space indentation, no tabs
+- **Code style:**
+  - `var` when type is apparent (`csharp_style_var_when_type_is_apparent = true`)
+  - Expression-bodied members for single-line implementations
+  - `readonly` fields where possible
+- **General:**
+  - UTF-8, LF line endings, final newline, trim trailing whitespace
+
+### 6. nuget.config
+
+Standard NuGet configuration pointing to the official `nuget.org` feed. Provides a single place to add private feeds later if needed.
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>
+```
+
+### 7. Directory Structure
+
+Create the following top-level folders (with `.gitkeep` files so they are tracked):
+
+```
+src/
+tests/
+samples/
+```
+
+## Acceptance Criteria
+
+- [ ] `global.json` exists and pins SDK 10.0.100 with `rollForward: latestFeature`
+- [ ] `CodeCompress.slnx` exists at the repo root
+- [ ] `Directory.Build.props` sets all shared properties listed above and references SonarAnalyzer.CSharp
+- [ ] `Directory.Packages.props` enables Central Package Management and declares all package versions
+- [ ] `.editorconfig` enforces all naming, formatting, and code style rules
+- [ ] `nuget.config` exists with the nuget.org feed
+- [ ] `src/`, `tests/`, and `samples/` directories exist
+- [ ] `dotnet restore` succeeds with zero errors
+- [ ] Solution builds with zero warnings (once projects are added in 01-002)
+
+## Files to Create/Modify
+
+| File                        | Action | Notes                                      |
+|-----------------------------|--------|--------------------------------------------|
+| `CodeCompress.slnx`          | Create | Empty solution                              |
+| `global.json`               | Create | SDK pin                                     |
+| `Directory.Build.props`     | Create | Shared build properties + SonarAnalyzer     |
+| `Directory.Packages.props`  | Create | Central Package Management versions         |
+| `.editorconfig`             | Create | Code style enforcement                      |
+| `nuget.config`              | Create | NuGet feed configuration                    |
+| `src/.gitkeep`              | Create | Ensure directory is tracked                 |
+| `tests/.gitkeep`            | Create | Ensure directory is tracked                 |
+| `samples/.gitkeep`          | Create | Ensure directory is tracked                 |
+
+## Out of Scope
+
+- Individual `.csproj` files (covered in 01-002)
+- Source code files (covered in later plans)
+- CI/CD pipeline configuration
+- Docker / container setup
+- LICENSE or README files
+
+## Notes / Decisions
+
+1. **Central Package Management** — All NuGet versions live in `Directory.Packages.props`. This avoids version drift across projects and makes upgrades atomic.
+2. **SonarAnalyzer in Directory.Build.props** — Referencing the analyzer at the repo level ensures every project gets static analysis without opt-in. The `PrivateAssets="all"` attribute prevents it from flowing to consumers.
+3. **rollForward: latestFeature** — Chosen over `latestPatch` to allow feature-band SDK updates (e.g., 10.0.200) while still requiring the 10.0.x major/minor line.
+4. **.editorconfig as source of truth** — The editor config enforces style in IDEs and via `EnforceCodeStyleInBuild` during CI builds, ensuring consistent formatting regardless of developer tooling.
+5. **Versions are advisory** — The version numbers in the table above should be verified against nuget.org at implementation time and updated to the actual latest stable releases.

--- a/docs/01-project-scaffold/002-csproj-files.md
+++ b/docs/01-project-scaffold/002-csproj-files.md
@@ -1,0 +1,143 @@
+# 002 — Project Files (.csproj)
+
+## Summary
+
+Create all `.csproj` project files for the CodeCompress solution and register them in `CodeCompress.slnx`. This establishes the three source projects (Core library, MCP Server executable, CLI executable) and three test projects (Core tests, Server tests, Integration tests). All projects use Central Package Management — no version numbers appear in any `.csproj` file.
+
+## Dependencies
+
+| Plan   | Description              | Reason                                                        |
+|--------|--------------------------|---------------------------------------------------------------|
+| 01-001 | Solution Structure       | Solution file, Directory.Build.props, Directory.Packages.props, and folder layout must exist before projects can be created |
+
+## Scope
+
+### Source Projects
+
+#### 1. `src/CodeCompress.Core/CodeCompress.Core.csproj`
+
+- **Output type:** Class library (default)
+- **Purpose:** Core library containing parsers, indexing engine, SQLite storage, models, and path validation
+- **Package references:**
+  - `Microsoft.Data.Sqlite` — SQLite access with FTS5 support
+  - `Microsoft.Extensions.Hosting` — DI abstractions (`IServiceCollection`, `IHostBuilder`, etc.)
+
+#### 2. `src/CodeCompress.Server/CodeCompress.Server.csproj`
+
+- **Output type:** `Exe`
+- **Purpose:** MCP server executable with stdio transport and `[McpServerToolType]` tool classes
+- **Project references:**
+  - `CodeCompress.Core`
+- **Package references:**
+  - `ModelContextProtocol` — MCP SDK for server hosting and tool registration
+  - `Microsoft.Extensions.Hosting` — Generic host for DI, logging, lifetime management
+
+#### 3. `src/CodeCompress.Cli/CodeCompress.Cli.csproj`
+
+- **Output type:** `Exe`
+- **Purpose:** Optional standalone CLI for testing and debugging index operations outside the MCP protocol
+- **Project references:**
+  - `CodeCompress.Core`
+
+### Test Projects
+
+All test projects set `<IsTestProject>true</IsTestProject>` to enable test discovery and ensure correct build behavior.
+
+#### 4. `tests/CodeCompress.Core.Tests/CodeCompress.Core.Tests.csproj`
+
+- **Output type:** `Exe` (required by TUnit's source-generated test runner)
+- **Purpose:** Unit tests for all Core library components (parsers, storage, index engine, models, validation)
+- **Project references:**
+  - `CodeCompress.Core`
+- **Package references:**
+  - `TUnit` — Testing framework (source-generated, AOT-compatible)
+  - `NSubstitute` — Interface mocking
+  - `Verify` — Snapshot testing for complex outputs
+
+#### 5. `tests/CodeCompress.Server.Tests/CodeCompress.Server.Tests.csproj`
+
+- **Output type:** `Exe` (required by TUnit)
+- **Purpose:** Unit tests for MCP tool classes and server-specific logic
+- **Project references:**
+  - `CodeCompress.Server`
+  - `CodeCompress.Core`
+- **Package references:**
+  - `TUnit` — Testing framework
+  - `NSubstitute` — Interface mocking
+
+#### 6. `tests/CodeCompress.Integration.Tests/CodeCompress.Integration.Tests.csproj`
+
+- **Output type:** `Exe` (required by TUnit)
+- **Purpose:** End-to-end integration tests exercising the full pipeline (parse, index, query)
+- **Project references:**
+  - `CodeCompress.Core`
+- **Package references:**
+  - `TUnit` — Testing framework
+
+### Solution Registration
+
+All six projects must be added to `CodeCompress.slnx` with appropriate solution folders:
+
+```
+CodeCompress.slnx
+  src/
+    CodeCompress.Core
+    CodeCompress.Server
+    CodeCompress.Cli
+  tests/
+    CodeCompress.Core.Tests
+    CodeCompress.Server.Tests
+    CodeCompress.Integration.Tests
+```
+
+### Placeholder Files
+
+Each project needs a minimal placeholder so it compiles:
+- **Libraries / Executables:** An empty `Program.cs` (for Exe projects) or a placeholder class file
+- **Test projects:** An empty test file or just the project file (TUnit does not require a `Main` method; the source generator provides it)
+
+## Acceptance Criteria
+
+- [ ] All six `.csproj` files exist in their respective directories
+- [ ] No `.csproj` file contains any `<PackageVersion>` or inline version attribute — all versions come from `Directory.Packages.props`
+- [ ] `CodeCompress.Core.csproj` references `Microsoft.Data.Sqlite` and `Microsoft.Extensions.Hosting`
+- [ ] `CodeCompress.Server.csproj` references `CodeCompress.Core` project, `ModelContextProtocol`, and `Microsoft.Extensions.Hosting`
+- [ ] `CodeCompress.Cli.csproj` references `CodeCompress.Core` project
+- [ ] `CodeCompress.Core.Tests.csproj` references `CodeCompress.Core` project, `TUnit`, `NSubstitute`, and `Verify`
+- [ ] `CodeCompress.Server.Tests.csproj` references `CodeCompress.Server` project, `CodeCompress.Core` project, `TUnit`, and `NSubstitute`
+- [ ] `CodeCompress.Integration.Tests.csproj` references `CodeCompress.Core` project and `TUnit`
+- [ ] All test projects have `<IsTestProject>true</IsTestProject>`
+- [ ] All six projects are registered in `CodeCompress.slnx` under the correct solution folders
+- [ ] `dotnet restore CodeCompress.slnx` succeeds with zero errors
+- [ ] `dotnet build CodeCompress.slnx` succeeds with zero warnings
+- [ ] `dotnet test CodeCompress.slnx` runs successfully (even with no tests defined yet)
+
+## Files to Create/Modify
+
+| File                                                             | Action | Notes                                        |
+|------------------------------------------------------------------|--------|----------------------------------------------|
+| `src/CodeCompress.Core/CodeCompress.Core.csproj`                 | Create | Class library with Sqlite + Hosting refs     |
+| `src/CodeCompress.Server/CodeCompress.Server.csproj`             | Create | Exe with Core project ref + MCP + Hosting    |
+| `src/CodeCompress.Cli/CodeCompress.Cli.csproj`                   | Create | Exe with Core project ref                    |
+| `tests/CodeCompress.Core.Tests/CodeCompress.Core.Tests.csproj`   | Create | Exe, IsTestProject, TUnit + NSubstitute + Verify |
+| `tests/CodeCompress.Server.Tests/CodeCompress.Server.Tests.csproj` | Create | Exe, IsTestProject, TUnit + NSubstitute     |
+| `tests/CodeCompress.Integration.Tests/CodeCompress.Integration.Tests.csproj` | Create | Exe, IsTestProject, TUnit              |
+| `CodeCompress.slnx`                                               | Modify | Add all six projects with solution folders   |
+| Placeholder `.cs` files per project                              | Create | Minimal files so projects compile            |
+
+## Out of Scope
+
+- Actual source code implementation (parsers, storage, tools, etc.)
+- Test method implementations
+- Build scripts or CI/CD configuration
+- NuGet package publishing configuration
+- Any changes to `Directory.Build.props` or `Directory.Packages.props` (established in 01-001)
+
+## Notes / Decisions
+
+1. **TUnit requires Exe output type** — Unlike xUnit/NUnit, TUnit uses source generation to produce its own entry point. All test projects must be `OutputType: Exe` for the generated test runner to work correctly.
+2. **IsTestProject property** — Setting `<IsTestProject>true</IsTestProject>` ensures `dotnet test` discovers and runs the projects, and prevents them from being published or packed accidentally.
+3. **Server references both MCP and Hosting** — The Server project needs its own `Microsoft.Extensions.Hosting` reference for `GenericHost` integration, separate from Core's use of DI abstractions.
+4. **Integration tests reference only Core** — Integration tests exercise the full pipeline through the public Core API, not through MCP tool classes. This keeps them transport-agnostic.
+5. **No version numbers in .csproj** — Central Package Management (enabled in 01-001) requires that all versions are declared exclusively in `Directory.Packages.props`. Any inline version in a `.csproj` will cause a build error.
+6. **Solution folders** — Using `src/` and `tests/` solution folders in the `.slnx` file mirrors the physical directory layout and keeps the solution explorer organized.

--- a/docs/02-core-models-and-interfaces/001-models-and-interfaces.md
+++ b/docs/02-core-models-and-interfaces/001-models-and-interfaces.md
@@ -1,0 +1,145 @@
+# 001 — Core Models and Interfaces
+
+## Summary
+
+Define all core models, enums, and interfaces that parsers, storage, and the indexing engine depend on. These types form the foundational contract for the entire CodeCompress pipeline: language parsers produce `ParseResult` values containing `SymbolInfo` and `DependencyInfo` records, and downstream components (storage, index engine, MCP tools) consume them.
+
+## Dependencies
+
+- **Feature 01** — Project scaffold and `.csproj` files must exist (`CodeCompress.Core`, `CodeCompress.Core.Tests`) with `Directory.Build.props`, `Directory.Packages.props`, and `global.json` in place.
+
+## Scope
+
+### Models (`src/CodeCompress.Core/Models/`)
+
+#### `SymbolKind` enum
+
+Represents the category of a parsed symbol.
+
+| Value      | Description                        |
+|------------|------------------------------------|
+| Function   | Top-level or free function         |
+| Method     | Function attached to a type/class  |
+| Type       | Type alias or typedef              |
+| Class      | Class declaration                  |
+| Interface  | Interface declaration              |
+| Export     | Exported value (e.g., Luau module) |
+| Constant   | Constant or read-only binding      |
+| Module     | Module or namespace                |
+
+#### `Visibility` enum
+
+Describes the access level of a symbol.
+
+| Value   | Description                      |
+|---------|----------------------------------|
+| Public  | Accessible outside its module    |
+| Private | Accessible only within its type  |
+| Local   | Scoped to the enclosing block    |
+
+#### `SymbolInfo` record
+
+Immutable record representing a single parsed symbol.
+
+| Property      | Type            | Nullable | Description                                  |
+|---------------|-----------------|----------|----------------------------------------------|
+| Name          | `string`        | No       | Symbol name                                  |
+| Kind          | `SymbolKind`    | No       | Category of the symbol                       |
+| Signature     | `string`        | No       | Full declaration signature                   |
+| ParentSymbol  | `string?`       | Yes      | Enclosing symbol name, if nested             |
+| ByteOffset    | `int`           | No       | Start byte offset in the source file         |
+| ByteLength    | `int`           | No       | Length in bytes of the symbol's source span  |
+| LineStart     | `int`           | No       | 1-based start line                           |
+| LineEnd       | `int`           | No       | 1-based end line                             |
+| Visibility    | `Visibility`    | No       | Access level                                 |
+| DocComment    | `string?`       | Yes      | Leading doc comment, if present              |
+
+#### `DependencyInfo` record
+
+Immutable record representing a dependency (require/import).
+
+| Property    | Type      | Nullable | Description                          |
+|-------------|-----------|----------|--------------------------------------|
+| RequirePath | `string`  | No       | The path or module being required    |
+| Alias       | `string?` | Yes      | Local alias assigned at import site  |
+
+#### `ParseResult` record
+
+Immutable record returned by every language parser.
+
+| Property     | Type                              | Description                |
+|--------------|-----------------------------------|----------------------------|
+| Symbols      | `IReadOnlyList<SymbolInfo>`       | All symbols found in file  |
+| Dependencies | `IReadOnlyList<DependencyInfo>`   | All dependencies in file   |
+
+### Interface (`src/CodeCompress.Core/Parsers/`)
+
+#### `ILanguageParser`
+
+Contract that every language parser must implement.
+
+| Member           | Type                  | Description                                           |
+|------------------|-----------------------|-------------------------------------------------------|
+| `LanguageId`     | `string` (get)        | Unique identifier, e.g. `"luau"`, `"csharp"`         |
+| `FileExtensions` | `string[]` (get)      | Extensions this parser handles, e.g. `[".luau"]`     |
+| `Parse`          | method                | `ParseResult Parse(string filePath, ReadOnlySpan<byte> content)` |
+
+### Tests (`tests/CodeCompress.Core.Tests/Models/`)
+
+- **SymbolKindTests** — Verify all expected enum members exist and have correct underlying values.
+- **VisibilityTests** — Verify all expected enum members exist and have correct underlying values.
+- **SymbolInfoTests** — Construct instances, verify property access, confirm record value equality and inequality, test nullable properties (`ParentSymbol`, `DocComment`) with `null`.
+- **DependencyInfoTests** — Construct instances, verify equality, test `Alias` as `null`.
+- **ParseResultTests** — Construct with empty and non-empty lists, verify `Symbols` and `Dependencies` contents, confirm record equality.
+
+## Acceptance Criteria
+
+- [ ] `SymbolKind` enum is defined with all eight members in `src/CodeCompress.Core/Models/SymbolKind.cs`.
+- [ ] `Visibility` enum is defined with all three members in `src/CodeCompress.Core/Models/Visibility.cs`.
+- [ ] `SymbolInfo` record is defined with all ten properties in `src/CodeCompress.Core/Models/SymbolInfo.cs`.
+- [ ] `DependencyInfo` record is defined with two properties in `src/CodeCompress.Core/Models/DependencyInfo.cs`.
+- [ ] `ParseResult` record is defined with two properties in `src/CodeCompress.Core/Models/ParseResult.cs`.
+- [ ] `ILanguageParser` interface is defined in `src/CodeCompress.Core/Parsers/ILanguageParser.cs`.
+- [ ] All types use `readonly record struct` or `record` as appropriate — no `dynamic` or `object` types.
+- [ ] All nullable properties use explicit `?` annotations.
+- [ ] `dotnet build CodeCompress.slnx` succeeds with zero warnings.
+- [ ] All model and enum tests pass via `dotnet test tests/CodeCompress.Core.Tests`.
+- [ ] Test coverage for models is 95%+.
+
+## Files to Create/Modify
+
+### Create
+
+| File | Description |
+|------|-------------|
+| `src/CodeCompress.Core/Models/SymbolKind.cs` | `SymbolKind` enum |
+| `src/CodeCompress.Core/Models/Visibility.cs` | `Visibility` enum |
+| `src/CodeCompress.Core/Models/SymbolInfo.cs` | `SymbolInfo` record |
+| `src/CodeCompress.Core/Models/DependencyInfo.cs` | `DependencyInfo` record |
+| `src/CodeCompress.Core/Models/ParseResult.cs` | `ParseResult` record |
+| `src/CodeCompress.Core/Parsers/ILanguageParser.cs` | `ILanguageParser` interface |
+| `tests/CodeCompress.Core.Tests/Models/SymbolKindTests.cs` | Enum member tests |
+| `tests/CodeCompress.Core.Tests/Models/VisibilityTests.cs` | Enum member tests |
+| `tests/CodeCompress.Core.Tests/Models/SymbolInfoTests.cs` | Record construction, equality, null handling tests |
+| `tests/CodeCompress.Core.Tests/Models/DependencyInfoTests.cs` | Record construction, equality tests |
+| `tests/CodeCompress.Core.Tests/Models/ParseResultTests.cs` | Record construction, list contents tests |
+
+### Modify
+
+None. This feature introduces new files only.
+
+## Out of Scope
+
+- Parser implementations (covered by later features per language).
+- Storage layer / SQLite schema (separate feature).
+- Index engine orchestration (separate feature).
+- MCP tool definitions (separate feature).
+- Validation logic for model fields (e.g., `ByteOffset >= 0`) — may be added in a future hardening pass.
+
+## Notes / Decisions
+
+- **Records over classes.** All models are C# records to get value equality, immutability, and `with`-expression support for free. This aligns with the project's emphasis on strongly typed, immutable data flowing through the pipeline.
+- **`ReadOnlySpan<byte>` on `Parse`.** The parser interface accepts `ReadOnlySpan<byte>` for the file content parameter to support zero-copy parsing as specified in the performance conventions. Callers are responsible for reading the file into a byte buffer.
+- **`string[]` for `FileExtensions`.** Kept as a simple array rather than `IReadOnlyList<string>` for brevity; parsers are expected to return small, fixed arrays.
+- **No base value for enums.** Both `SymbolKind` and `Visibility` use default `int` backing with auto-assigned values starting at 0. Explicit numbering is not required since these are not persisted as integers in the current design (SQLite stores the string name).
+- **Namespace convention.** All models live under `CodeCompress.Core.Models`; the parser interface lives under `CodeCompress.Core.Parsers`.

--- a/docs/03-sqlite-storage-layer/001-connection-factory-and-schema.md
+++ b/docs/03-sqlite-storage-layer/001-connection-factory-and-schema.md
@@ -1,0 +1,115 @@
+# 03-001: SqliteConnectionFactory and Schema Creation
+
+## Summary
+
+Establish the SQLite foundation for CodeCompress by implementing a connection factory that creates and configures per-repository databases, and a migrations system that idempotently provisions the full schema (tables, indexes, FTS5 virtual tables). This is the lowest layer of the storage stack — all subsequent storage work depends on it.
+
+## Dependencies
+
+- **Feature 01** — Project models and shared types (e.g., repository identity, symbol kinds)
+- **Feature 02** — Language parser interfaces (symbol/file models that inform table shapes)
+
+## Scope
+
+### SqliteConnectionFactory (src/CodeCompress.Core/Storage/SqliteConnectionFactory.cs)
+
+- Computes the database path: `~/.codecompress/{repo-hash}.db`
+  - `repo-hash` = lowercase hex SHA-256 of the **normalized absolute path** to the project root (forward slashes, no trailing separator, invariant culture)
+  - Directory `~/.codecompress/` is created if it does not exist
+- Opens a `SqliteConnection` from `Microsoft.Data.Sqlite` with the computed path
+- Applies connection-level PRAGMAs immediately after open:
+  - `PRAGMA journal_mode=WAL;`
+  - `PRAGMA synchronous=NORMAL;`
+  - `PRAGMA foreign_keys=ON;`
+- Exposes an async factory method: `Task<SqliteConnection> CreateConnectionAsync(string projectRootPath)`
+- Validates that `projectRootPath` is a rooted, canonical path (uses `PathValidator`)
+- Implements `IConnectionFactory` interface for DI registration and testability
+
+### Migrations (src/CodeCompress.Core/Storage/Migrations.cs)
+
+Creates all tables on first run. Must be idempotent (`CREATE TABLE IF NOT EXISTS` / `CREATE INDEX IF NOT EXISTS`).
+
+#### Tables
+
+| Table | Columns |
+|-------|---------|
+| **repositories** | `id TEXT PRIMARY KEY` (SHA-256 of root path), `root_path TEXT NOT NULL`, `name TEXT NOT NULL`, `language TEXT NOT NULL`, `last_indexed INTEGER NOT NULL`, `file_count INTEGER NOT NULL DEFAULT 0`, `symbol_count INTEGER NOT NULL DEFAULT 0` |
+| **files** | `id INTEGER PRIMARY KEY AUTOINCREMENT`, `repo_id TEXT NOT NULL REFERENCES repositories(id) ON DELETE CASCADE`, `relative_path TEXT NOT NULL`, `content_hash TEXT NOT NULL`, `byte_length INTEGER NOT NULL`, `line_count INTEGER NOT NULL`, `last_modified INTEGER NOT NULL`, `indexed_at INTEGER NOT NULL` |
+| **symbols** | `id INTEGER PRIMARY KEY AUTOINCREMENT`, `file_id INTEGER NOT NULL REFERENCES files(id) ON DELETE CASCADE`, `name TEXT NOT NULL`, `kind TEXT NOT NULL`, `signature TEXT NOT NULL`, `parent_symbol TEXT`, `byte_offset INTEGER NOT NULL`, `byte_length INTEGER NOT NULL`, `line_start INTEGER NOT NULL`, `line_end INTEGER NOT NULL`, `visibility TEXT NOT NULL`, `doc_comment TEXT` |
+| **dependencies** | `id INTEGER PRIMARY KEY AUTOINCREMENT`, `file_id INTEGER NOT NULL REFERENCES files(id) ON DELETE CASCADE`, `requires_path TEXT NOT NULL`, `resolved_file_id INTEGER REFERENCES files(id) ON DELETE SET NULL`, `alias TEXT` |
+| **index_snapshots** | `id INTEGER PRIMARY KEY AUTOINCREMENT`, `repo_id TEXT NOT NULL REFERENCES repositories(id) ON DELETE CASCADE`, `snapshot_label TEXT NOT NULL`, `created_at INTEGER NOT NULL`, `file_hashes TEXT NOT NULL` (JSON blob) |
+
+#### Indexes
+
+- `ix_files_repo_id` on `files(repo_id)`
+- `ix_files_content_hash` on `files(content_hash)`
+- `ix_files_repo_path` UNIQUE on `files(repo_id, relative_path)`
+- `ix_symbols_file_id` on `symbols(file_id)`
+- `ix_symbols_name` on `symbols(name)`
+- `ix_symbols_kind` on `symbols(kind)`
+- `ix_dependencies_file_id` on `dependencies(file_id)`
+- `ix_dependencies_resolved` on `dependencies(resolved_file_id)`
+- `ix_snapshots_repo_id` on `index_snapshots(repo_id)`
+
+#### FTS5 Virtual Tables (created here, populated by SymbolStore in 03-002)
+
+- `symbols_fts` — `CREATE VIRTUAL TABLE IF NOT EXISTS symbols_fts USING fts5(name, signature, doc_comment, content=symbols, content_rowid=id)`
+- `file_content_fts` — `CREATE VIRTUAL TABLE IF NOT EXISTS file_content_fts USING fts5(relative_path, content)`
+
+#### Migration Runner
+
+- Static async method: `Task ApplyAsync(SqliteConnection connection)`
+- Executes all DDL in a single transaction
+- Safe to call on every connection open (idempotent)
+
+## Acceptance Criteria
+
+- [ ] `SqliteConnectionFactory` computes the correct database path for a given project root
+- [ ] Database directory (`~/.codecompress/`) is created automatically if missing
+- [ ] Opened connections have WAL mode enabled (verified via `PRAGMA journal_mode` query)
+- [ ] Opened connections have `synchronous=NORMAL` (verified via `PRAGMA synchronous` query)
+- [ ] Opened connections have `foreign_keys=ON` (verified via `PRAGMA foreign_keys` query)
+- [ ] All six tables exist after migration (repositories, files, symbols, dependencies, index_snapshots)
+- [ ] All indexes exist after migration
+- [ ] FTS5 virtual tables (symbols_fts, file_content_fts) exist after migration
+- [ ] Migrations are idempotent — running twice produces no errors and no duplicate objects
+- [ ] `PathValidator` rejects non-rooted paths and paths containing `..` traversal
+- [ ] Repo hash is deterministic — same path always produces the same hash
+- [ ] Repo hash normalizes path separators (forward slashes) and removes trailing separators before hashing
+- [ ] All SQL uses parameterized queries or literal DDL — zero string concatenation with user input
+- [ ] All tests pass: `SqliteConnectionFactoryTests`, `MigrationsTests`
+
+## Files to Create/Modify
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `src/CodeCompress.Core/Storage/IConnectionFactory.cs` | Interface for DI |
+| `src/CodeCompress.Core/Storage/SqliteConnectionFactory.cs` | Connection factory implementation |
+| `src/CodeCompress.Core/Storage/Migrations.cs` | Schema creation and idempotent DDL |
+| `tests/CodeCompress.Core.Tests/Storage/SqliteConnectionFactoryTests.cs` | Factory unit tests |
+| `tests/CodeCompress.Core.Tests/Storage/MigrationsTests.cs` | Schema verification tests |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `src/CodeCompress.Core/DependencyInjection.cs` (or equivalent) | Register `IConnectionFactory` as singleton |
+
+## Out of Scope
+
+- CRUD operations on any table (covered in 03-002)
+- FTS5 data population and triggers (covered in 03-002)
+- Query methods, search, and aggregation (covered in 03-003)
+- Database backup, export, or compaction
+- Multi-database or cross-repository queries
+- Connection pooling beyond what `Microsoft.Data.Sqlite` provides by default
+
+## Notes/Decisions
+
+- **In-memory databases for tests:** Test classes should use `SqliteConnection("DataSource=:memory:")` to avoid filesystem side effects. The factory can be bypassed in tests by injecting an already-opened in-memory connection.
+- **SHA-256 for repo hash:** Using the full 64-character hex digest avoids collisions and aligns with the content-hash strategy used for files.
+- **INTEGER for timestamps:** All timestamp columns store Unix epoch seconds as INTEGER, consistent with SQLite best practices and avoiding datetime parsing overhead.
+- **JSON blob for snapshot hashes:** `file_hashes` in `index_snapshots` stores a JSON dictionary of `{ relative_path: content_hash }`. This avoids a separate join table and keeps snapshot diffing simple.
+- **FTS5 content-sync tables:** `symbols_fts` uses `content=symbols, content_rowid=id` so it references the main symbols table without duplicating storage. Triggers or manual rebuild commands will be added in 03-002.

--- a/docs/03-sqlite-storage-layer/002-symbol-store-crud.md
+++ b/docs/03-sqlite-storage-layer/002-symbol-store-crud.md
@@ -1,0 +1,155 @@
+# 03-002: SymbolStore Repository — CRUD Operations
+
+## Summary
+
+Implement the `SymbolStore` class as a repository-pattern data access layer over the SQLite database provisioned in 03-001. This class owns all insert, read, update, and delete operations for repositories, files, symbols, dependencies, and snapshots. Batch inserts use explicit transactions for performance. FTS5 virtual tables are kept in sync via SQLite triggers. All SQL is parameterized — zero string concatenation.
+
+## Dependencies
+
+- **03-001** — `SqliteConnectionFactory`, `Migrations`, schema must be in place
+- **Feature 01** — Domain models (`Repository`, `FileRecord`, `Symbol`, `Dependency`, `IndexSnapshot`)
+- **Feature 02** — Parser output models that feed into symbol/file inserts
+
+## Scope
+
+### SymbolStore (src/CodeCompress.Core/Storage/SymbolStore.cs)
+
+Implements `ISymbolStore` interface. Receives `SqliteConnection` via constructor (injected by the connection factory or directly in tests).
+
+#### Repository Operations
+
+| Method | Signature | Behavior |
+|--------|-----------|----------|
+| `UpsertRepository` | `Task UpsertRepositoryAsync(Repository repo)` | INSERT OR REPLACE into `repositories`. Updates `last_indexed`, `file_count`, `symbol_count`. |
+| `GetRepository` | `Task<Repository?> GetRepositoryAsync(string repoId)` | SELECT by primary key. Returns null if not found. |
+| `DeleteRepository` | `Task DeleteRepositoryAsync(string repoId)` | DELETE from `repositories`. Cascading FKs remove child rows. |
+
+#### File Operations
+
+| Method | Signature | Behavior |
+|--------|-----------|----------|
+| `InsertFiles` | `Task InsertFilesAsync(IReadOnlyList<FileRecord> files)` | Batch INSERT within a transaction. Returns inserted row IDs. |
+| `GetFilesByRepo` | `Task<IReadOnlyList<FileRecord>> GetFilesByRepoAsync(string repoId)` | SELECT all files for a repository. |
+| `GetFileByPath` | `Task<FileRecord?> GetFileByPathAsync(string repoId, string relativePath)` | SELECT by unique index `(repo_id, relative_path)`. |
+| `UpdateFile` | `Task UpdateFileAsync(FileRecord file)` | UPDATE by primary key — sets `content_hash`, `byte_length`, `line_count`, `last_modified`, `indexed_at`. |
+| `DeleteFile` | `Task DeleteFileAsync(long fileId)` | DELETE by primary key. Cascading FKs remove child symbols and dependencies. |
+
+#### Symbol Operations
+
+| Method | Signature | Behavior |
+|--------|-----------|----------|
+| `InsertSymbols` | `Task InsertSymbolsAsync(IReadOnlyList<Symbol> symbols)` | Batch INSERT within a transaction. |
+| `GetSymbolsByFile` | `Task<IReadOnlyList<Symbol>> GetSymbolsByFileAsync(long fileId)` | SELECT all symbols for a file, ordered by `line_start`. |
+| `DeleteSymbolsByFile` | `Task DeleteSymbolsByFileAsync(long fileId)` | DELETE all symbols belonging to a file. |
+
+#### Dependency Operations
+
+| Method | Signature | Behavior |
+|--------|-----------|----------|
+| `InsertDependencies` | `Task InsertDependenciesAsync(IReadOnlyList<Dependency> deps)` | Batch INSERT within a transaction. |
+| `GetDependenciesByFile` | `Task<IReadOnlyList<Dependency>> GetDependenciesByFileAsync(long fileId)` | SELECT all dependencies for a file. |
+| `DeleteDependenciesByFile` | `Task DeleteDependenciesByFileAsync(long fileId)` | DELETE all dependencies belonging to a file. |
+
+#### Snapshot Operations
+
+| Method | Signature | Behavior |
+|--------|-----------|----------|
+| `CreateSnapshot` | `Task<long> CreateSnapshotAsync(IndexSnapshot snapshot)` | INSERT into `index_snapshots`. Returns new row ID. |
+| `GetSnapshot` | `Task<IndexSnapshot?> GetSnapshotAsync(long snapshotId)` | SELECT by primary key. |
+| `GetSnapshotsByRepo` | `Task<IReadOnlyList<IndexSnapshot>> GetSnapshotsByRepoAsync(string repoId)` | SELECT all snapshots for a repository, ordered by `created_at DESC`. |
+
+### Batch Insert Strategy
+
+- All batch methods (`InsertFilesAsync`, `InsertSymbolsAsync`, `InsertDependenciesAsync`) wrap operations in an explicit `BEGIN TRANSACTION` / `COMMIT`
+- Use a single prepared `SqliteCommand` with parameters reset per row to minimize allocations
+- On failure, `ROLLBACK` the transaction and let the exception propagate
+- No partial inserts — all-or-nothing semantics
+
+### FTS5 Synchronization
+
+SQLite triggers maintain FTS5 tables automatically:
+
+#### symbols_fts Triggers
+
+```sql
+-- After INSERT on symbols
+CREATE TRIGGER IF NOT EXISTS symbols_ai AFTER INSERT ON symbols BEGIN
+    INSERT INTO symbols_fts(rowid, name, signature, doc_comment)
+    VALUES (new.id, new.name, new.signature, new.doc_comment);
+END;
+
+-- After DELETE on symbols
+CREATE TRIGGER IF NOT EXISTS symbols_ad AFTER DELETE ON symbols BEGIN
+    INSERT INTO symbols_fts(symbols_fts, rowid, name, signature, doc_comment)
+    VALUES ('delete', old.id, old.name, old.signature, old.doc_comment);
+END;
+
+-- After UPDATE on symbols
+CREATE TRIGGER IF NOT EXISTS symbols_au AFTER UPDATE ON symbols BEGIN
+    INSERT INTO symbols_fts(symbols_fts, rowid, name, signature, doc_comment)
+    VALUES ('delete', old.id, old.name, old.signature, old.doc_comment);
+    INSERT INTO symbols_fts(rowid, name, signature, doc_comment)
+    VALUES (new.id, new.name, new.signature, new.doc_comment);
+END;
+```
+
+#### file_content_fts
+
+- `file_content_fts` is a standalone (not content-synced) FTS5 table
+- Managed explicitly by `SymbolStore` during file insert/update/delete rather than via triggers, because file content is not stored in the `files` table itself — it is read from disk and inserted directly into FTS5
+
+### ISymbolStore Interface (src/CodeCompress.Core/Storage/ISymbolStore.cs)
+
+Declares all methods listed above. Enables DI registration and NSubstitute mocking in higher-layer tests.
+
+## Acceptance Criteria
+
+- [ ] `UpsertRepositoryAsync` inserts a new repository and updates an existing one (verified by round-trip read)
+- [ ] `DeleteRepositoryAsync` cascades to remove all child files, symbols, dependencies, and snapshots
+- [ ] `InsertFilesAsync` inserts a batch of files in a single transaction
+- [ ] `GetFileByPathAsync` returns the correct file by `(repo_id, relative_path)` and returns null for missing paths
+- [ ] `InsertSymbolsAsync` inserts a batch of symbols; `GetSymbolsByFileAsync` retrieves them in `line_start` order
+- [ ] `DeleteSymbolsByFileAsync` removes all symbols for a file and their FTS5 entries
+- [ ] `InsertDependenciesAsync` inserts a batch of dependencies in a single transaction
+- [ ] `CreateSnapshotAsync` returns the auto-incremented snapshot ID
+- [ ] `GetSnapshotsByRepoAsync` returns snapshots ordered by `created_at DESC`
+- [ ] Batch inserts roll back entirely on failure — no partial rows are committed
+- [ ] FTS5 triggers keep `symbols_fts` in sync after insert, update, and delete on `symbols`
+- [ ] `file_content_fts` is populated and cleaned up correctly during file insert/update/delete
+- [ ] All SQL uses `@param` parameterized syntax — zero string concatenation
+- [ ] No `dynamic` or `object` types in public API signatures
+- [ ] All tests pass: `SymbolStoreCrudTests`
+
+## Files to Create/Modify
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `src/CodeCompress.Core/Storage/ISymbolStore.cs` | Repository interface |
+| `src/CodeCompress.Core/Storage/SymbolStore.cs` | Full CRUD implementation |
+| `tests/CodeCompress.Core.Tests/Storage/SymbolStoreCrudTests.cs` | CRUD operation tests |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `src/CodeCompress.Core/Storage/Migrations.cs` | Add FTS5 trigger DDL to the migration script |
+| `src/CodeCompress.Core/DependencyInjection.cs` (or equivalent) | Register `ISymbolStore` as scoped/transient |
+
+## Out of Scope
+
+- FTS5 search queries and ranking (covered in 03-003)
+- Project outline aggregation queries (covered in 03-003)
+- Dependency graph traversal (covered in 03-003)
+- FTS5 query sanitization (covered in 03-003)
+- Index engine orchestration (Feature 04+)
+- MCP tool routing (Feature 05+)
+
+## Notes/Decisions
+
+- **Prepared statement reuse:** For batch inserts, create one `SqliteCommand`, set its `CommandText` once, add parameters once, then loop over rows resetting parameter values. This avoids repeated parsing overhead.
+- **CASCADE deletes:** The schema uses `ON DELETE CASCADE` on all foreign keys. Deleting a repository removes everything. Deleting a file removes its symbols and dependencies. This keeps cleanup logic out of application code.
+- **FTS5 content-sync vs. standalone:** `symbols_fts` uses content-sync mode (`content=symbols`) to avoid duplicating data. `file_content_fts` is standalone because file content is not stored in any regular table — it is inserted directly into FTS5 from disk during indexing.
+- **Transaction isolation:** Each batch method manages its own transaction. The caller (IndexEngine) is responsible for orchestrating the order of operations but does not need to manage transactions.
+- **In-memory testing:** All tests use in-memory SQLite databases. `Migrations.ApplyAsync` is called in test setup to provision the schema before each test.

--- a/docs/03-sqlite-storage-layer/003-symbol-store-queries.md
+++ b/docs/03-sqlite-storage-layer/003-symbol-store-queries.md
@@ -1,0 +1,137 @@
+# 03-003: SymbolStore Queries — FTS5 Search, Outlines, Dependency Graphs
+
+## Summary
+
+Extend `SymbolStore` with advanced query methods that power the MCP query and delta tools: FTS5 full-text search over symbols and file content, project outline aggregation, exact and batch symbol lookups, module API extraction, recursive dependency graph traversal, and snapshot-based change detection. All FTS5 queries are sanitized to prevent syntax injection.
+
+## Dependencies
+
+- **03-002** — `SymbolStore` CRUD operations, FTS5 triggers, and `ISymbolStore` interface
+- **03-001** — Schema (tables, indexes, FTS5 virtual tables) must be provisioned
+
+## Scope
+
+### FTS5 Query Sanitization (src/CodeCompress.Core/Storage/Fts5Sanitizer.cs)
+
+A dedicated static utility class for sanitizing user-supplied FTS5 query strings before they reach SQLite.
+
+- Strip or escape FTS5 special syntax characters: `*`, `"`, `(`, `)`, `+`, `-`, `^`, `NEAR`, `AND`, `OR`, `NOT`, column filters (`:`)
+- Convert the sanitized input into a safe quoted phrase or set of quoted terms
+- Method signature: `static string Sanitize(string rawQuery)`
+- Returns an empty string for null/whitespace input (caller skips the query)
+- Never throws — always returns a safe string
+
+### Query Methods (added to SymbolStore / ISymbolStore)
+
+#### Symbol Search
+
+| Method | Signature | Behavior |
+|--------|-----------|----------|
+| `SearchSymbols` | `Task<IReadOnlyList<SymbolSearchResult>> SearchSymbolsAsync(string repoId, string query, string? kind, int limit)` | FTS5 MATCH on `symbols_fts`, joined back to `symbols` and `files` for metadata. Optional filter by `kind` (function, class, etc.). Results ranked by FTS5 `bm25()`. Limited to `limit` rows (capped at a server-side max, e.g., 100). |
+| `SearchText` | `Task<IReadOnlyList<TextSearchResult>> SearchTextAsync(string repoId, string query, string? glob, int limit)` | FTS5 MATCH on `file_content_fts`. Optional glob filter on `relative_path` (e.g., `src/**/*.luau`). Returns file path, matching snippet via `snippet()`, and rank. Limited to `limit` rows. |
+
+#### Exact and Batch Lookups
+
+| Method | Signature | Behavior |
+|--------|-----------|----------|
+| `GetSymbolByName` | `Task<Symbol?> GetSymbolByNameAsync(string repoId, string symbolName)` | Exact match on `symbols.name` joined to `files.repo_id`. If `symbolName` contains `.` or `:`, treat as qualified name and match against `parent_symbol.name` pattern. Returns null if not found. |
+| `GetSymbolsByNames` | `Task<IReadOnlyList<Symbol>> GetSymbolsByNamesAsync(string repoId, IReadOnlyList<string> symbolNames)` | Batch lookup using `WHERE name IN (...)` with parameterized placeholders. Returns all matches (may be fewer than requested if some names do not exist). |
+
+#### Project Outline
+
+| Method | Signature | Behavior |
+|--------|-----------|----------|
+| `GetProjectOutline` | `Task<ProjectOutline> GetProjectOutlineAsync(string repoId, bool includePrivate, string groupBy, int maxDepth)` | Aggregation query that returns a hierarchical view of the repository. `groupBy` controls grouping: `"file"` groups symbols under their file path, `"kind"` groups by symbol kind. `maxDepth` limits nesting for large projects. `includePrivate` controls whether symbols with `visibility = "private"` are included. Returns a structured `ProjectOutline` model (not raw SQL rows). |
+
+#### Module API
+
+| Method | Signature | Behavior |
+|--------|-----------|----------|
+| `GetModuleApi` | `Task<ModuleApi> GetModuleApiAsync(string repoId, string filePath)` | Returns all symbols and dependencies for a single file. Joins `symbols` and `dependencies` on `file_id`. Returns a `ModuleApi` model containing the file metadata, symbol list, and dependency list. `filePath` is validated against the repo root via `PathValidator`. |
+
+#### Dependency Graph
+
+| Method | Signature | Behavior |
+|--------|-----------|----------|
+| `GetDependencyGraph` | `Task<DependencyGraph> GetDependencyGraphAsync(string repoId, string? rootFile, string direction, int depth)` | Traverses the dependency graph starting from `rootFile` (or all files if null). `direction` is `"dependents"` (who depends on me) or `"dependencies"` (what do I depend on). `depth` limits traversal depth (default 3, max 10). Implementation uses either a recursive CTE or iterative BFS with parameterized queries at each level. Returns a `DependencyGraph` model with nodes and edges. |
+
+#### Change Detection
+
+| Method | Signature | Behavior |
+|--------|-----------|----------|
+| `GetChangedFiles` | `Task<ChangedFilesResult> GetChangedFilesAsync(string repoId, long snapshotId)` | Loads the snapshot's `file_hashes` JSON, loads current file hashes from `files` table, and diffs them. Returns three lists: `added` (in current but not snapshot), `modified` (hash changed), `removed` (in snapshot but not current). |
+
+### Result Models (src/CodeCompress.Core/Models/)
+
+| Model | Fields |
+|-------|--------|
+| `SymbolSearchResult` | `Symbol`, `FilePath`, `Rank` |
+| `TextSearchResult` | `FilePath`, `Snippet`, `Rank` |
+| `ProjectOutline` | `RepoId`, `Groups` (list of `OutlineGroup` with name, symbols, children) |
+| `ModuleApi` | `File`, `Symbols`, `Dependencies` |
+| `DependencyGraph` | `Nodes` (list of file paths), `Edges` (list of `{From, To, Alias?}`) |
+| `ChangedFilesResult` | `Added`, `Modified`, `Removed` (each a list of `FileRecord`) |
+
+## Acceptance Criteria
+
+- [ ] `Fts5Sanitizer.Sanitize` strips all FTS5 special operators and returns safe quoted terms
+- [ ] `Fts5Sanitizer.Sanitize` returns empty string for null, empty, or whitespace-only input
+- [ ] `Fts5Sanitizer.Sanitize` handles adversarial input (e.g., `"NEAR/3 OR DROP TABLE"`, `"name:*"`, `")(--"`)
+- [ ] `SearchSymbolsAsync` returns FTS5-ranked results matching the query
+- [ ] `SearchSymbolsAsync` filters by `kind` when provided
+- [ ] `SearchSymbolsAsync` respects the `limit` parameter and enforces a server-side maximum
+- [ ] `SearchTextAsync` returns file paths and snippets matching the query
+- [ ] `SearchTextAsync` filters by glob pattern on `relative_path` when provided
+- [ ] `GetSymbolByNameAsync` returns exact match and handles qualified names (e.g., `ModuleName.FunctionName`)
+- [ ] `GetSymbolsByNamesAsync` returns correct results for batch lookups and handles missing names gracefully
+- [ ] `GetProjectOutlineAsync` groups symbols by file or kind, respects `includePrivate` and `maxDepth`
+- [ ] `GetModuleApiAsync` returns all symbols and dependencies for a given file path
+- [ ] `GetModuleApiAsync` validates the file path against the repository root
+- [ ] `GetDependencyGraphAsync` traverses in both directions (`dependents` and `dependencies`)
+- [ ] `GetDependencyGraphAsync` respects the `depth` limit and caps at a maximum of 10
+- [ ] `GetChangedFilesAsync` correctly identifies added, modified, and removed files compared to a snapshot
+- [ ] All SQL uses `@param` parameterized syntax — zero string concatenation
+- [ ] All FTS5 queries pass through `Fts5Sanitizer.Sanitize` before reaching SQLite
+- [ ] No `dynamic` or `object` types in public API signatures
+- [ ] All tests pass: `SymbolStoreQueryTests`, `Fts5SanitizerTests`
+
+## Files to Create/Modify
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `src/CodeCompress.Core/Storage/Fts5Sanitizer.cs` | FTS5 query sanitization utility |
+| `src/CodeCompress.Core/Models/SymbolSearchResult.cs` | Search result model |
+| `src/CodeCompress.Core/Models/TextSearchResult.cs` | Text search result model |
+| `src/CodeCompress.Core/Models/ProjectOutline.cs` | Outline aggregation model |
+| `src/CodeCompress.Core/Models/ModuleApi.cs` | Module API model |
+| `src/CodeCompress.Core/Models/DependencyGraph.cs` | Dependency graph model |
+| `src/CodeCompress.Core/Models/ChangedFilesResult.cs` | Change detection result model |
+| `tests/CodeCompress.Core.Tests/Storage/SymbolStoreQueryTests.cs` | Query method tests |
+| `tests/CodeCompress.Core.Tests/Storage/Fts5SanitizerTests.cs` | Sanitizer unit tests |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `src/CodeCompress.Core/Storage/ISymbolStore.cs` | Add all new query method signatures |
+| `src/CodeCompress.Core/Storage/SymbolStore.cs` | Implement all new query methods |
+
+## Out of Scope
+
+- MCP tool implementations that call these methods (Feature 05+)
+- Index engine orchestration and incremental re-indexing (Feature 04+)
+- Caching of query results in memory
+- Pagination beyond simple `LIMIT` (no cursor-based pagination)
+- Cross-repository queries or federated search
+- Write operations (already covered in 03-002)
+
+## Notes/Decisions
+
+- **FTS5 sanitization strategy:** The safest approach is to split the user query into individual terms, wrap each in double quotes, and join with spaces (implicit AND in FTS5). This prevents all operator injection while preserving multi-word search. Example: input `"foo OR bar*"` becomes `"foo" "OR" "bar"` — FTS5 treats `"OR"` as a literal term, not an operator.
+- **BM25 ranking:** FTS5's built-in `bm25()` function provides relevance ranking. The column weights can be tuned later (e.g., weighting `name` higher than `doc_comment` in `symbols_fts`).
+- **Recursive CTE for dependency graph:** SQLite supports `WITH RECURSIVE` which is ideal for graph traversal up to a bounded depth. The depth parameter is enforced in the CTE's recursion termination condition, not in application code, to prevent runaway queries.
+- **Glob filtering for text search:** The `glob` parameter on `SearchTextAsync` filters on the `relative_path` column using SQLite's `GLOB` function (case-sensitive, supports `*` and `?`). This is applied as a WHERE clause, not as part of the FTS5 MATCH expression.
+- **Snapshot diffing in application code:** `GetChangedFilesAsync` deserializes the snapshot's JSON `file_hashes` and compares in-memory against current file records. This is simpler and more maintainable than a complex SQL join between JSON and the `files` table, and snapshots are bounded in size (thousands of files, not millions).
+- **Qualified name lookup:** `GetSymbolByNameAsync` splits on `.` or `:` to separate parent from child symbol names. This supports Luau's `Module.Function` and `Module:Method` conventions as well as C#'s `Namespace.Class.Method` patterns.

--- a/docs/04-path-validation/001-path-validator.md
+++ b/docs/04-path-validation/001-path-validator.md
@@ -1,0 +1,164 @@
+# 001 — PathValidator: OWASP Path Traversal Prevention
+
+## Summary
+
+Implement `PathValidator`, a critical security component that prevents path traversal attacks (OWASP A01) across all MCP tool parameters that accept file paths. Every file system access in CodeCompress must pass through PathValidator, which canonicalizes the input path and verifies it resolves within the declared project root. This is a hard security boundary — no file outside the project root may be read, regardless of how the path is constructed.
+
+## Dependencies
+
+- **Feature 01** (Project Scaffold) — solution structure, build configuration, shared props
+- **Feature 02** (Core Models and Interfaces) — exception types if custom validation exceptions are defined there
+
+## Scope
+
+### 1. PathValidator Static Class
+
+**File:** `src/CodeCompress.Core/Validation/PathValidator.cs`
+
+A static class (no instance state needed) exposing three public methods:
+
+#### `ValidatePath(string inputPath, string projectRoot) → string`
+
+- Accepts an absolute path and a project root.
+- Returns the canonicalized safe path if valid.
+- Throws `ArgumentException` (or a custom `PathValidationException`) if the path escapes the root or is otherwise invalid.
+- Steps:
+  1. Reject null, empty, or whitespace inputs immediately.
+  2. Canonicalize both `inputPath` and `projectRoot` via `Path.GetFullPath()` to resolve `.`, `..`, double slashes, mixed separators, and trailing slashes.
+  3. Normalize the project root to include a trailing directory separator so that `/project` does not match `/project-other`.
+  4. Perform a starts-with check: the canonicalized input must start with the canonicalized root.
+  5. On Windows, use `StringComparison.OrdinalIgnoreCase`; on Linux/macOS, use `StringComparison.Ordinal`.
+  6. If the path is exactly the root directory, allow it.
+
+#### `ValidateRelativePath(string relativePath, string projectRoot) → string`
+
+- Resolves a relative path against the project root using `Path.GetFullPath(relativePath, projectRoot)`.
+- Delegates to `ValidatePath` for the actual security check.
+- Returns the canonicalized absolute path.
+
+#### `IsWithinRoot(string candidatePath, string projectRoot) → bool`
+
+- Non-throwing variant of `ValidatePath`.
+- Returns `true` if the candidate resolves within root, `false` otherwise.
+- Catches exceptions from invalid inputs and returns `false`.
+
+### 2. Edge Cases and Platform Handling
+
+| Concern | Approach |
+|---------|----------|
+| **Null / empty / whitespace** | Throw `ArgumentException` with a clear message. Do not propagate `NullReferenceException`. |
+| **`..` traversal** | `Path.GetFullPath()` resolves `..` segments before the starts-with check, so `"/project/../../../etc/passwd"` becomes `"/etc/passwd"` and fails. |
+| **Symlinks** | After canonicalization, if the OS resolves a symlink to a target outside root, the starts-with check rejects it. On .NET, `Path.GetFullPath()` does not resolve symlinks by default; use `new FileInfo(path).LinkTarget` or `File.ResolveLinkTarget()` when the path exists, and re-validate the resolved target. If the file does not yet exist, accept the canonicalized path (no symlink to resolve). |
+| **Case sensitivity** | Use `OperatingSystem.IsWindows()` to select the comparison: `OrdinalIgnoreCase` on Windows, `Ordinal` on Linux/macOS. |
+| **Trailing / double slashes** | `Path.GetFullPath()` normalizes these. Ensure the root always ends with the directory separator character for the starts-with check. |
+| **Mixed separators** | `Path.GetFullPath()` normalizes `/` vs `\` per platform. |
+| **UNC paths on Windows** | Reject any path starting with `\\` (or `//` before normalization) unless the project root itself is a UNC path. UNC paths to network shares are an escalation vector. |
+| **Null bytes** | Reject any path containing `\0`. .NET's `Path.GetFullPath()` already throws on null bytes, but validate explicitly for a clear error message. |
+| **Special characters** | Allow valid filesystem characters. `Path.GetFullPath()` throws on invalid path characters — let that propagate with a descriptive wrapper. |
+| **Very long paths** | Allow paths up to the OS limit. If `Path.GetFullPath()` throws `PathTooLongException`, wrap with context. |
+
+### 3. Test Coverage
+
+**File:** `tests/CodeCompress.Core.Tests/Validation/PathValidatorTests.cs`
+
+All tests use TUnit with async fluent assertions.
+
+#### Happy Path Tests
+
+- Valid absolute path within project root returns canonicalized path.
+- Valid relative path (`"src/Foo.cs"`) resolves to `{root}/src/Foo.cs`.
+- Path exactly equal to root is accepted.
+- Subdirectory path is accepted.
+- `IsWithinRoot` returns `true` for valid paths.
+
+#### Traversal Attack Tests
+
+- `"/project/../../../etc/passwd"` — rejected.
+- `"/project/src/../../outside"` — rejected.
+- Relative path `"../../etc/passwd"` — rejected.
+- Multiple `..` segments that escape root — rejected.
+- `..` that stays within root (e.g., `"/project/src/../lib/Foo.cs"`) — accepted.
+
+#### Input Validation Tests
+
+- `null` input — throws `ArgumentException`.
+- Empty string — throws `ArgumentException`.
+- Whitespace-only string — throws `ArgumentException`.
+- `null` project root — throws `ArgumentException`.
+
+#### Null Byte / Encoding Tests
+
+- Path containing `\0` — rejected.
+- Paths with URL-encoded characters (`%2e%2e`) are treated as literal characters (not decoded), which is correct — the filesystem does not interpret URL encoding.
+
+#### Platform-Specific Tests
+
+- **Windows case sensitivity:** `"/Project/SRC/Foo.cs"` with root `"/project"` — accepted on Windows, rejected on Linux (use conditional test or parameterized with `OperatingSystem.IsWindows()` guard).
+- **UNC path:** `"\\\\server\\share\\file"` — rejected (unless root is also UNC).
+- **Mixed separators:** `"/project\\src/Foo.cs"` — normalized and accepted.
+
+#### Edge Case Tests
+
+- Trailing slash on root does not affect validation.
+- Double slashes in path (`"/project//src//Foo.cs"`) — normalized and accepted.
+- Path that is a prefix of root but not a child (`"/project-other/file"` with root `"/project"`) — rejected (the trailing-separator trick prevents this).
+- Very long path — accepted up to OS limit, appropriate error beyond.
+- `IsWithinRoot` returns `false` for all invalid cases (does not throw).
+
+#### Parameterized Tests
+
+Use `[Arguments(...)]` for traversal vectors:
+
+```csharp
+[Test]
+[Arguments("/../../../etc/passwd")]
+[Arguments("/../../windows/system32/config/sam")]
+[Arguments("/../")]
+[Arguments("/./../../outside")]
+public async Task ValidatePath_TraversalAttempts_Throws(string maliciousSegment)
+{
+    // Arrange — prepend project root to malicious segment
+    // Act & Assert — should throw
+}
+```
+
+## Acceptance Criteria
+
+- [ ] `PathValidator` class exists at `src/CodeCompress.Core/Validation/PathValidator.cs`
+- [ ] `ValidatePath` canonicalizes and validates absolute paths against a project root
+- [ ] `ValidateRelativePath` resolves relative paths and delegates to `ValidatePath`
+- [ ] `IsWithinRoot` provides a non-throwing boolean check
+- [ ] Null, empty, and whitespace inputs throw `ArgumentException`
+- [ ] Paths containing `..` that escape root are rejected
+- [ ] Paths containing null bytes are rejected
+- [ ] UNC paths are rejected (unless root is UNC)
+- [ ] Case comparison is OS-aware (case-insensitive on Windows, case-sensitive on Linux/macOS)
+- [ ] The trailing-separator normalization prevents prefix false positives (`/project` vs `/project-other`)
+- [ ] Symlinks that resolve outside root are rejected (when the path exists on disk)
+- [ ] All test cases in `PathValidatorTests.cs` pass
+- [ ] Code coverage on `PathValidator.cs` is 95% or above
+- [ ] Zero build warnings (SonarAnalyzer, nullable, code style)
+- [ ] No string concatenation in error messages that echoes back raw user input (prompt injection prevention)
+
+## Files to Create/Modify
+
+| File | Action | Notes |
+|------|--------|-------|
+| `src/CodeCompress.Core/Validation/PathValidator.cs` | Create | Static class with three public methods |
+| `tests/CodeCompress.Core.Tests/Validation/PathValidatorTests.cs` | Create | Full test suite covering all cases above |
+
+## Out of Scope
+
+- Integrating PathValidator into MCP tool methods (happens in Features 07-10 when tools are built).
+- File content reading or modification — PathValidator only validates paths, it does not perform I/O.
+- Network path (UNC) support as a feature — UNC paths are explicitly rejected for security.
+- Symbolic link creation or manipulation — only detection/resolution of existing symlinks.
+- Custom exception types — use `ArgumentException` unless Feature 02 defines a `PathValidationException`. Revisit if needed.
+
+## Notes / Decisions
+
+1. **Static class, not a service** — PathValidator has no dependencies and no state. Making it static avoids unnecessary DI registration and keeps call sites simple (`PathValidator.ValidatePath(...)` rather than injecting an interface). If future requirements add configuration (e.g., allowed UNC roots), it can be refactored to an instance behind `IPathValidator`.
+2. **Trailing directory separator trick** — Comparing `candidatePath.StartsWith(rootWithSeparator)` prevents the classic false positive where `/project-other/evil.cs` matches root `/project`. The root is always normalized to end with `Path.DirectorySeparatorChar` before comparison.
+3. **Symlink handling is best-effort** — On .NET, resolving symlinks portably is non-trivial. The implementation should use `File.ResolveLinkTarget(path, returnFinalTarget: true)` when the path exists and is a symlink, then re-validate the resolved target. If the file does not exist (e.g., validating a path before creating a database), skip symlink resolution — canonicalization via `Path.GetFullPath()` is sufficient.
+4. **No URL decoding** — The filesystem layer does not interpret `%2e%2e` as `..`. Decoding URL-encoded paths would be incorrect and could introduce a bypass if a future layer pre-decodes. PathValidator operates on raw filesystem paths only.
+5. **Error messages must not echo user input** — Per the prompt injection prevention requirement, exception messages should describe what went wrong (e.g., "Path resolves outside the project root") without including the actual path value in freeform text that could be surfaced to an AI agent. The path can be included in structured error data if needed for debugging.

--- a/docs/05-luau-parser/001-core-patterns.md
+++ b/docs/05-luau-parser/001-core-patterns.md
@@ -1,0 +1,183 @@
+# 001 — Luau Parser: Core Function/Method/Class Pattern Extraction
+
+## Summary
+
+Implement the first language parser for CodeCompress (MVP). `LuauParser` is a regex/pattern-based parser for Luau (Roblox Lua variant) that extracts core symbol types: module classes, methods, functions, local functions, and module return statements. Luau syntax is regular enough that full AST parsing is unnecessary — line-oriented regex matching over `ReadOnlySpan<byte>` provides accurate extraction with zero-copy performance.
+
+## Dependencies
+
+- **Feature 01** — Project scaffold, solution file, and `.csproj` files for `CodeCompress.Core` and `CodeCompress.Core.Tests`.
+- **Feature 02** — Core models and interfaces (`ILanguageParser`, `SymbolInfo`, `SymbolKind`, `Visibility`, `ParseResult`, `DependencyInfo`).
+
+## Scope
+
+### 1. LuauParser Class (`src/CodeCompress.Core/Parsers/LuauParser.cs`)
+
+Implements `ILanguageParser` with:
+
+| Member           | Value / Signature                                                  |
+|------------------|--------------------------------------------------------------------|
+| `LanguageId`     | `"luau"`                                                           |
+| `FileExtensions` | `[".luau", ".lua"]`                                                |
+| `Parse`          | `ParseResult Parse(string filePath, ReadOnlySpan<byte> content)`   |
+
+### 2. Core Symbol Patterns
+
+The parser must recognize and extract the following Luau patterns:
+
+#### Module Class Declaration
+
+```lua
+local ClassName = {} :: ClassName
+```
+
+- **Kind:** `SymbolKind.Class`
+- **Visibility:** `Visibility.Public`
+- **Name:** `ClassName`
+- **Signature:** Full declaration line
+
+#### Method Declaration
+
+```lua
+function ClassName:MethodName(params): ReturnType
+```
+
+- **Kind:** `SymbolKind.Method`
+- **Visibility:** `Visibility.Public` (if on a returned/exported class), `Visibility.Private` otherwise
+- **Name:** `MethodName`
+- **ParentSymbol:** `ClassName`
+- **Signature:** Full declaration line including parameters and return type
+
+#### Top-Level Function Declaration
+
+```lua
+function functionName(params): ReturnType
+```
+
+- **Kind:** `SymbolKind.Function`
+- **Visibility:** `Visibility.Public`
+- **Name:** `functionName`
+- **Signature:** Full declaration line
+
+#### Local Function Declaration
+
+```lua
+local function name(params): ReturnType
+```
+
+- **Kind:** `SymbolKind.Function`
+- **Visibility:** `Visibility.Private`
+- **Name:** `name`
+- **Signature:** Full declaration line
+
+#### Module Return Statement
+
+```lua
+return ClassName
+```
+
+- **Kind:** `SymbolKind.Export`
+- **Visibility:** `Visibility.Public`
+- **Name:** `ClassName`
+- **Signature:** `return ClassName`
+
+### 3. Symbol Metadata Capture
+
+For every extracted symbol, the parser must populate:
+
+| Field          | Derivation                                                                 |
+|----------------|----------------------------------------------------------------------------|
+| `Name`         | Extracted from regex capture group                                         |
+| `Kind`         | Determined by pattern match (see above)                                    |
+| `Signature`    | Full declaration line, trimmed                                             |
+| `ParentSymbol` | Class name for methods; `null` for top-level symbols                       |
+| `ByteOffset`   | Byte position of the first character of the declaration in the source file |
+| `ByteLength`   | Byte length from declaration start to matching `end` keyword               |
+| `LineStart`    | 1-based line number of the declaration                                     |
+| `LineEnd`      | 1-based line number of the corresponding `end` keyword                     |
+| `Visibility`   | Determined by pattern and export analysis (see above)                      |
+| `DocComment`   | `null` (deferred to 05-002)                                               |
+
+### 4. End-Keyword Matching
+
+Functions, methods, and local functions in Luau are terminated by an `end` keyword. The parser must track nesting depth (counting `function`, `if`, `for`, `while`, `do`, `repeat` openers against `end` / `until` closers) to find the correct closing `end` for each symbol, yielding accurate `ByteLength` and `LineEnd` values.
+
+### 5. ReadOnlySpan Processing
+
+- Decode `ReadOnlySpan<byte>` as UTF-8.
+- Process line-by-line for regex matching.
+- Track cumulative byte offsets for each line to compute `ByteOffset` per symbol.
+
+### 6. DI Registration
+
+`LuauParser` must be registered as an `ILanguageParser` implementation in the DI container. The `IndexEngine` auto-resolves parsers by file extension, so no additional wiring is needed beyond registration. Adding a new language parser requires only one class — no other changes.
+
+## Acceptance Criteria
+
+- [ ] `LuauParser` implements `ILanguageParser` with `LanguageId = "luau"` and `FileExtensions = [".luau", ".lua"]`.
+- [ ] `Parse` accepts `ReadOnlySpan<byte>` content and returns a `ParseResult`.
+- [ ] Module class declarations (`local X = {} :: X`) are extracted as `SymbolKind.Class` with `Visibility.Public`.
+- [ ] Method declarations (`function X:Y(...)`) are extracted as `SymbolKind.Method` with correct `ParentSymbol`.
+- [ ] Top-level function declarations are extracted as `SymbolKind.Function` with `Visibility.Public`.
+- [ ] Local function declarations are extracted as `SymbolKind.Function` with `Visibility.Private`.
+- [ ] Module return statements are extracted as `SymbolKind.Export`.
+- [ ] `ByteOffset`, `ByteLength`, `LineStart`, and `LineEnd` are accurate for all symbols.
+- [ ] End-keyword nesting is correctly tracked (nested blocks do not confuse symbol boundaries).
+- [ ] Empty file input returns an empty `ParseResult` (zero symbols, zero dependencies).
+- [ ] File with only comments returns an empty `ParseResult`.
+- [ ] File with multiple symbols returns all symbols in declaration order.
+- [ ] `dotnet build CodeCompress.slnx` succeeds with zero warnings.
+- [ ] All tests pass via `dotnet test tests/CodeCompress.Core.Tests`.
+- [ ] Parser test coverage is 95%+.
+
+## Files to Create/Modify
+
+### Create
+
+| File | Description |
+|------|-------------|
+| `src/CodeCompress.Core/Parsers/LuauParser.cs` | Luau language parser implementation |
+| `tests/CodeCompress.Core.Tests/Parsers/LuauParserTests.cs` | Parser unit tests |
+
+### Modify
+
+| File | Description |
+|------|-------------|
+| DI registration site (e.g., `ServiceCollectionExtensions.cs`) | Register `LuauParser` as `ILanguageParser` |
+
+## Test Cases (`tests/CodeCompress.Core.Tests/Parsers/LuauParserTests.cs`)
+
+| Test | Description |
+|------|-------------|
+| Parse_SingleFunction_ReturnsCorrectSymbolInfo | Top-level `function foo()` yields one `Function` symbol with correct metadata |
+| Parse_MethodOnClass_ReturnsCorrectParentAndVisibility | `function Cls:bar()` yields `Method` with `ParentSymbol = "Cls"` |
+| Parse_LocalFunction_ReturnsPrivateVisibility | `local function helper()` yields `Function` with `Visibility.Private` |
+| Parse_ModuleClassDeclaration_ReturnsClassSymbol | `local Cls = {} :: Cls` yields `Class` with `Visibility.Public` |
+| Parse_ModuleReturn_ReturnsExportSymbol | `return Cls` yields `Export` symbol |
+| Parse_MultipleSymbols_ReturnsAllInOrder | File with class, method, function, local function, return yields all five |
+| Parse_EmptyFile_ReturnsEmptyResult | Zero-byte input returns empty `ParseResult` |
+| Parse_OnlyComments_ReturnsEmptyResult | File containing only `--` comments returns empty `ParseResult` |
+| Parse_ByteOffsets_AreAccurate | Byte offsets match actual positions in the source bytes |
+| Parse_LineNumbers_AreOneBased | `LineStart` and `LineEnd` are 1-based and correct |
+| Parse_NestedBlocks_DoNotConfuseEndMatching | Function containing `if`/`for`/`while` blocks resolves correct `end` |
+| Parse_FunctionWithReturnType_CapturesFullSignature | `function foo(): string` signature includes return type annotation |
+| Parse_MethodWithParameters_CapturesFullSignature | `function Cls:bar(x: number, y: string): boolean` captures full signature |
+
+## Out of Scope
+
+- Type definitions (`export type`, `type`) — covered in 05-002.
+- Constants (SCREAMING_SNAKE_CASE detection) — covered in 05-002.
+- Dependency extraction (`require()`) — covered in 05-002.
+- Doc comment capture — covered in 05-002.
+- Multi-line type definitions and brace-depth tracking — covered in 05-002.
+- Metatable pattern detection — covered in 05-002.
+- Generic/union/intersection types — covered in 05-002.
+- Integration with IndexEngine or SQLite storage — separate features.
+
+## Notes / Decisions
+
+1. **Regex over AST.** Luau syntax is sufficiently regular (no preprocessor, no significant indentation semantics, clear keyword delimiters) that regex-based line matching provides reliable extraction without the complexity and dependency cost of a full parser. This aligns with the project's stated approach for Phase 1.
+2. **End-keyword nesting.** Luau uses `end` to close multiple block types (`function`, `if`, `for`, `while`, `do`) and `until` to close `repeat` blocks. The parser must maintain a nesting counter to pair each symbol's opening line with its correct `end`. This is the most complex part of the parser logic.
+3. **Visibility heuristic.** Top-level `function` declarations and class declarations are treated as `Public`. `local function` declarations are `Private`. Method visibility depends on whether its parent class is the module's return value — this requires a two-pass approach or post-processing after the return statement is found.
+4. **UTF-8 assumption.** Luau source files are assumed to be UTF-8 encoded. The parser decodes `ReadOnlySpan<byte>` to string lines via `Encoding.UTF8`. Byte offsets are computed on the raw bytes, not on decoded characters, ensuring accuracy for multi-byte content.
+5. **Dependencies list.** The `ParseResult.Dependencies` list will be empty in this plan; dependency extraction is deferred to 05-002.

--- a/docs/05-luau-parser/002-types-constants-dependencies.md
+++ b/docs/05-luau-parser/002-types-constants-dependencies.md
@@ -1,0 +1,247 @@
+# 002 — Luau Parser: Types, Constants, Dependencies, and Edge Cases
+
+## Summary
+
+Extend the Luau parser with extraction of type definitions, constants, `require()` dependencies, and doc comments. Handle edge cases including multi-line type definitions, generic types, union/intersection types, metatable OOP patterns, nested functions, and malformed input. This plan brings `LuauParser` to full feature completeness for the MVP.
+
+## Dependencies
+
+- **Feature 05-001** — Core `LuauParser` implementation with function, method, class, and export extraction already working and tested.
+
+## Scope
+
+### 1. Additional Symbol Patterns
+
+#### Export Type Definition
+
+```lua
+export type TypeName = { field: string, count: number }
+```
+
+- **Kind:** `SymbolKind.Type`
+- **Visibility:** `Visibility.Public`
+- **Name:** `TypeName`
+- **Signature:** Full declaration (first line for multi-line types, or entire declaration for single-line)
+- **ByteLength:** Spans from `export` keyword to closing `}` (for table types) or end of declaration
+
+#### Local Type Definition
+
+```lua
+type TypeName = { field: string }
+```
+
+- **Kind:** `SymbolKind.Type`
+- **Visibility:** `Visibility.Private`
+- **Name:** `TypeName`
+- **Signature:** Full declaration
+
+#### Generic Type Definition
+
+```lua
+export type Result<T> = { ok: boolean, value: T? }
+```
+
+- Parsed identically to non-generic types; the generic parameter list `<T>` is included in the `Name` (as `Result<T>`) and in the `Signature`.
+
+#### Union and Intersection Types
+
+```lua
+type Status = "active" | "downed" | "dead"
+export type Combined = TypeA & TypeB
+```
+
+- Extracted as `SymbolKind.Type` with appropriate visibility.
+- `Signature` captures the full right-hand side.
+
+#### Constant Declaration
+
+```lua
+local MAX_RETRIES = 5
+local DEFAULT_TIMEOUT = 30
+```
+
+- **Detection:** `local IDENTIFIER = value` where `IDENTIFIER` matches `^[A-Z][A-Z0-9_]+$` (SCREAMING_SNAKE_CASE).
+- **Kind:** `SymbolKind.Constant`
+- **Visibility:** `Visibility.Private`
+- **Name:** The constant identifier
+- **Signature:** Full declaration line
+
+### 2. Dependency Extraction
+
+#### Path-Style Require
+
+```lua
+local Module = require(path.to.Module)
+local Service = require(script.Parent.ServiceName)
+```
+
+- **RequirePath:** `path.to.Module` or `script.Parent.ServiceName` (the full expression inside `require(...)`)
+- **Alias:** `Module` or `Service` (the local variable name)
+
+#### String-Style Require
+
+```lua
+local Http = require("HttpService")
+```
+
+- **RequirePath:** `HttpService` (the string literal contents, without quotes)
+- **Alias:** `Http`
+
+#### Bare Require (No Alias)
+
+```lua
+require(script.Parent.Init)
+```
+
+- **RequirePath:** `script.Parent.Init`
+- **Alias:** `null`
+
+### 3. Doc Comment Capture
+
+Luau uses `--` for single-line comments. A doc comment is defined as one or more contiguous `--` comment lines immediately preceding a symbol declaration (no blank lines between the comment block and the declaration).
+
+```lua
+-- Calculates the distance between two points.
+-- Returns the Euclidean distance as a number.
+function calculateDistance(a: Vector3, b: Vector3): number
+```
+
+- The concatenated comment text (without leading `-- ` prefixes) is stored in `SymbolInfo.DocComment`.
+- Non-contiguous comments (separated by blank lines from the declaration) are not captured.
+
+### 4. Multi-Line Type Definitions
+
+Type definitions using table syntax can span many lines:
+
+```lua
+export type PlayerData = {
+    name: string,
+    health: number,
+    inventory: { Item },
+    position: Vector3,
+}
+```
+
+The parser must track brace depth (`{` increments, `}` decrements) starting from the opening `{` to find the matching closing `}`, yielding correct `ByteLength` and `LineEnd` values.
+
+### 5. Metatable Pattern Detection
+
+Luau OOP classes commonly use a metatable setup pattern:
+
+```lua
+local ClassName = {}
+ClassName.__index = ClassName
+
+function ClassName.new(...)
+    local self = (setmetatable :: any)({}, ClassName)
+    -- ...
+    return self
+end
+```
+
+- The `local ClassName = {}` followed by `ClassName.__index = ClassName` pattern should be recognized as a `SymbolKind.Class` declaration (if not already matched by the `local X = {} :: X` pattern from 05-001).
+- `ClassName.new(...)` is a constructor — extracted as `SymbolKind.Method` with `ParentSymbol = "ClassName"`.
+- The `(setmetatable :: any)(self, ClassName)` line inside a function body is not itself a symbol, but its presence reinforces the class identification.
+
+### 6. Edge Cases
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Multi-line function signatures | Signature captures the full opening line; `ByteOffset` starts at `function` keyword |
+| Nested functions inside functions | Inner function is extracted with correct `ParentSymbol` set to the enclosing function name |
+| Multiple return values in type annotations | `function foo(): (string, number)` — full return type captured in signature |
+| Empty type body `type X = {}` | Single-line type, `ByteLength` covers the full line |
+| Malformed/incomplete declaration (e.g., `function` with no name) | Gracefully skipped — no crash, no symbol emitted, parsing continues |
+| Unterminated type (EOF before closing `}`) | Emit symbol with `LineEnd` set to last line of file; `ByteLength` covers to EOF |
+| Unterminated function (EOF before `end`) | Emit symbol with `LineEnd` set to last line of file |
+| Mixed symbol types in one file | All symbol types extracted in declaration order |
+| Very long files (10,000+ lines) | Parser completes without performance degradation |
+| Binary/non-UTF-8 content | Graceful handling — return empty `ParseResult` or best-effort extraction |
+
+### 7. Dot-Syntax Static Methods
+
+```lua
+function ClassName.staticMethod(params): ReturnType
+```
+
+- **Kind:** `SymbolKind.Method`
+- **Visibility:** Determined by parent class export status
+- **ParentSymbol:** `ClassName`
+- Distinguished from colon-syntax instance methods but extracted with the same `SymbolKind`
+
+## Acceptance Criteria
+
+- [ ] `export type` declarations are extracted as `SymbolKind.Type` with `Visibility.Public`.
+- [ ] `type` (non-export) declarations are extracted as `SymbolKind.Type` with `Visibility.Private`.
+- [ ] Generic type parameters are captured in the name and signature (e.g., `Result<T>`).
+- [ ] Union types (`"a" | "b"`) and intersection types (`A & B`) are extracted correctly.
+- [ ] SCREAMING_SNAKE_CASE locals are extracted as `SymbolKind.Constant` with `Visibility.Private`.
+- [ ] `require(path.to.Module)` produces a `DependencyInfo` with correct `RequirePath` and `Alias`.
+- [ ] `require("StringModule")` produces a `DependencyInfo` with the string contents as `RequirePath`.
+- [ ] Bare `require()` calls (no alias) produce a `DependencyInfo` with `Alias = null`.
+- [ ] Contiguous `--` comment blocks preceding a symbol are captured in `DocComment`.
+- [ ] Multi-line type definitions have correct `ByteLength` and `LineEnd` via brace-depth tracking.
+- [ ] Metatable pattern (`X = {}` + `X.__index = X`) is recognized as a class declaration.
+- [ ] Dot-syntax static methods (`function X.y()`) are extracted as methods with correct `ParentSymbol`.
+- [ ] Nested functions have correct `ParentSymbol` referencing the enclosing function.
+- [ ] Malformed declarations are gracefully skipped without crashing the parser.
+- [ ] Unterminated symbols (EOF before `end` or `}`) are handled with best-effort `LineEnd`/`ByteLength`.
+- [ ] `dotnet build CodeCompress.slnx` succeeds with zero warnings.
+- [ ] All tests pass via `dotnet test tests/CodeCompress.Core.Tests`.
+- [ ] Combined parser test coverage (05-001 + 05-002) is 95%+.
+
+## Files to Create/Modify
+
+### Create
+
+None. All new tests are added to the existing test file.
+
+### Modify
+
+| File | Description |
+|------|-------------|
+| `src/CodeCompress.Core/Parsers/LuauParser.cs` | Add type, constant, dependency, doc comment, and metatable extraction logic |
+| `tests/CodeCompress.Core.Tests/Parsers/LuauParserTests.cs` | Add test cases for all new patterns and edge cases |
+
+## Test Cases (additions to `LuauParserTests.cs`)
+
+| Test | Description |
+|------|-------------|
+| Parse_ExportType_ReturnsPublicTypeSymbol | `export type Foo = { ... }` yields `Type` with `Visibility.Public` |
+| Parse_LocalType_ReturnsPrivateTypeSymbol | `type Bar = { ... }` yields `Type` with `Visibility.Private` |
+| Parse_GenericType_CapturesTypeParameters | `export type Result<T>` name includes `<T>` |
+| Parse_UnionType_ExtractsCorrectly | `type Status = "a" \| "b"` yields `Type` with full signature |
+| Parse_IntersectionType_ExtractsCorrectly | `type Combined = A & B` yields `Type` with full signature |
+| Parse_MultiLineType_CorrectByteLength | Brace-depth tracking yields accurate span for multi-line type body |
+| Parse_Constant_ScreamingSnakeCase_ReturnsConstantSymbol | `local MAX_RETRIES = 5` yields `Constant` with `Visibility.Private` |
+| Parse_NonConstantLocal_IsNotExtractedAsConstant | `local myVar = 5` is not treated as a constant |
+| Parse_RequirePathStyle_ReturnsDependency | `local M = require(path.to.M)` yields `DependencyInfo` with correct path and alias |
+| Parse_RequireStringStyle_ReturnsDependency | `local H = require("Http")` yields `DependencyInfo` with `RequirePath = "Http"` |
+| Parse_RequireNoAlias_ReturnsDependencyWithNullAlias | Bare `require(...)` yields `Alias = null` |
+| Parse_DocComment_CapturedOnSymbol | Contiguous `--` block before function populates `DocComment` |
+| Parse_NonContiguousComment_NotCaptured | Comment separated by blank line from declaration yields `DocComment = null` |
+| Parse_MetatablePattern_RecognizedAsClass | `X = {}` + `X.__index = X` yields `Class` symbol |
+| Parse_DotSyntaxMethod_ExtractsWithParent | `function Cls.static()` yields `Method` with `ParentSymbol = "Cls"` |
+| Parse_NestedFunction_CorrectParent | Inner function has `ParentSymbol` set to enclosing function |
+| Parse_MalformedDeclaration_GracefullySkipped | `function` with no name does not crash; other symbols still extracted |
+| Parse_UnterminatedFunction_HandledGracefully | EOF before `end` yields symbol with `LineEnd` at last line |
+| Parse_UnterminatedType_HandledGracefully | EOF before closing `}` yields symbol with best-effort span |
+| Parse_MixedFile_AllSymbolTypes | File with class, method, function, type, constant, require, export yields all correctly |
+| Parse_MultipleReturnTypes_CapturedInSignature | `function foo(): (string, number)` signature includes full return annotation |
+
+## Out of Scope
+
+- Integration with `IndexEngine` or SQLite storage — separate features.
+- Incremental parsing (only re-parsing changed regions of a file) — potential future optimization.
+- Semantic analysis (resolving types across files, type checking) — out of scope for a pattern-based parser.
+- Other languages (C#, Python, TypeScript) — separate features per the phased rollout.
+- Performance benchmarking — may be added as a separate plan if needed.
+
+## Notes / Decisions
+
+1. **Brace-depth tracking for types.** Multi-line table types (`{ ... }`) require tracking `{`/`}` nesting depth, similar to how 05-001 tracks `end`-keyword nesting for functions. Both mechanisms coexist in the parser — function-like symbols use end-keyword matching, type symbols use brace-depth matching.
+2. **SCREAMING_SNAKE_CASE heuristic.** Constants are detected purely by naming convention (`^[A-Z][A-Z0-9_]+$`). This is a pragmatic heuristic — Luau has no `const` keyword. False positives (e.g., `local HTTP_STATUS = require(...)`) are acceptable since the symbol is still meaningful to index. The regex requires at least two characters and at least one underscore or digit to avoid matching single-letter capitals.
+3. **Doc comment convention.** Luau does not have a standardized doc comment format (no `///` or `/** */` equivalent). We treat any contiguous block of `--` comments immediately preceding a declaration as a doc comment. `---` (triple-dash) comments are treated identically to `--` comments. The leading `-- ` prefix (including the space) is stripped from each line.
+4. **Metatable as fallback class detection.** The `X.__index = X` pattern is a secondary class detection heuristic, complementing the `local X = {} :: X` type annotation pattern from 05-001. If both patterns match the same name, only one `Class` symbol is emitted (no duplicates).
+5. **Two-pass visibility resolution.** Determining whether a method's parent class is exported requires knowing the module's `return` statement. The parser uses a two-pass approach: first pass extracts all symbols with provisional visibility, second pass adjusts method visibility based on whether their parent class name matches the returned value.
+6. **Dependency extraction is position-independent.** `require()` calls are extracted wherever they appear in the file (top-level, inside functions, inside conditional blocks). All are recorded as dependencies since they represent module-level relationships regardless of runtime conditionality.

--- a/docs/06-index-engine/001-file-hasher.md
+++ b/docs/06-index-engine/001-file-hasher.md
@@ -1,0 +1,97 @@
+# 001 — FileHasher: SHA-256 Parallel File Hashing
+
+## Summary
+
+`FileHasher` computes SHA-256 hashes of source files for change detection during incremental indexing. It uses `Parallel.ForEachAsync` for concurrent hashing and async file I/O throughout, with `ReadOnlyMemory<byte>` / buffer pooling for efficient memory use. An `IFileHasher` interface is provided for testability.
+
+## Dependencies
+
+| Dependency | What it provides |
+|------------|-----------------|
+| Feature 01 (Project Scaffold) | Solution structure, `Directory.Build.props`, global analyzers |
+| Feature 02 (Core Models & Interfaces) | Base model types, shared interfaces |
+
+## Scope
+
+### Production Code
+
+**File:** `src/CodeCompress.Core/Indexing/FileHasher.cs`
+
+#### `IFileHasher` Interface
+
+```csharp
+public interface IFileHasher
+{
+    Task<string> HashFileAsync(string filePath, CancellationToken cancellationToken = default);
+    Task<Dictionary<string, string>> HashFilesAsync(IEnumerable<string> filePaths, CancellationToken cancellationToken = default);
+}
+```
+
+#### `FileHasher` Class
+
+- **`HashFileAsync(string filePath, CancellationToken) -> string`**
+  - Opens file with async `FileStream` (read-only, sequential scan hint).
+  - Computes SHA-256 using `System.Security.Cryptography.SHA256`.
+  - Uses `ArrayPool<byte>` or `ReadOnlyMemory<byte>` buffering — no large allocations per file.
+  - Returns lowercase hex-encoded hash string.
+  - Throws `FileNotFoundException` for missing files.
+
+- **`HashFilesAsync(IEnumerable<string> filePaths, CancellationToken) -> Dictionary<string, string>`**
+  - Uses `Parallel.ForEachAsync` with a configurable `MaxDegreeOfParallelism` (default: `Environment.ProcessorCount`).
+  - Collects results into a `ConcurrentDictionary<string, string>`, then returns as `Dictionary`.
+  - Propagates cancellation via `CancellationToken`.
+  - If any single file fails, the exception propagates (no partial results swallowed).
+
+### Test Code
+
+**File:** `tests/CodeCompress.Core.Tests/Indexing/FileHasherTests.cs`
+
+| # | Test Case | Assertion |
+|---|-----------|-----------|
+| 1 | Hash a known file with known content | Returns expected SHA-256 hex string |
+| 2 | Hash same content twice | Both hashes are identical |
+| 3 | Hash different content | Hashes differ |
+| 4 | Hash multiple files in parallel | All results correct and dictionary complete |
+| 5 | Non-existent file path | Throws `FileNotFoundException` |
+| 6 | Empty file (zero bytes) | Returns valid SHA-256 of empty input (`e3b0c44298fc...`) |
+| 7 | Large file (>1 MB generated temp file) | Completes without error, returns valid hash |
+| 8 | Cancellation token cancelled before start | Throws `OperationCanceledException` |
+| 9 | Cancellation token cancelled mid-batch | Throws `OperationCanceledException`, does not hang |
+
+All tests use temporary files created in a `[Before(Test)]` setup and cleaned up in `[After(Test)]`. TUnit assertion style (`await Assert.That(...)`) throughout.
+
+## Acceptance Criteria
+
+- [ ] `IFileHasher` interface defined with both methods
+- [ ] `FileHasher` implements `IFileHasher`
+- [ ] `HashFileAsync` returns correct lowercase hex SHA-256 for any file
+- [ ] `HashFilesAsync` hashes files concurrently via `Parallel.ForEachAsync`
+- [ ] No blocking I/O — all file access is async
+- [ ] Memory-efficient: uses `ArrayPool<byte>` or pooled buffers, not unbounded `byte[]` allocations
+- [ ] `CancellationToken` respected in both methods
+- [ ] `FileNotFoundException` thrown for missing files
+- [ ] All 9 test cases pass
+- [ ] Zero build warnings (SonarAnalyzer, nullable, code style)
+- [ ] No `dynamic` or `object` types in public API
+
+## Files to Create/Modify
+
+| Action | File |
+|--------|------|
+| Create | `src/CodeCompress.Core/Indexing/FileHasher.cs` |
+| Create | `src/CodeCompress.Core/Indexing/IFileHasher.cs` |
+| Create | `tests/CodeCompress.Core.Tests/Indexing/FileHasherTests.cs` |
+
+## Out of Scope
+
+- Directory walking / file discovery (handled by `IndexEngine` in 003)
+- Storing hashes in SQLite (handled by `SymbolStore` in Feature 03)
+- Path validation / security checks (handled by `PathValidator` in Feature 04)
+- Incremental comparison logic (handled by `ChangeTracker` in 002)
+
+## Notes / Decisions
+
+- **Hash algorithm:** SHA-256 chosen for collision resistance and consistency with Git-style integrity checks. `System.Security.Cryptography.SHA256.HashDataAsync` (or `IncrementalHash`) preferred over `SHA256.Create()` for thread safety.
+- **Buffer size:** 8 KB default buffer aligns with typical file system block size; can be tuned later.
+- **Parallelism cap:** Defaults to `Environment.ProcessorCount` to avoid thread-pool starvation; the `IndexEngine` may override this later.
+- **Path normalization:** `FileHasher` does NOT normalize or validate paths — callers (IndexEngine) must pass already-validated absolute paths.

--- a/docs/06-index-engine/002-change-tracker.md
+++ b/docs/06-index-engine/002-change-tracker.md
@@ -1,0 +1,109 @@
+# 002 — ChangeTracker: Diff Logic for Incremental Indexing
+
+## Summary
+
+`ChangeTracker` compares current file hashes against previously stored hashes to classify every file as new, modified, deleted, or unchanged. This diff result (`ChangeSet`) drives the `IndexEngine`'s decision about which files to parse, update, or remove — enabling incremental indexing that skips unchanged files entirely.
+
+## Dependencies
+
+| Dependency | What it provides |
+|------------|-----------------|
+| Feature 01 (Project Scaffold) | Solution structure, `Directory.Build.props`, global analyzers |
+| Feature 02 (Core Models & Interfaces) | Base model types, shared interfaces |
+
+## Scope
+
+### Production Code
+
+**File:** `src/CodeCompress.Core/Indexing/ChangeTracker.cs`
+
+#### `ChangeSet` Record
+
+```csharp
+public sealed record ChangeSet(
+    IReadOnlyList<string> NewFiles,
+    IReadOnlyList<string> ModifiedFiles,
+    IReadOnlyList<string> DeletedFiles,
+    IReadOnlyList<string> UnchangedFiles);
+```
+
+- Immutable record type with `IReadOnlyList<string>` properties (file paths).
+- Provides a convenience `bool HasChanges => NewFiles.Count > 0 || ModifiedFiles.Count > 0 || DeletedFiles.Count > 0;` property.
+
+#### `IChangeTracker` Interface
+
+```csharp
+public interface IChangeTracker
+{
+    ChangeSet DetectChanges(
+        Dictionary<string, string> currentHashes,
+        Dictionary<string, string> storedHashes);
+}
+```
+
+#### `ChangeTracker` Class
+
+- **`DetectChanges(currentHashes, storedHashes) -> ChangeSet`**
+  - Iterates `currentHashes`:
+    - Key not in `storedHashes` --> **New**
+    - Key in `storedHashes` but value differs --> **Modified**
+    - Key in `storedHashes` with same value --> **Unchanged**
+  - Iterates `storedHashes`:
+    - Key not in `currentHashes` --> **Deleted**
+  - Pure function — no side effects, no I/O, no async needed.
+  - Uses `StringComparer.OrdinalIgnoreCase` for path keys (cross-platform safety).
+
+### Test Code
+
+**File:** `tests/CodeCompress.Core.Tests/Indexing/ChangeTrackerTests.cs`
+
+| # | Test Case | Setup | Expected |
+|---|-----------|-------|----------|
+| 1 | First index — all new | current: 3 files, stored: empty | NewFiles=3, rest empty |
+| 2 | Mix of all categories | current has new+modified+unchanged, stored has deleted+modified+unchanged | Correct counts in each bucket |
+| 3 | No changes | current == stored (same keys & values) | UnchangedFiles = all, rest empty |
+| 4 | All deleted | current: empty, stored: 3 files | DeletedFiles=3, rest empty |
+| 5 | Empty project (current empty, stored empty) | Both dictionaries empty | All lists empty |
+| 6 | First run (stored empty) | current: 5 files, stored: empty | NewFiles=5 |
+| 7 | Single modified file | One path with different hash | ModifiedFiles=1, UnchangedFiles=rest |
+| 8 | HasChanges true when changes exist | Any non-empty change bucket | `HasChanges` returns `true` |
+| 9 | HasChanges false when no changes | All unchanged | `HasChanges` returns `false` |
+| 10 | Case-insensitive path matching | Same path different casing | Treated as same file (unchanged, not new+deleted) |
+
+All tests are synchronous (no async needed). TUnit assertion style throughout.
+
+## Acceptance Criteria
+
+- [ ] `ChangeSet` record defined with `NewFiles`, `ModifiedFiles`, `DeletedFiles`, `UnchangedFiles`
+- [ ] `ChangeSet.HasChanges` convenience property works correctly
+- [ ] `IChangeTracker` interface defined
+- [ ] `ChangeTracker` implements `IChangeTracker`
+- [ ] `DetectChanges` correctly classifies all four categories
+- [ ] Path comparison is case-insensitive (`StringComparer.OrdinalIgnoreCase`)
+- [ ] Pure function — no I/O, no side effects, no state mutation
+- [ ] All 10 test cases pass
+- [ ] Zero build warnings (SonarAnalyzer, nullable, code style)
+- [ ] No `dynamic` or `object` types in public API
+
+## Files to Create/Modify
+
+| Action | File |
+|--------|------|
+| Create | `src/CodeCompress.Core/Indexing/ChangeTracker.cs` |
+| Create | `src/CodeCompress.Core/Indexing/IChangeTracker.cs` |
+| Create | `src/CodeCompress.Core/Indexing/ChangeSet.cs` |
+| Create | `tests/CodeCompress.Core.Tests/Indexing/ChangeTrackerTests.cs` |
+
+## Out of Scope
+
+- Computing the hashes themselves (handled by `FileHasher` in 001)
+- Loading stored hashes from SQLite (handled by `SymbolStore` in Feature 03)
+- Acting on the `ChangeSet` (parsing, storing — handled by `IndexEngine` in 003)
+- File discovery or directory walking
+
+## Notes / Decisions
+
+- **Synchronous by design:** `DetectChanges` is a pure in-memory comparison of two dictionaries — no reason for async. The `IndexEngine` will call it after awaiting hash results.
+- **Case-insensitive paths:** Windows file systems are case-insensitive; macOS HFS+ is case-insensitive by default. Using `OrdinalIgnoreCase` avoids false positives (same file detected as both new and deleted due to casing).
+- **Immutable output:** `ChangeSet` uses `IReadOnlyList<string>` to prevent callers from mutating the result.
+- **No path normalization here:** Callers must pass already-normalized paths. Both `currentHashes` and `storedHashes` should use the same normalization scheme (enforced by `PathValidator` upstream).

--- a/docs/06-index-engine/003-index-engine.md
+++ b/docs/06-index-engine/003-index-engine.md
@@ -1,0 +1,176 @@
+# 003 — IndexEngine: Orchestrates Full and Incremental Indexing
+
+## Summary
+
+`IndexEngine` is the singleton orchestration service that ties together `FileHasher`, `ChangeTracker`, language parsers, and `SymbolStore` to perform full and incremental indexing of a codebase. It discovers source files, hashes them, detects changes, dispatches parsing to the correct `ILanguageParser` by file extension, and persists results to SQLite — all with parallel execution and cancellation support.
+
+## Dependencies
+
+| Dependency | What it provides |
+|------------|-----------------|
+| Feature 03 (SQLite Storage) | `SymbolStore` / `ISymbolStore` — persistent hash and symbol storage |
+| Feature 04 (Path Validation) | `PathValidator` — canonicalization and traversal prevention |
+| Feature 05 (Luau Parser) | `LuauParser : ILanguageParser` — first concrete parser for testing |
+| 06-001 (FileHasher) | `IFileHasher` — parallel SHA-256 hashing |
+| 06-002 (ChangeTracker) | `IChangeTracker` — diff logic producing `ChangeSet` |
+
+## Scope
+
+### Production Code
+
+**File:** `src/CodeCompress.Core/Indexing/IndexEngine.cs`
+
+#### `IndexResult` Record
+
+```csharp
+public sealed record IndexResult(
+    int FilesIndexed,
+    int FilesSkipped,
+    int FilesDeleted,
+    int SymbolsFound,
+    long DurationMs);
+```
+
+#### `IIndexEngine` Interface
+
+```csharp
+public interface IIndexEngine
+{
+    Task<IndexResult> IndexProjectAsync(
+        string projectRoot,
+        string? language = null,
+        string[]? includePatterns = null,
+        string[]? excludePatterns = null,
+        CancellationToken cancellationToken = default);
+}
+```
+
+#### `IndexEngine` Class
+
+**Constructor injection:**
+- `IFileHasher` — for hashing discovered files
+- `IChangeTracker` — for diffing current vs. stored hashes
+- `IEnumerable<ILanguageParser>` — all registered language parsers (resolved via DI)
+- `ISymbolStore` (or `SymbolStore`) — for reading stored hashes and writing parse results
+- `IPathValidator` — for path canonicalization and security checks
+- `ILogger<IndexEngine>` — structured logging
+
+**Initialization (constructor or lazy init):**
+- Builds a `Dictionary<string, ILanguageParser>` mapping file extensions (e.g., `.luau`, `.lua`, `.cs`) to their parser, sourced from each parser's `FileExtensions` property.
+
+**`IndexProjectAsync` — Step-by-Step Flow:**
+
+1. **Validate project root** via `IPathValidator`. Reject if path is invalid or does not exist.
+2. **Discover source files:**
+   - Recursively walk `projectRoot` using `Directory.EnumerateFiles` with `SearchOption.AllDirectories`.
+   - Apply default excludes: `.git/`, `node_modules/`, `bin/`, `obj/`, `Packages/`, `build/`, `*.rbxlx`, `*.rbxl`.
+   - Apply caller-supplied `excludePatterns` (glob-style, matched against relative paths).
+   - Apply caller-supplied `includePatterns` (if provided, only matching files are kept).
+   - If `language` parameter is set, filter to only file extensions registered by the matching parser's `LanguageId`.
+   - Skip files whose extensions have no registered parser.
+3. **Hash all discovered files** in parallel via `IFileHasher.HashFilesAsync`.
+4. **Load stored hashes** from `ISymbolStore` for this project root.
+5. **Detect changes** via `IChangeTracker.DetectChanges(currentHashes, storedHashes)`.
+6. **If no changes:** return early with `FilesIndexed=0, FilesSkipped=allFiles.Count`.
+7. **Parse new and modified files** via `Parallel.ForEachAsync`:
+   - Resolve the correct `ILanguageParser` from the extension map.
+   - Call `parser.ParseAsync(filePath, cancellationToken)`.
+   - Collect all `Symbol` results.
+8. **Update `ISymbolStore` in a single transaction:**
+   - Insert symbols for new files.
+   - Replace symbols for modified files (delete old, insert new).
+   - Delete symbols and file records for deleted files.
+   - Update stored file hashes.
+9. **Update repository metadata** (last indexed timestamp, file count, symbol count).
+10. **Return `IndexResult`** with aggregate stats and elapsed time.
+
+**Default exclude list (constant):**
+
+```csharp
+private static readonly string[] DefaultExcludes =
+[
+    ".git", "node_modules", "bin", "obj",
+    "Packages", "build", ".vs", ".idea"
+];
+
+private static readonly string[] DefaultExcludeExtensions =
+[
+    ".rbxlx", ".rbxl"
+];
+```
+
+**Pattern matching:**
+- Glob patterns (`*`, `**`, `?`) for include/exclude, matched against paths relative to `projectRoot`.
+- Use `Microsoft.Extensions.FileSystemGlobbing` (already in the .NET SDK) for glob evaluation.
+
+### Test Code
+
+**File:** `tests/CodeCompress.Core.Tests/Indexing/IndexEngineTests.cs`
+
+All dependencies are mocked via **NSubstitute**. No real file system or SQLite access.
+
+| # | Test Case | Mocked Setup | Expected |
+|---|-----------|-------------|----------|
+| 1 | Full index of new project | ChangeTracker returns all NewFiles, no stored hashes | All files parsed, symbols stored, `FilesIndexed` = file count |
+| 2 | Incremental — one modified file | ChangeTracker returns 1 Modified, rest Unchanged | Only 1 file re-parsed, `FilesIndexed=1`, `FilesSkipped=rest` |
+| 3 | Incremental — no changes | ChangeTracker returns all Unchanged | Zero files parsed, `FilesIndexed=0`, `FilesSkipped=all` |
+| 4 | Deleted file | ChangeTracker returns 1 Deleted | Symbols removed from store, `FilesDeleted=1` |
+| 5 | Language filter — Luau only | `language="luau"`, project has .luau and .cs files | Only .luau files discovered and indexed |
+| 6 | Exclude patterns respected | Exclude `**/tests/**` | Files under tests/ not discovered |
+| 7 | Include patterns respected | Include `src/**/*.luau` | Only matching files discovered |
+| 8 | Unknown file extensions skipped | Project has .txt files, no parser registered | .txt files excluded, no errors |
+| 9 | Mixed-language project | .luau and .cs files, both parsers registered | Each file dispatched to correct parser |
+| 10 | Default excludes applied | Project tree includes .git/, node_modules/, bin/ | Those directories not walked |
+| 11 | Invalid project root | Path fails validation | Throws appropriate exception |
+| 12 | Cancellation during hashing | Token cancelled mid-hash | `OperationCanceledException` thrown |
+| 13 | Parser failure for one file | Parser throws for one file | Error logged, other files still indexed (or configurable: fail-fast) |
+
+## Acceptance Criteria
+
+- [ ] `IIndexEngine` interface defined with `IndexProjectAsync`
+- [ ] `IndexEngine` implements `IIndexEngine` as a singleton service
+- [ ] `IndexResult` record defined with all five properties
+- [ ] Extension-to-parser lookup map built from injected `IEnumerable<ILanguageParser>`
+- [ ] File discovery walks directory recursively, applies default and custom excludes
+- [ ] Include patterns filter discovered files when provided
+- [ ] Language filter restricts indexing to matching parser's extensions
+- [ ] Files hashed in parallel via `IFileHasher`
+- [ ] Changes detected via `IChangeTracker`
+- [ ] Early return when `ChangeSet.HasChanges` is false
+- [ ] New/modified files parsed in parallel via `Parallel.ForEachAsync`
+- [ ] Correct parser selected per file extension
+- [ ] `ISymbolStore` updated in a single transaction (insert new, replace modified, delete removed)
+- [ ] Repository metadata updated after indexing
+- [ ] `CancellationToken` propagated to all async operations
+- [ ] All 13 test cases pass
+- [ ] 90%+ code coverage on `IndexEngine`
+- [ ] Zero build warnings (SonarAnalyzer, nullable, code style)
+- [ ] No `dynamic` or `object` types in public API
+
+## Files to Create/Modify
+
+| Action | File |
+|--------|------|
+| Create | `src/CodeCompress.Core/Indexing/IndexEngine.cs` |
+| Create | `src/CodeCompress.Core/Indexing/IIndexEngine.cs` |
+| Create | `src/CodeCompress.Core/Indexing/IndexResult.cs` |
+| Create | `tests/CodeCompress.Core.Tests/Indexing/IndexEngineTests.cs` |
+| Modify | `src/CodeCompress.Core/DependencyInjection.cs` (register `IndexEngine` as singleton) |
+
+## Out of Scope
+
+- MCP tool wiring (`index_project` tool) — handled in Feature 07
+- Snapshot creation / labeling — handled in Feature 07
+- Cache invalidation tool — handled in Feature 07
+- C# parser implementation — handled in Feature 12
+- Real integration tests with file system + SQLite — handled in Feature 11
+- Progress reporting / streaming updates to the MCP client
+
+## Notes / Decisions
+
+- **Singleton lifetime:** `IndexEngine` is registered as singleton because it holds the extension-to-parser map and is stateless otherwise. All mutable state lives in `SymbolStore` (scoped per database).
+- **Error handling strategy:** A single file failing to parse should NOT abort the entire index operation. Log the error, skip the file, and continue. The `IndexResult` could include an `Errors` count or list in a future iteration, but for now logging is sufficient.
+- **Glob matching:** `Microsoft.Extensions.FileSystemGlobbing.Matcher` is part of the .NET SDK and provides battle-tested glob support. No external dependency needed.
+- **Transaction scope:** All store mutations (inserts, updates, deletes) for a single `IndexProjectAsync` call are wrapped in one SQLite transaction for atomicity and performance.
+- **Parallelism:** `Parallel.ForEachAsync` is used for both hashing (in `FileHasher`) and parsing (in `IndexEngine`). The degree of parallelism defaults to `Environment.ProcessorCount` but could be made configurable via options in the future.
+- **Testability:** Because every dependency is behind an interface and injected, the `IndexEngine` tests are pure unit tests with no file system or database access. Integration tests (Feature 11) will exercise the real stack.

--- a/docs/07-mcp-server-and-indexing-tools/001-server-host-setup.md
+++ b/docs/07-mcp-server-and-indexing-tools/001-server-host-setup.md
@@ -1,0 +1,106 @@
+# 001 — MCP Server Host Setup
+
+## Summary
+
+Configure the MCP server executable using `GenericHost`, the `ModelContextProtocol` SDK, stdio transport, and full DI registration of all core services. `Program.cs` is the composition root that wires every component together — parsers, indexing engine, storage, validation — and starts listening for MCP protocol messages on stdin/stdout. The server auto-discovers tool classes decorated with `[McpServerToolType]`.
+
+## Dependencies
+
+- **Feature 01** — Project scaffold, solution file, `CodeCompress.Server.csproj`.
+- **Feature 02** — Core models and interfaces (`ILanguageParser`, `SymbolInfo`, `ParseResult`, etc.).
+- **Feature 03** — SQLite storage layer (`SqliteConnectionFactory`, `SymbolStore`).
+- **Feature 04** — `PathValidator` for input sanitization.
+- **Feature 05** — `LuauParser` (first `ILanguageParser` implementation).
+- **Feature 06** — `IndexEngine`, `FileHasher`, `ChangeTracker`.
+
+## Scope
+
+### 1. Program.cs (`src/CodeCompress.Server/Program.cs`)
+
+The composition root builds and runs the generic host:
+
+| Responsibility | Detail |
+|---|---|
+| Host builder | `Host.CreateDefaultBuilder(args)` with MCP server configuration |
+| MCP SDK integration | `.AddMcpServer()` on the service collection with stdio transport; auto-discovers `[McpServerToolType]` classes |
+| Structured logging | `ILogger` via `Microsoft.Extensions.Logging`; console logging for diagnostics (stderr only — stdout is the MCP transport) |
+| Graceful shutdown | `CancellationToken` propagation; clean SQLite connection disposal |
+
+### 2. DI Registration
+
+All core services registered in a single `IServiceCollection` extension method or directly in `Program.cs`:
+
+| Service | Lifetime | Notes |
+|---|---|---|
+| `ILanguageParser` implementations | Singleton (collection) | Registered via `AddSingleton<ILanguageParser, LuauParser>()`. Future parsers added the same way. Resolved as `IEnumerable<ILanguageParser>` by `IndexEngine`. |
+| `IndexEngine` | Singleton | Stateless orchestrator; holds no per-request state. Receives `IEnumerable<ILanguageParser>`, `SymbolStore`, `FileHasher`, `ChangeTracker`. |
+| `SymbolStore` | Singleton | Thread-safe via SQLite WAL mode. Single long-lived connection per database file. |
+| `SqliteConnectionFactory` | Singleton | Creates/opens connections to `~/.codecompress/{repo-hash}.db`. |
+| `FileHasher` | Singleton | Stateless SHA-256 hasher. |
+| `ChangeTracker` | Singleton | Compares file hashes for incremental indexing. |
+| `PathValidator` | Singleton | Stateless path canonicalization and traversal checks. |
+
+### 3. Stdio Transport
+
+- MCP protocol messages arrive on `stdin` and responses are written to `stdout`.
+- All diagnostic/log output must go to `stderr` to avoid corrupting the MCP message stream.
+- The `ModelContextProtocol` SDK handles framing, serialization, and tool dispatch.
+
+### 4. Tool Auto-Discovery
+
+- The SDK scans for classes annotated with `[McpServerToolType]` and methods annotated with `[McpServerTool]`.
+- No manual tool registration required — adding a new tool class is a single-file change.
+- Tool classes receive dependencies via constructor injection.
+
+### 5. Server Startup Test (`tests/CodeCompress.Server.Tests/ServerHostTests.cs`)
+
+Verify the DI container builds correctly and all critical services resolve without error:
+
+| Test | Description |
+|---|---|
+| Host_Builds_Without_Errors | Build the host, verify no exceptions during `BuildServiceProvider` |
+| AllCoreServices_Resolve | Resolve `IndexEngine`, `SymbolStore`, `PathValidator`, `IEnumerable<ILanguageParser>` — all non-null |
+| LanguageParsers_Resolve_AsCollection | `IEnumerable<ILanguageParser>` contains at least `LuauParser` |
+| StdioTransport_IsConfigured | Verify MCP server is configured for stdio (not HTTP/SSE) |
+
+## Acceptance Criteria
+
+- [ ] `Program.cs` builds a `GenericHost` with MCP server configuration and stdio transport.
+- [ ] All core services (`IndexEngine`, `SymbolStore`, `SqliteConnectionFactory`, `FileHasher`, `ChangeTracker`, `PathValidator`) are registered in DI.
+- [ ] `ILanguageParser` implementations are registered as a collection and resolvable as `IEnumerable<ILanguageParser>`.
+- [ ] Logging output goes to `stderr` only — `stdout` is reserved for MCP protocol messages.
+- [ ] `[McpServerToolType]` classes are auto-discovered by the SDK.
+- [ ] Server starts without errors when executed via `dotnet run --project src/CodeCompress.Server`.
+- [ ] DI container resolves all services without exceptions (verified by test).
+- [ ] `dotnet build CodeCompress.slnx` succeeds with zero warnings.
+- [ ] All tests pass via `dotnet test tests/CodeCompress.Server.Tests`.
+
+## Files to Create/Modify
+
+### Create
+
+| File | Description |
+|---|---|
+| `src/CodeCompress.Server/Program.cs` | Composition root — host builder, DI, MCP server config |
+| `tests/CodeCompress.Server.Tests/ServerHostTests.cs` | DI resolution and startup tests |
+
+### Modify
+
+| File | Description |
+|---|---|
+| `src/CodeCompress.Server/CodeCompress.Server.csproj` | Add package references (`ModelContextProtocol`, `Microsoft.Extensions.Hosting`) if not already present |
+
+## Out of Scope
+
+- MCP tool implementations — covered in 07-002 and Feature 08.
+- HTTP/SSE transport — stdio only for MVP.
+- Authentication or authorization — not required for local stdio transport.
+- CLI tool (`CodeCompress.Cli`) wiring — separate project with its own composition root.
+- Health checks or readiness probes — not applicable for stdio-based server.
+
+## Notes / Decisions
+
+1. **Singleton lifetimes.** All core services are stateless or thread-safe, so singleton lifetime avoids unnecessary allocations. `SymbolStore` relies on SQLite WAL mode for concurrent read safety. Write operations are serialized internally.
+2. **Logging to stderr.** This is critical — any `Console.WriteLine` or logger output to stdout will corrupt the MCP JSON-RPC message stream. The host must be configured with a stderr-only logging provider.
+3. **Parser registration pattern.** Each `ILanguageParser` is registered individually (`AddSingleton<ILanguageParser, LuauParser>()`). When Phase 2 adds `CSharpParser`, it is a single additional registration line. `IndexEngine` receives all parsers via `IEnumerable<ILanguageParser>` and builds an internal dictionary keyed by file extension.
+4. **No lazy initialization.** All services are eagerly validated at startup via the DI container. Fail-fast on misconfiguration.

--- a/docs/07-mcp-server-and-indexing-tools/002-indexing-tools.md
+++ b/docs/07-mcp-server-and-indexing-tools/002-indexing-tools.md
@@ -1,0 +1,170 @@
+# 002 — IndexingTools: index_project, snapshot_create, invalidate_cache
+
+## Summary
+
+Implement the first MCP tool class — `IndexingTools` — containing three tools that build and manage the code index. These tools are the entry point for AI agents to trigger indexing of a codebase, create named snapshots for delta queries, and force re-indexing when needed. All tools enforce path validation and return structured data only, never echoing raw user input.
+
+## Dependencies
+
+- **Feature 07-001** — MCP server host setup, DI registration, stdio transport.
+- **Feature 03** — `SymbolStore` for snapshot creation and cache invalidation.
+- **Feature 04** — `PathValidator` for input sanitization.
+- **Feature 06** — `IndexEngine` for project indexing orchestration.
+
+## Scope
+
+### 1. IndexingTools Class (`src/CodeCompress.Server/Tools/IndexingTools.cs`)
+
+Decorated with `[McpServerToolType]`. Receives `IndexEngine`, `SymbolStore`, and `PathValidator` via constructor injection.
+
+### 2. index_project Tool
+
+```csharp
+[McpServerTool(Name = "index_project")]
+```
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `path` | `string` | Yes | — | Absolute path to project root |
+| `language` | `string?` | No | `null` | Filter to a specific language (e.g., `"luau"`) |
+| `include_patterns` | `string[]?` | No | `null` | Glob patterns for files to include |
+| `exclude_patterns` | `string[]?` | No | `null` | Glob patterns for files to exclude |
+
+**Behavior:**
+1. Validate `path` via `PathValidator` — reject traversal attempts, non-existent directories.
+2. Call `IndexEngine.IndexProjectAsync(path, language, includePatterns, excludePatterns, cancellationToken)`.
+3. Return structured result:
+
+```json
+{
+  "repo_id": "abc123",
+  "files_indexed": 42,
+  "files_skipped": 3,
+  "symbols_found": 187,
+  "duration_ms": 1250
+}
+```
+
+4. On validation failure, return structured error: `{ "error": "Path validation failed", "code": "INVALID_PATH" }`.
+5. Never echo the raw `path` value back in any response field.
+
+### 3. snapshot_create Tool
+
+```csharp
+[McpServerTool(Name = "snapshot_create")]
+```
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `path` | `string` | Yes | — | Absolute path to project root |
+| `label` | `string` | Yes | — | Human-readable snapshot label |
+
+**Behavior:**
+1. Validate `path` via `PathValidator`.
+2. Sanitize `label`:
+   - Strip characters that could be interpreted as agent instructions (markdown directives, system prompt fragments, tool-call-like syntax).
+   - Truncate to 128 characters maximum.
+   - Allow only alphanumeric characters, spaces, hyphens, underscores, and periods.
+3. Call `SymbolStore.CreateSnapshotAsync(repoId, sanitizedLabel, cancellationToken)`.
+4. Return structured result:
+
+```json
+{
+  "snapshot_id": "snap-001",
+  "label": "pre-refactor",
+  "file_count": 42,
+  "symbol_count": 187
+}
+```
+
+### 4. invalidate_cache Tool
+
+```csharp
+[McpServerTool(Name = "invalidate_cache")]
+```
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `path` | `string` | Yes | — | Absolute path to project root |
+
+**Behavior:**
+1. Validate `path` via `PathValidator`.
+2. Call `SymbolStore.InvalidateCacheAsync(repoId, cancellationToken)` — deletes stored file hashes for the repository, forcing a full re-index on the next `index_project` call.
+3. Return structured result:
+
+```json
+{
+  "success": true,
+  "message": "Cache invalidated. Next index operation will perform a full reparse."
+}
+```
+
+### 5. Security Considerations
+
+- All three tools validate `path` as the first operation — reject before any other processing.
+- Structured JSON responses only. No freeform text fields containing user-supplied values.
+- `label` sanitization prevents prompt injection via snapshot labels (a malicious agent could pass crafted labels designed to influence future tool output consumption).
+- Error messages use fixed strings, not interpolated user input.
+
+## Acceptance Criteria
+
+- [ ] `IndexingTools` is decorated with `[McpServerToolType]` and auto-discovered by the MCP SDK.
+- [ ] `index_project` validates `path`, calls `IndexEngine`, and returns structured indexing results.
+- [ ] `index_project` rejects paths with traversal attempts (`..`) and paths outside the project root.
+- [ ] `index_project` supports optional `language`, `include_patterns`, and `exclude_patterns` parameters.
+- [ ] `snapshot_create` validates `path`, sanitizes `label`, creates a snapshot, and returns structured results.
+- [ ] `snapshot_create` strips malicious content from `label` (markdown directives, prompt fragments).
+- [ ] `snapshot_create` truncates `label` to 128 characters.
+- [ ] `invalidate_cache` validates `path`, deletes stored hashes, and returns success confirmation.
+- [ ] All tools return structured error responses on validation failure — no exceptions leak to the MCP transport.
+- [ ] No tool echoes raw user-supplied input (paths, labels) in response fields.
+- [ ] `dotnet build CodeCompress.slnx` succeeds with zero warnings.
+- [ ] All tests pass via `dotnet test tests/CodeCompress.Server.Tests`.
+- [ ] Tool test coverage is 85%+.
+
+## Files to Create/Modify
+
+### Create
+
+| File | Description |
+|---|---|
+| `src/CodeCompress.Server/Tools/IndexingTools.cs` | MCP tool class with `index_project`, `snapshot_create`, `invalidate_cache` |
+| `tests/CodeCompress.Server.Tests/Tools/IndexingToolsTests.cs` | Unit tests for all three tools |
+
+### Modify
+
+None — `[McpServerToolType]` auto-discovery handles registration.
+
+## Test Cases (`tests/CodeCompress.Server.Tests/Tools/IndexingToolsTests.cs`)
+
+| Test | Description |
+|---|---|
+| IndexProject_ValidPath_ReturnsIndexingResults | Valid directory path triggers indexing, returns file/symbol counts |
+| IndexProject_TraversalPath_ReturnsError | Path containing `..` is rejected with structured error |
+| IndexProject_NonExistentPath_ReturnsError | Path to non-existent directory returns error |
+| IndexProject_WithLanguageFilter_PassesToEngine | `language` parameter forwarded to `IndexEngine` |
+| IndexProject_WithGlobPatterns_PassesToEngine | Include/exclude patterns forwarded to `IndexEngine` |
+| SnapshotCreate_ValidInputs_ReturnsSnapshotInfo | Valid path and label create snapshot, return structured result |
+| SnapshotCreate_MaliciousLabel_IsSanitized | Label containing markdown/prompt injection is stripped to safe characters |
+| SnapshotCreate_LongLabel_IsTruncated | Label exceeding 128 characters is truncated |
+| SnapshotCreate_InvalidPath_ReturnsError | Invalid path rejected before snapshot creation |
+| InvalidateCache_ValidPath_ReturnsSuccess | Cache invalidated, success response returned |
+| InvalidateCache_InvalidPath_ReturnsError | Invalid path rejected |
+| InvalidateCache_ForcesFullReindex | After invalidation, next `index_project` re-parses all files (integration-style with mocks) |
+
+All tests use **NSubstitute** to mock `IndexEngine`, `SymbolStore`, and `PathValidator`.
+
+## Out of Scope
+
+- Query tools (`project_outline`, `get_symbol`, etc.) — covered in Feature 08.
+- Delta tools (`changes_since`, `file_tree`) — separate feature.
+- Dependency tools (`dependency_graph`) — separate feature.
+- HTTP/SSE transport — stdio only.
+- Actual file system interaction in tests — all mocked.
+
+## Notes / Decisions
+
+1. **Structured responses over freeform text.** MCP tool outputs are consumed by AI agents. Returning structured JSON prevents misinterpretation and reduces prompt injection surface. The `ModelContextProtocol` SDK serializes return objects to JSON automatically.
+2. **Label sanitization regex.** The allow-list approach (`[a-zA-Z0-9 _.\-]`) is safer than a deny-list. Any character outside this set is stripped. This is intentionally restrictive — snapshot labels are identifiers, not prose.
+3. **Error response pattern.** All tools catch `PathValidationException` (or equivalent) and return a structured error object rather than throwing. The MCP SDK should not see unhandled exceptions from tool methods.
+4. **NSubstitute for isolation.** Tool tests mock all dependencies to test only the tool logic (validation, parameter forwarding, response shaping). Integration tests that exercise the full stack are in `CodeCompress.Integration.Tests`.

--- a/docs/08-query-tools/001-outline-and-module-api.md
+++ b/docs/08-query-tools/001-outline-and-module-api.md
@@ -1,0 +1,205 @@
+# 001 — QueryTools: project_outline and get_module_api
+
+## Summary
+
+Implement the two highest-value query tools — `project_outline` delivers a compressed, token-efficient overview of an entire codebase (signatures only, no bodies), and `get_module_api` returns the full public API surface of a single module. Together these tools enable an AI agent to understand codebase structure at a fraction of the token cost of loading raw source files. Both tools return structured data with all output fields sanitized against prompt injection.
+
+## Dependencies
+
+- **Feature 07** — MCP server host setup and DI registration.
+- **Feature 03** — `SymbolStore` queries (`GetProjectOutline`, `GetModuleApi`).
+- **Feature 04** — `PathValidator` for input sanitization.
+
+## Scope
+
+### 1. QueryTools Class (`src/CodeCompress.Server/Tools/QueryTools.cs`)
+
+Decorated with `[McpServerToolType]`. Receives `SymbolStore` and `PathValidator` via constructor injection. This class will hold all query tools across plans 08-001, 08-002, and 08-003.
+
+### 2. project_outline Tool
+
+```csharp
+[McpServerTool(Name = "project_outline")]
+```
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `path` | `string` | Yes | — | Absolute path to project root |
+| `include_private` | `bool` | No | `false` | Include private/local symbols |
+| `group_by` | `string` | No | `"file"` | Grouping: `"file"`, `"kind"`, or `"directory"` |
+| `max_depth` | `int?` | No | `null` (unlimited) | Limit directory traversal depth |
+
+**Behavior:**
+1. Validate `path` via `PathValidator`.
+2. Validate `group_by` is one of `"file"`, `"kind"`, `"directory"` — reject invalid values.
+3. Call `SymbolStore.GetProjectOutlineAsync(repoId, includePrivate, cancellationToken)`.
+4. Format the result into structured markdown grouped by the selected strategy:
+
+**group_by = "file" (default):**
+```
+# Project Outline: {name} ({file_count} files, {symbol_count} symbols)
+## src/services/
+### CombatService.luau (12 symbols)
+  public class CombatService
+  public method CombatService:ProcessAttack(attacker, target): DamageResult
+  public method CombatService:CalculateDamage(stats): number
+  private function validateTarget(target): boolean
+## src/utils/
+### MathUtils.luau (4 symbols)
+  public function lerp(a: number, b: number, t: number): number
+```
+
+**group_by = "kind":**
+```
+# Project Outline: {name} ({file_count} files, {symbol_count} symbols)
+## Classes (5)
+  CombatService — src/services/CombatService.luau:3
+  InventoryManager — src/services/InventoryManager.luau:1
+## Functions (23)
+  lerp — src/utils/MathUtils.luau:5
+  clamp — src/utils/MathUtils.luau:12
+## Methods (41)
+  CombatService:ProcessAttack — src/services/CombatService.luau:8
+```
+
+**group_by = "directory":**
+```
+# Project Outline: {name}
+## src/ (3 subdirectories)
+### src/services/ (2 files, 24 symbols)
+    CombatService.luau: class CombatService, 6 methods
+    InventoryManager.luau: class InventoryManager, 4 methods
+### src/utils/ (1 file, 4 symbols)
+    MathUtils.luau: 4 functions
+```
+
+5. Apply `max_depth` filtering — if set, truncate the directory tree at the specified depth (1 = top-level only).
+6. Apply `include_private` — if `false`, omit symbols with `Visibility.Private`.
+7. **Token budget target:** ~3-8k tokens regardless of codebase size. Signatures only, no function bodies.
+
+### 3. get_module_api Tool
+
+```csharp
+[McpServerTool(Name = "get_module_api")]
+```
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `path` | `string` | Yes | — | Absolute path to project root |
+| `module_path` | `string` | Yes | — | Relative path to the module file (e.g., `"src/services/CombatService.luau"`) |
+
+**Behavior:**
+1. Validate `path` via `PathValidator`.
+2. Validate `module_path` — must be a relative path, must not contain `..`, and when combined with `path` must resolve to a file within the project root.
+3. Call `SymbolStore.GetModuleApiAsync(repoId, modulePath, cancellationToken)`.
+4. Return structured result containing:
+
+```json
+{
+  "module": "src/services/CombatService.luau",
+  "exports": ["CombatService"],
+  "symbols": [
+    {
+      "name": "CombatService",
+      "kind": "class",
+      "signature": "local CombatService = {} :: CombatService",
+      "line": 3,
+      "doc_comment": null
+    },
+    {
+      "name": "ProcessAttack",
+      "kind": "method",
+      "parent": "CombatService",
+      "signature": "function CombatService:ProcessAttack(attacker: Player, target: Player): DamageResult",
+      "parameters": ["attacker: Player", "target: Player"],
+      "return_type": "DamageResult",
+      "line": 8,
+      "doc_comment": "-- Processes an attack between two players"
+    }
+  ],
+  "dependencies": [
+    { "module": "src/utils/MathUtils", "symbols": ["clamp", "lerp"] }
+  ]
+}
+```
+
+5. Non-existent module returns structured error: `{ "error": "Module not found", "code": "MODULE_NOT_FOUND" }`.
+
+### 4. Security Considerations
+
+- All output fields are structured data — no freeform text echoing user input.
+- Symbol names, signatures, and doc comments originate from source files (untrusted). These are returned as structured JSON fields, not embedded in prose or instructions.
+- `module_path` is validated as a relative path and canonicalized against the project root to prevent traversal.
+- `group_by` is validated against an allow-list of values.
+
+## Acceptance Criteria
+
+- [ ] `QueryTools` is decorated with `[McpServerToolType]` and auto-discovered by the MCP SDK.
+- [ ] `project_outline` validates `path` and returns a structured markdown outline.
+- [ ] `project_outline` with `group_by = "file"` groups symbols by file within directories.
+- [ ] `project_outline` with `group_by = "kind"` groups symbols by `SymbolKind`.
+- [ ] `project_outline` with `group_by = "directory"` produces a directory-focused summary.
+- [ ] `project_outline` with `include_private = false` omits `Visibility.Private` symbols.
+- [ ] `project_outline` with `include_private = true` includes all symbols.
+- [ ] `project_outline` with `max_depth` limits directory traversal depth.
+- [ ] `project_outline` produces ~3-8k tokens for a typical codebase (signatures only).
+- [ ] `get_module_api` validates both `path` and `module_path`.
+- [ ] `get_module_api` returns full API surface: symbols, signatures, parameters, return types, doc comments, dependencies.
+- [ ] `get_module_api` with non-existent module returns structured error.
+- [ ] `get_module_api` rejects `module_path` with traversal attempts.
+- [ ] Invalid `group_by` value returns structured error.
+- [ ] No tool echoes raw user-supplied input in response fields.
+- [ ] `dotnet build CodeCompress.slnx` succeeds with zero warnings.
+- [ ] All tests pass via `dotnet test tests/CodeCompress.Server.Tests`.
+- [ ] Tool test coverage is 85%+.
+
+## Files to Create/Modify
+
+### Create
+
+| File | Description |
+|---|---|
+| `src/CodeCompress.Server/Tools/QueryTools.cs` | MCP tool class with `project_outline` and `get_module_api` |
+| `tests/CodeCompress.Server.Tests/Tools/QueryToolsTests.cs` | Unit tests for both tools |
+
+### Modify
+
+None — `[McpServerToolType]` auto-discovery handles registration.
+
+## Test Cases (`tests/CodeCompress.Server.Tests/Tools/QueryToolsTests.cs`)
+
+| Test | Description |
+|---|---|
+| ProjectOutline_ValidPath_ReturnsStructuredOutline | Valid project returns outline with file/symbol counts |
+| ProjectOutline_GroupByFile_GroupsCorrectly | Symbols grouped under file headings within directories |
+| ProjectOutline_GroupByKind_GroupsCorrectly | Symbols grouped by `SymbolKind` (Classes, Functions, Methods) |
+| ProjectOutline_GroupByDirectory_SummarizesDirectories | Directory-level summary with file and symbol counts |
+| ProjectOutline_InvalidGroupBy_ReturnsError | Unrecognized `group_by` value returns structured error |
+| ProjectOutline_IncludePrivateFalse_OmitsPrivateSymbols | Private symbols excluded from output |
+| ProjectOutline_IncludePrivateTrue_IncludesAllSymbols | Private symbols included in output |
+| ProjectOutline_MaxDepth_LimitsTraversal | `max_depth = 1` shows only top-level directory contents |
+| ProjectOutline_InvalidPath_ReturnsError | Path validation failure returns structured error |
+| GetModuleApi_ValidModule_ReturnsFullApi | Returns symbols, signatures, parameters, return types, dependencies |
+| GetModuleApi_NonExistentModule_ReturnsError | Non-existent module path returns `MODULE_NOT_FOUND` error |
+| GetModuleApi_TraversalModulePath_ReturnsError | `module_path` with `..` is rejected |
+| GetModuleApi_InvalidProjectPath_ReturnsError | Invalid `path` returns error |
+| GetModuleApi_IncludesDependencies | Module's `require()` dependencies included in response |
+
+All tests use **NSubstitute** to mock `SymbolStore` and `PathValidator`.
+
+## Out of Scope
+
+- `get_symbol`, `get_symbols` — covered in 08-002.
+- `search_symbols`, `search_text` — covered in 08-003.
+- Delta tools (`changes_since`, `file_tree`) — separate feature.
+- Dependency tools (`dependency_graph`) — separate feature.
+- Outline formatting customization beyond `group_by` and `max_depth`.
+- Pagination of outline results.
+
+## Notes / Decisions
+
+1. **Token budget.** The outline format is deliberately compressed — signatures only, no function bodies, no inline documentation beyond what fits in a signature line. For a 100-file project with ~500 symbols, the outline should be ~4-6k tokens. This is the primary value proposition of CodeCompress.
+2. **Markdown vs. JSON for outline.** The outline is returned as structured markdown (not raw JSON) because AI agents consume it as context, and markdown provides better information density per token than nested JSON. The `get_module_api` response uses JSON because it is structured data that agents may need to process programmatically.
+3. **group_by validation.** Using an allow-list (`"file"`, `"kind"`, `"directory"`) rather than an enum parameter because MCP tool parameters are untyped strings from the agent. Invalid values return a structured error rather than silently defaulting.
+4. **module_path as relative path.** Requiring a relative path (not absolute) prevents the agent from accessing files outside the project root. The tool combines `path + module_path` and validates the result via `PathValidator`.
+5. **Snapshot testing.** Outline formatting is a good candidate for **Verify** snapshot tests in addition to assertion-based tests. Snapshot tests capture the exact output format and detect unintended formatting changes.

--- a/docs/08-query-tools/002-get-symbol-tools.md
+++ b/docs/08-query-tools/002-get-symbol-tools.md
@@ -1,0 +1,184 @@
+# 002 — QueryTools: get_symbol and get_symbols (Byte-Offset Retrieval)
+
+## Summary
+
+Implement the symbol retrieval tools that use byte-offset seeking to extract the exact source code of specific symbols from source files. These tools are the surgical alternative to loading entire files — the AI agent requests symbols by qualified name, and the tool reads only the precise bytes needed from disk. `get_symbols` provides batch retrieval for efficiency, and both tools handle partial failures gracefully.
+
+## Dependencies
+
+- **Feature 08-001** — `QueryTools` class and `project_outline`/`get_module_api` tools (same class file).
+- **Feature 03** — `SymbolStore` for looking up symbol metadata (byte offsets, file paths).
+- **Feature 04** — `PathValidator` for input sanitization.
+
+## Scope
+
+### 1. get_symbol Tool (added to `src/CodeCompress.Server/Tools/QueryTools.cs`)
+
+```csharp
+[McpServerTool(Name = "get_symbol")]
+```
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `path` | `string` | Yes | — | Absolute path to project root |
+| `symbol_name` | `string` | Yes | — | Fully qualified symbol name (e.g., `"CombatService:ProcessAttack"`) |
+| `include_context` | `bool` | No | `false` | Include 5 lines before/after the symbol |
+
+**Behavior:**
+1. Validate `path` via `PathValidator`.
+2. Look up the symbol in `SymbolStore` by qualified name: `SymbolStore.GetSymbolAsync(repoId, symbolName, cancellationToken)`.
+3. If symbol not found, return structured error: `{ "error": "Symbol not found", "code": "SYMBOL_NOT_FOUND", "symbol": "<sanitized_name>" }`.
+4. Construct the full file path from the project root and the symbol's stored relative file path. Validate the resolved path via `PathValidator`.
+5. Open the source file with `FileStream` using async I/O:
+   - Seek to `ByteOffset`.
+   - Read exactly `ByteLength` bytes.
+   - Decode as UTF-8.
+6. If `include_context = true`:
+   - Read additional lines: 5 lines before `LineStart` and 5 lines after `LineEnd`.
+   - Use line-based reading for context (seek to approximate position, then scan for line boundaries).
+7. Return structured result:
+
+```json
+{
+  "name": "ProcessAttack",
+  "kind": "method",
+  "parent": "CombatService",
+  "file": "src/services/CombatService.luau",
+  "line_start": 8,
+  "line_end": 32,
+  "signature": "function CombatService:ProcessAttack(attacker: Player, target: Player): DamageResult",
+  "source_code": "function CombatService:ProcessAttack(attacker, target)\n  -- full body here\nend"
+}
+```
+
+8. Source code content comes from source files and is **untrusted**. It is returned as a structured JSON field (`source_code`), never embedded in freeform prose.
+
+### 2. get_symbols Tool (added to `src/CodeCompress.Server/Tools/QueryTools.cs`)
+
+```csharp
+[McpServerTool(Name = "get_symbols")]
+```
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `path` | `string` | Yes | — | Absolute path to project root |
+| `symbol_names` | `string[]` | Yes | — | Array of fully qualified symbol names |
+
+**Behavior:**
+1. Validate `path` via `PathValidator`.
+2. Validate `symbol_names` is not empty and does not exceed a reasonable limit (e.g., 50 symbols per call).
+3. Look up all symbols in `SymbolStore` in a single batch query: `SymbolStore.GetSymbolsAsync(repoId, symbolNames, cancellationToken)`.
+4. For each found symbol, read source code from file using byte-offset seeking (same logic as `get_symbol`).
+5. Group file reads — if multiple symbols are in the same file, open the file once and seek to each offset.
+6. Handle partial failures:
+   - Symbols found: return full result objects.
+   - Symbols not found: return error entries in a separate `errors` array.
+
+```json
+{
+  "results": [
+    {
+      "name": "ProcessAttack",
+      "kind": "method",
+      "parent": "CombatService",
+      "file": "src/services/CombatService.luau",
+      "line_start": 8,
+      "line_end": 32,
+      "signature": "...",
+      "source_code": "..."
+    }
+  ],
+  "errors": [
+    {
+      "symbol": "NonExistentSymbol",
+      "error": "Symbol not found",
+      "code": "SYMBOL_NOT_FOUND"
+    }
+  ]
+}
+```
+
+### 3. File Reading Strategy
+
+| Concern | Approach |
+|---|---|
+| File access | `FileStream` with `FileOptions.Asynchronous` and `FileOptions.SequentialScan` |
+| Seeking | `stream.Seek(byteOffset, SeekOrigin.Begin)` |
+| Reading | Read exactly `byteLength` bytes into a buffer |
+| Decoding | `Encoding.UTF8.GetString(buffer)` |
+| Context lines | For `include_context`, read a larger region and trim to line boundaries |
+| Batch optimization | For `get_symbols`, group symbols by file to minimize file opens |
+| Read-only | Files are opened read-only with `FileAccess.Read` and `FileShare.Read` |
+
+### 4. Security Considerations
+
+- `symbol_name` is untrusted input — used only as a lookup key in parameterized SQL queries, never interpolated into SQL or file paths.
+- Source file contents are untrusted (could contain prompt injection). Returned as a structured `source_code` field.
+- File paths resolved from `SymbolStore` are re-validated via `PathValidator` before file access to prevent stored-path injection.
+- `symbol_names` array size is limited to prevent resource exhaustion.
+
+## Acceptance Criteria
+
+- [ ] `get_symbol` validates `path` and looks up the symbol by qualified name.
+- [ ] `get_symbol` reads source code from file using byte-offset seeking (not loading the entire file).
+- [ ] `get_symbol` returns correct `name`, `kind`, `file`, `line_start`, `line_end`, `signature`, and `source_code`.
+- [ ] `get_symbol` with `include_context = true` includes 5 lines before and after the symbol.
+- [ ] `get_symbol` with non-existent symbol returns `SYMBOL_NOT_FOUND` error.
+- [ ] `get_symbols` performs batch retrieval of multiple symbols.
+- [ ] `get_symbols` returns partial results when some symbols are found and others are not.
+- [ ] `get_symbols` groups file reads for symbols in the same file.
+- [ ] `get_symbols` rejects requests exceeding the symbol limit (50).
+- [ ] Byte offsets correctly map to the expected source code content.
+- [ ] Path validation applies to both the project root and resolved file paths.
+- [ ] Source code is returned as a structured field, not embedded in freeform text.
+- [ ] `dotnet build CodeCompress.slnx` succeeds with zero warnings.
+- [ ] All tests pass via `dotnet test tests/CodeCompress.Server.Tests`.
+
+## Files to Create/Modify
+
+### Create
+
+None — tests are added to the existing test file.
+
+### Modify
+
+| File | Description |
+|---|---|
+| `src/CodeCompress.Server/Tools/QueryTools.cs` | Add `get_symbol` and `get_symbols` tool methods |
+| `tests/CodeCompress.Server.Tests/Tools/QueryToolsTests.cs` | Add unit tests for both tools |
+
+## Test Cases (added to `tests/CodeCompress.Server.Tests/Tools/QueryToolsTests.cs`)
+
+| Test | Description |
+|---|---|
+| GetSymbol_ExistingSymbol_ReturnsSourceCode | Qualified name lookup returns correct source code and metadata |
+| GetSymbol_WithContext_IncludesSurroundingLines | `include_context = true` adds 5 lines before and after |
+| GetSymbol_WithContext_AtFileStart_HandlesGracefully | Symbol at line 1 — context does not go to negative line numbers |
+| GetSymbol_WithContext_AtFileEnd_HandlesGracefully | Symbol at end of file — context does not exceed file bounds |
+| GetSymbol_NonExistent_ReturnsError | Unknown symbol name returns `SYMBOL_NOT_FOUND` |
+| GetSymbol_InvalidPath_ReturnsError | Path validation failure returns structured error |
+| GetSymbol_ByteOffset_MatchesFileContent | Retrieved bytes match the expected source code at the stored offset |
+| GetSymbols_AllFound_ReturnsAllResults | Batch of 3 symbols all found — 3 results, 0 errors |
+| GetSymbols_SomeMissing_ReturnsPartialResults | 2 found, 1 missing — 2 results, 1 error |
+| GetSymbols_NoneFound_ReturnsAllErrors | All symbols missing — 0 results, N errors |
+| GetSymbols_SameFile_GroupsReads | Multiple symbols from same file — file opened once (verify via mock) |
+| GetSymbols_ExceedsLimit_ReturnsError | More than 50 symbols requested — rejected |
+| GetSymbols_EmptyArray_ReturnsError | Empty `symbol_names` array — rejected |
+| GetSymbols_InvalidPath_ReturnsError | Path validation failure returns structured error |
+
+Tests use **NSubstitute** to mock `SymbolStore` and `PathValidator`. File reading tests use a temporary file with known content to verify byte-offset accuracy.
+
+## Out of Scope
+
+- `search_symbols`, `search_text` — covered in 08-003.
+- Caching of file contents in memory — files are read on demand.
+- Streaming large symbol bodies — symbols are returned as complete strings.
+- Decompilation or source generation — only reads existing source files.
+
+## Notes / Decisions
+
+1. **Byte-offset seeking vs. line-based reading.** Byte-offset seeking is the primary strategy because it reads exactly the bytes needed without scanning the entire file. The parser already computes `ByteOffset` and `ByteLength` during indexing, so this data is available in `SymbolStore`. This is critical for large files where a single function might be 50 lines in a 5000-line file.
+2. **Context line implementation.** For `include_context`, the tool cannot simply seek to `ByteOffset - N` because it does not know where line boundaries are. The strategy is: seek backward from `ByteOffset` to find 5 line-break characters, and read forward from `ByteOffset + ByteLength` until 5 line-break characters are found. This is a bounded scan, not a full-file read.
+3. **Batch optimization.** `get_symbols` groups requested symbols by file path before reading. This avoids opening the same file multiple times when an agent requests several symbols from the same module, which is the common case.
+4. **Symbol name qualification.** Symbol names use the format `ClassName:MethodName` for methods and plain `FunctionName` for top-level functions. This matches the Luau naming convention and is unambiguous within a project.
+5. **File change detection.** If the file has changed since indexing (byte offsets may be stale), the tool returns the stored code region without validation. A future enhancement could verify the content hash and suggest re-indexing.

--- a/docs/08-query-tools/003-search-tools.md
+++ b/docs/08-query-tools/003-search-tools.md
@@ -1,0 +1,215 @@
+# 003 — QueryTools: search_symbols and search_text (FTS5)
+
+## Summary
+
+Implement full-text search tools powered by SQLite FTS5 virtual tables. `search_symbols` searches the symbol index (names, signatures, doc comments) and `search_text` searches raw file contents. Both tools sanitize FTS5 queries to prevent syntax injection, support advanced search operators (AND, OR, prefix matching), and return ranked results with contextual snippets. These tools enable AI agents to discover relevant code without knowing exact symbol names.
+
+## Dependencies
+
+- **Feature 08-002** — `QueryTools` class with existing tool methods.
+- **Feature 03** — `SymbolStore` FTS5 queries (`SearchSymbols`, `SearchText`, `symbols_fts`, `file_content_fts` virtual tables).
+- **Feature 04** — `PathValidator` for input sanitization.
+
+## Scope
+
+### 1. search_symbols Tool (added to `src/CodeCompress.Server/Tools/QueryTools.cs`)
+
+```csharp
+[McpServerTool(Name = "search_symbols")]
+```
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `path` | `string` | Yes | — | Absolute path to project root |
+| `query` | `string` | Yes | — | FTS5 search query |
+| `kind` | `string?` | No | `null` | Filter by `SymbolKind` (e.g., `"function"`, `"class"`, `"method"`) |
+| `limit` | `int` | No | `20` | Maximum results to return |
+
+**Behavior:**
+1. Validate `path` via `PathValidator`.
+2. Validate `query` is not empty or whitespace.
+3. Sanitize `query` via FTS5 query sanitizer (see section 3 below).
+4. Validate `kind` against allowed `SymbolKind` values if provided — reject invalid values.
+5. Clamp `limit` to range `[1, 100]`.
+6. Call `SymbolStore.SearchSymbolsAsync(repoId, sanitizedQuery, kind, limit, cancellationToken)`.
+7. Return ranked results:
+
+```json
+{
+  "query": "<sanitized_query>",
+  "total_matches": 7,
+  "results": [
+    {
+      "name": "ProcessAttack",
+      "kind": "method",
+      "parent": "CombatService",
+      "file": "src/services/CombatService.luau",
+      "line": 8,
+      "signature": "function CombatService:ProcessAttack(attacker: Player, target: Player): DamageResult",
+      "snippet": "...processes an attack between two players and returns damage result...",
+      "rank": 1
+    }
+  ]
+}
+```
+
+8. The `snippet` field contains the FTS5 `snippet()` function output — a context window around the matching terms. This content is from source files and is **untrusted**.
+
+### 2. search_text Tool (added to `src/CodeCompress.Server/Tools/QueryTools.cs`)
+
+```csharp
+[McpServerTool(Name = "search_text")]
+```
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `path` | `string` | Yes | — | Absolute path to project root |
+| `query` | `string` | Yes | — | FTS5 search query |
+| `glob` | `string?` | No | `null` | File pattern filter (e.g., `"*.luau"`, `"src/services/*.lua"`) |
+| `limit` | `int` | No | `20` | Maximum results to return |
+
+**Behavior:**
+1. Validate `path` via `PathValidator`.
+2. Validate `query` is not empty or whitespace.
+3. Sanitize `query` via FTS5 query sanitizer.
+4. Sanitize `glob` if provided — allow only safe glob characters (`*`, `?`, `/`, `.`, alphanumeric). Strip anything else.
+5. Clamp `limit` to range `[1, 100]`.
+6. Call `SymbolStore.SearchTextAsync(repoId, sanitizedQuery, glob, limit, cancellationToken)`.
+7. Return ranked results:
+
+```json
+{
+  "query": "<sanitized_query>",
+  "total_matches": 12,
+  "results": [
+    {
+      "file": "src/services/CombatService.luau",
+      "line": 15,
+      "snippet": "...local damage = baseDamage * multiplier...",
+      "rank": 1
+    }
+  ]
+}
+```
+
+### 3. FTS5 Query Sanitization
+
+A dedicated sanitization method that processes the raw query string before passing it to SQLite FTS5:
+
+| Input Pattern | Action |
+|---|---|
+| Simple words (`damage`, `health`) | Pass through as-is |
+| Boolean operators (`AND`, `OR`, `NOT`) | Allow — FTS5 supports these natively |
+| Quoted phrases (`"damage result"`) | Allow if balanced quotes; strip unbalanced quotes |
+| Prefix matching (`combat*`) | Allow — FTS5 supports prefix queries |
+| Column filters (`name:foo`) | **Strip** — prevent targeting specific FTS5 columns |
+| Parentheses for grouping | Allow if balanced; strip unbalanced |
+| Special FTS5 syntax (`NEAR`, `^`) | **Strip** — prevent advanced operators that could be abused |
+| Empty after sanitization | Fall back to plain text search (treat original query as a literal phrase) |
+
+**Fallback behavior:** If the sanitized query causes an FTS5 syntax error at execution time, catch the `SqliteException`, treat the original query as a plain text literal (wrap in double quotes), and retry once.
+
+### 4. Security Considerations
+
+- FTS5 query injection is the primary threat. A crafted query could exploit FTS5 syntax to extract unintended data or cause errors. The sanitizer uses an allow-list approach.
+- Column filter stripping prevents targeting internal FTS5 columns (e.g., `rowid:*`).
+- `glob` parameter sanitization prevents shell injection patterns — only glob metacharacters are allowed.
+- Snippet content originates from source files and is untrusted. Returned as structured JSON fields.
+- `limit` is clamped to prevent resource exhaustion from unbounded queries.
+
+## Acceptance Criteria
+
+- [ ] `search_symbols` validates `path`, sanitizes `query`, and returns ranked symbol matches.
+- [ ] `search_symbols` supports FTS5 operators: `AND`, `OR`, `NOT`, quoted phrases, prefix matching (`*`).
+- [ ] `search_symbols` with `kind` filter returns only symbols of the specified kind.
+- [ ] `search_symbols` respects `limit` parameter (clamped to `[1, 100]`).
+- [ ] `search_symbols` with malicious FTS5 query sanitizes input without crashing.
+- [ ] `search_text` validates `path`, sanitizes `query`, and returns ranked file content matches.
+- [ ] `search_text` with `glob` filter returns only matches in files matching the pattern.
+- [ ] `search_text` `glob` parameter is sanitized against injection.
+- [ ] FTS5 query sanitizer strips column filters, `NEAR`, `^`, and unbalanced quotes/parentheses.
+- [ ] Malformed FTS5 queries fall back to plain text search (wrapped in quotes) without error.
+- [ ] Empty or whitespace-only `query` returns structured error.
+- [ ] Invalid `kind` value returns structured error.
+- [ ] All responses return structured data only — no raw user input echoed in freeform fields.
+- [ ] `dotnet build CodeCompress.slnx` succeeds with zero warnings.
+- [ ] All tests pass via `dotnet test tests/CodeCompress.Server.Tests`.
+- [ ] Tool test coverage is 85%+.
+
+## Files to Create/Modify
+
+### Create
+
+| File | Description |
+|---|---|
+| `src/CodeCompress.Server/Sanitization/Fts5QuerySanitizer.cs` | FTS5 query sanitization logic |
+| `tests/CodeCompress.Server.Tests/Sanitization/Fts5QuerySanitizerTests.cs` | Sanitizer unit tests |
+
+### Modify
+
+| File | Description |
+|---|---|
+| `src/CodeCompress.Server/Tools/QueryTools.cs` | Add `search_symbols` and `search_text` tool methods |
+| `tests/CodeCompress.Server.Tests/Tools/QueryToolsTests.cs` | Add unit tests for both search tools |
+
+## Test Cases
+
+### Fts5QuerySanitizerTests (`tests/CodeCompress.Server.Tests/Sanitization/Fts5QuerySanitizerTests.cs`)
+
+| Test | Description |
+|---|---|
+| Sanitize_SimpleWord_PassesThrough | `"damage"` returns `"damage"` unchanged |
+| Sanitize_MultipleWords_PassesThrough | `"damage health"` returns unchanged |
+| Sanitize_BooleanOperators_Allowed | `"damage OR health"` returns unchanged |
+| Sanitize_QuotedPhrase_Allowed | `"\"damage result\""` returns unchanged |
+| Sanitize_PrefixMatch_Allowed | `"combat*"` returns unchanged |
+| Sanitize_UnbalancedQuotes_Stripped | `"damage \"result"` strips the unbalanced quote |
+| Sanitize_ColumnFilter_Stripped | `"name:foo"` strips the column filter prefix |
+| Sanitize_NearOperator_Stripped | `"NEAR(damage, health)"` strips `NEAR` syntax |
+| Sanitize_CaretOperator_Stripped | `"^damage"` strips the caret |
+| Sanitize_UnbalancedParentheses_Stripped | `"(damage OR"` strips unbalanced parenthesis |
+| Sanitize_BalancedParentheses_Allowed | `"(damage OR health)"` returns unchanged |
+| Sanitize_EmptyAfterSanitization_FallsBackToLiteral | Input that becomes empty after stripping is wrapped as literal |
+
+### QueryToolsTests — Search Tools (added to `tests/CodeCompress.Server.Tests/Tools/QueryToolsTests.cs`)
+
+| Test | Description |
+|---|---|
+| SearchSymbols_SimpleQuery_ReturnsRankedResults | `"damage"` returns matching symbols ranked by relevance |
+| SearchSymbols_WithOrOperator_ReturnsUnion | `"damage OR health"` returns symbols matching either term |
+| SearchSymbols_WithAndOperator_ReturnsIntersection | `"damage AND combat"` returns symbols matching both terms |
+| SearchSymbols_PrefixQuery_ReturnsMatches | `"combat*"` matches `CombatService`, `CombatUtils`, etc. |
+| SearchSymbols_WithKindFilter_FiltersResults | `kind = "method"` returns only methods |
+| SearchSymbols_InvalidKind_ReturnsError | `kind = "invalid"` returns structured error |
+| SearchSymbols_WithLimit_RespectsLimit | `limit = 5` returns at most 5 results |
+| SearchSymbols_LimitClamped_Above100 | `limit = 500` clamped to 100 |
+| SearchSymbols_MaliciousQuery_Sanitized | Column filters and special syntax stripped, no crash |
+| SearchSymbols_EmptyQuery_ReturnsError | Empty string returns structured error |
+| SearchSymbols_InvalidPath_ReturnsError | Path validation failure returns error |
+| SearchSymbols_FallbackOnSyntaxError | Malformed query retries as literal phrase |
+| SearchText_SimpleQuery_ReturnsFileMatches | `"multiplier"` returns file locations with snippets |
+| SearchText_WithGlobFilter_FiltersFiles | `glob = "*.luau"` returns only `.luau` file matches |
+| SearchText_MaliciousGlob_Sanitized | Glob with injection patterns is sanitized |
+| SearchText_WithLimit_RespectsLimit | `limit = 10` returns at most 10 results |
+| SearchText_EmptyQuery_ReturnsError | Empty string returns structured error |
+| SearchText_InvalidPath_ReturnsError | Path validation failure returns error |
+
+All tests use **NSubstitute** to mock `SymbolStore` and `PathValidator`.
+
+## Out of Scope
+
+- FTS5 highlighting (bold/italic markup in snippets) — snippets use plain text with `...` ellipsis.
+- Fuzzy/typo-tolerant search — FTS5 does not support this natively.
+- Search result pagination (offset-based) — agents can adjust `limit` for now.
+- Search across multiple repositories simultaneously.
+- Custom FTS5 tokenizer configuration — use SQLite default tokenizer.
+- Proximity search (`NEAR`) — stripped by the sanitizer as a security measure.
+
+## Notes / Decisions
+
+1. **FTS5 sanitization as a dedicated class.** The sanitizer is extracted into `Fts5QuerySanitizer` rather than inlined in the tool methods because it is a security-critical component that deserves focused unit testing. It may also be reused by future tools.
+2. **Allow-list over deny-list.** The sanitizer permits specific FTS5 syntax (`AND`, `OR`, `NOT`, `*`, balanced quotes/parentheses) and strips everything else. This is more robust than trying to deny-list every possible FTS5 injection vector.
+3. **Graceful fallback.** Rather than returning an error when FTS5 rejects a query, the tool retries with the original input wrapped in double quotes (literal phrase match). This provides a degraded but functional experience for queries that contain accidental FTS5 syntax.
+4. **Snippet generation.** FTS5's built-in `snippet()` function generates context windows around matching terms. This is more efficient than post-processing in C# because it happens within the SQLite query engine.
+5. **Glob sanitization.** The `glob` parameter is used in a SQL `LIKE` or `GLOB` clause, not passed to the file system. Only glob metacharacters (`*`, `?`) and path characters (`/`, `.`, alphanumeric) are allowed. This prevents SQL injection through the glob parameter.
+6. **Limit clamping.** The `[1, 100]` range prevents both empty results (limit = 0) and resource exhaustion (limit = 10000). The default of 20 balances token cost with result completeness.

--- a/docs/09-delta-tools/001-changes-since-and-file-tree.md
+++ b/docs/09-delta-tools/001-changes-since-and-file-tree.md
@@ -1,0 +1,141 @@
+# 001 — DeltaTools: changes_since and file_tree
+
+## Summary
+
+Change tracking tools that show what changed since a snapshot and provide an annotated file tree. The `changes_since` tool compares the current state of a project against a previously-created snapshot to produce a structured delta report (new/modified/deleted files and symbol-level diffs). The `file_tree` tool walks the project directory and returns an annotated tree with file counts and line counts per directory, respecting default exclusion patterns.
+
+## Dependencies
+
+- **Feature 07** — MCP server host, DI, `[McpServerToolType]` infrastructure.
+- **Feature 03** — `SymbolStore` snapshot persistence and snapshot retrieval queries.
+- **Feature 06** — `IndexEngine` for current file hashes and symbol data.
+- **Feature 04** — `PathValidator` for input sanitization.
+
+## Scope
+
+### 1. DeltaTools Class (`src/CodeCompress.Server/Tools/DeltaTools.cs`)
+
+A `[McpServerToolType]` class containing two `[McpServerTool]` methods. Receives `IndexEngine`, `SymbolStore`, and `PathValidator` via constructor injection.
+
+### 2. changes_since Tool
+
+| Aspect | Detail |
+|---|---|
+| Parameters | `path` (string, required) — project root; `snapshot_label` (string, required) — label of the snapshot to diff against |
+| Path validation | `PathValidator.Validate(path)` — reject traversal attempts |
+| Label sanitization | Strip or escape any characters that could be interpreted as agent instructions; reject labels exceeding 256 characters |
+| Snapshot lookup | `SymbolStore.GetSnapshot(repoId, snapshotLabel)` — returns file hashes and symbol data at snapshot time |
+| Current state | Load current file hashes from the indexed repository via `SymbolStore` |
+| Diff logic | Compare snapshot file hashes against current hashes to classify files as new, modified, or deleted |
+| Symbol-level diff | For modified files: compare old vs new symbol lists by name+kind to identify added, modified (signature changed), and removed symbols |
+| Output format | Structured text with token-efficient layout (target ~1-3k tokens for a typical delta): |
+
+```
+Changes since snapshot "{label}":
+
+New files (N):
+  path/to/file.luau — 5 symbols
+
+Modified files (N):
+  path/to/other.luau
+    + addedFunction(param: Type): ReturnType
+    ~ modifiedFunction(param: Type): NewReturnType
+    - removedFunction()
+
+Deleted files (N):
+  path/to/gone.luau
+
+Summary: +X added, ~Y modified, -Z removed symbols
+```
+
+| Error handling | Non-existent snapshot returns a clear error message with available snapshot labels |
+
+### 3. file_tree Tool
+
+| Aspect | Detail |
+|---|---|
+| Parameters | `path` (string, required) — project root; `max_depth` (int, default 5) — maximum directory depth |
+| Path validation | `PathValidator.Validate(path)` — reject traversal attempts |
+| Directory walk | Recursive traversal of project directory up to `max_depth` |
+| Default excludes | `.git/`, `node_modules/`, `bin/`, `obj/`, `.vs/`, `.idea/`, `Packages/`, `__pycache__/` |
+| Annotations | Each directory shows file count and aggregate line count; each file shows line count |
+| Output format | Indented tree structure: |
+
+```
+src/ (42 files, 3,210 lines)
+  server/ (28 files, 2,100 lines)
+    Services/ (8 files, 890 lines)
+      CombatService.luau (120 lines)
+      AIService.luau (95 lines)
+    init.server.luau (45 lines)
+  shared/ (14 files, 1,110 lines)
+    Types/ (3 files, 210 lines)
+```
+
+### 4. Security
+
+- All path parameters validated via `PathValidator` before any file system access.
+- Snapshot labels sanitized — no raw user input echoed into output without escaping.
+- Output is structured data only — no freeform text fields that could carry prompt injection.
+- `max_depth` clamped to a reasonable range (1-20) to prevent excessive traversal.
+
+### 5. Tests (`tests/CodeCompress.Server.Tests/Tools/DeltaToolsTests.cs`)
+
+| Test | Description |
+|---|---|
+| ChangesSince_NewFiles_ReportsCorrectly | Add new files after snapshot, verify they appear in "New files" section with symbol counts |
+| ChangesSince_ModifiedFiles_ShowsSymbolDiffs | Modify a file's symbols after snapshot, verify added/modified/removed symbols listed |
+| ChangesSince_DeletedFiles_ReportsCorrectly | Delete files after snapshot, verify they appear in "Deleted files" section |
+| ChangesSince_NoChanges_ReturnsEmptyDiff | No changes since snapshot, verify clean empty diff report |
+| ChangesSince_NonExistentSnapshot_ReturnsError | Request a snapshot that does not exist, verify error with available labels |
+| ChangesSince_InvalidPath_RejectsTraversal | Path with `..` or outside project root is rejected |
+| ChangesSince_SnapshotLabelSanitized | Labels with special characters are sanitized in output |
+| FileTree_RespectsMaxDepth | Set max_depth=2, verify deeper directories are not shown |
+| FileTree_ExcludesDefaultPatterns | Verify `.git/`, `node_modules/`, etc. are excluded |
+| FileTree_AnnotatesWithCounts | Verify file and line counts appear on directories and files |
+| FileTree_EmptyDirectory_HandledGracefully | Empty project directory returns a minimal tree |
+| FileTree_InvalidPath_RejectsTraversal | Path validation rejects traversal attempts |
+| FileTree_MaxDepthClamped | Negative or excessive max_depth values are clamped |
+
+## Acceptance Criteria
+
+- [ ] `DeltaTools` class is annotated with `[McpServerToolType]` and auto-discovered by the MCP server.
+- [ ] `changes_since` compares snapshot state against current index and returns a structured delta report.
+- [ ] Modified files include symbol-level diffs (added/modified/removed symbols with signatures).
+- [ ] Non-existent snapshots return a clear error with available snapshot labels.
+- [ ] `file_tree` returns an annotated directory tree respecting `max_depth` and default excludes.
+- [ ] All path parameters are validated via `PathValidator`.
+- [ ] Snapshot labels are sanitized before being included in output.
+- [ ] Output contains structured data only — no raw user input echoed without escaping.
+- [ ] `dotnet build CodeCompress.slnx` succeeds with zero warnings.
+- [ ] All tests pass via `dotnet test tests/CodeCompress.Server.Tests`.
+- [ ] 85%+ code coverage for `DeltaTools`.
+
+## Files to Create/Modify
+
+### Create
+
+| File | Description |
+|---|---|
+| `src/CodeCompress.Server/Tools/DeltaTools.cs` | `[McpServerToolType]` class with `changes_since` and `file_tree` tools |
+| `tests/CodeCompress.Server.Tests/Tools/DeltaToolsTests.cs` | Unit tests for both tools |
+
+### Modify
+
+| File | Description |
+|---|---|
+| `src/CodeCompress.Core/Storage/SymbolStore.cs` | Add `GetSnapshot` method if not already present; add query for snapshot file hashes |
+
+## Out of Scope
+
+- Watching for file system changes in real time (inotify/fswatch) — changes are detected at query time.
+- Custom exclude patterns — only default excludes for MVP.
+- Streaming output for large trees — full tree is returned in one response.
+- Binary file detection — all files in the tree are counted regardless of type.
+
+## Notes / Decisions
+
+1. **Symbol-level diffs.** Comparing symbols by `Name + Kind` pair. If a symbol's signature changes but its name and kind remain the same, it is classified as "modified." If a new name+kind appears, it is "added." If one disappears, it is "removed." This is a heuristic — renames will appear as remove+add.
+2. **Token budget.** The `changes_since` output is designed to be compact (~1-3k tokens for a typical delta) so AI agents can consume it without excessive context usage. Full source code of changed functions is not included — agents should follow up with `get_symbol` for details.
+3. **Default excludes.** The exclusion list is hardcoded for MVP. A future enhancement could allow per-project `.codecompressignore` files.
+4. **Line counting in file_tree.** Line counts are computed by counting newline characters in each file. Binary files may produce inaccurate counts, but this is acceptable for the annotated tree use case.

--- a/docs/10-dependency-tools/001-dependency-graph.md
+++ b/docs/10-dependency-tools/001-dependency-graph.md
@@ -1,0 +1,142 @@
+# 001 — DependencyTools: dependency_graph
+
+## Summary
+
+Graph traversal tool that exposes import/require relationships between files in an indexed project. Supports directional queries (who I depend on, who depends on me, or both), depth-limited traversal, and full project graph generation. Returns an adjacency list with metadata in a token-efficient structured format.
+
+## Dependencies
+
+- **Feature 07** — MCP server host, DI, `[McpServerToolType]` infrastructure.
+- **Feature 03** — `SymbolStore` dependency storage and query methods (`GetDependencyGraph`, `GetFileDependencies`, `GetFileDependents`).
+- **Feature 04** — `PathValidator` for input sanitization.
+- **Feature 05** — `LuauParser` captures `require()` statements as `DependencyInfo`.
+- **Feature 06** — `IndexEngine` stores parsed dependencies in `SymbolStore`.
+
+## Scope
+
+### 1. DependencyTools Class (`src/CodeCompress.Server/Tools/DependencyTools.cs`)
+
+A `[McpServerToolType]` class containing one `[McpServerTool]` method. Receives `SymbolStore` and `PathValidator` via constructor injection.
+
+### 2. dependency_graph Tool
+
+| Aspect | Detail |
+|---|---|
+| Parameters | `path` (string, required) — project root; `root_file` (string?, optional) — start traversal from a specific file; `direction` (string, default "both") — one of "dependencies", "dependents", "both"; `depth` (int?, default unlimited) — maximum traversal depth |
+| Path validation | `PathValidator.Validate(path)` and `PathValidator.Validate(root_file)` if provided — reject traversal attempts |
+| Direction semantics | `"dependencies"` = outgoing edges (files I require/import); `"dependents"` = incoming edges (files that require/import me); `"both"` = both directions |
+| Traversal | BFS from `root_file` with depth limit. Each level expands edges in the specified direction. Visited set prevents revisiting nodes (handles circular dependencies). |
+| Full project mode | If `root_file` is omitted, return all files and their relationships (no traversal, just the full adjacency list from `SymbolStore`) |
+| Depth clamping | `depth` is clamped to range 1-50; if omitted or null, no depth limit (full reachability) |
+
+### 3. Output Format
+
+Structured adjacency list, one entry per file, with directional edges:
+
+```
+Dependency graph for "CombatService.luau" (depth: 2, direction: both):
+
+CombatService.luau
+  requires -> GameTypes.luau, WeaponConfig.luau, Config.luau
+  required by -> AgentService.luau, MissionService.luau
+
+GameTypes.luau
+  requires -> (none)
+  required by -> CombatService.luau, AIService.luau
+
+WeaponConfig.luau
+  requires -> GameTypes.luau
+  required by -> CombatService.luau
+```
+
+For direction "dependencies" only outgoing edges are shown; for "dependents" only incoming edges. Files with no edges in the requested direction are still listed with `(none)`.
+
+Full project mode includes a summary line: `Total: N files, M dependency edges`.
+
+### 4. Graph Traversal Algorithm
+
+```
+BFS(root_file, direction, max_depth):
+  queue = [(root_file, 0)]
+  visited = {root_file}
+  result = {}
+  while queue not empty:
+    (file, level) = dequeue
+    if max_depth != null and level >= max_depth: continue expanding
+    edges = get_edges(file, direction)
+    result[file] = edges
+    for neighbor in edges:
+      if neighbor not in visited:
+        visited.add(neighbor)
+        queue.enqueue((neighbor, level + 1))
+  return result
+```
+
+### 5. Security
+
+- All path parameters validated via `PathValidator`.
+- `direction` parameter validated against allowed values ("dependencies", "dependents", "both") — reject anything else.
+- `depth` clamped to prevent excessive traversal.
+- Output is structured data only — file paths from the index, no raw user input echoed.
+
+### 6. Tests (`tests/CodeCompress.Server.Tests/Tools/DependencyToolsTests.cs`)
+
+| Test | Description |
+|---|---|
+| SingleFile_Dependencies_ReturnsOutgoingEdges | File with requires, direction="dependencies" — lists required files |
+| SingleFile_Dependents_ReturnsIncomingEdges | File required by others, direction="dependents" — lists dependent files |
+| SingleFile_Both_ReturnsBothDirections | direction="both" — lists both requires and required-by |
+| DepthLimiting_StopsAtSpecifiedDepth | depth=1 returns only direct edges, not transitive |
+| FullProjectGraph_NoRootFile_ReturnsAllEdges | No root_file — returns complete adjacency list with summary |
+| FileWithNoDependencies_ReturnsEmptyEdges | Isolated file returns `(none)` for both directions |
+| NonExistentFile_ReturnsError | root_file not in index — clear error message |
+| CircularDependencies_NoInfiniteLoop | A requires B, B requires A — traversal terminates correctly |
+| InvalidDirection_ReturnsError | direction="invalid" — rejected with allowed values listed |
+| PathValidation_RejectsTraversal | Path with `..` or outside project root is rejected |
+| DepthClamping_ExcessiveDepth_Clamped | depth=999 clamped to 50 |
+| MultipleRootsInGraph_CorrectTraversal | Complex graph with multiple entry points traversed correctly |
+| TransitiveDependencies_FullChain | A->B->C->D with unlimited depth — all nodes included |
+
+## Acceptance Criteria
+
+- [ ] `DependencyTools` class is annotated with `[McpServerToolType]` and auto-discovered by the MCP server.
+- [ ] `dependency_graph` supports three direction modes: "dependencies", "dependents", "both".
+- [ ] Depth-limited BFS traversal correctly stops at the specified depth.
+- [ ] Full project graph is returned when `root_file` is omitted.
+- [ ] Circular dependencies are handled without infinite loops.
+- [ ] Non-existent `root_file` returns a clear error message.
+- [ ] Invalid `direction` values are rejected with allowed values listed.
+- [ ] All path parameters are validated via `PathValidator`.
+- [ ] Output is structured data only — no prompt injection vectors.
+- [ ] `dotnet build CodeCompress.slnx` succeeds with zero warnings.
+- [ ] All tests pass via `dotnet test tests/CodeCompress.Server.Tests`.
+- [ ] 85%+ code coverage for `DependencyTools`.
+
+## Files to Create/Modify
+
+### Create
+
+| File | Description |
+|---|---|
+| `src/CodeCompress.Server/Tools/DependencyTools.cs` | `[McpServerToolType]` class with `dependency_graph` tool |
+| `tests/CodeCompress.Server.Tests/Tools/DependencyToolsTests.cs` | Unit tests for dependency graph traversal |
+
+### Modify
+
+| File | Description |
+|---|---|
+| `src/CodeCompress.Core/Storage/SymbolStore.cs` | Add `GetFileDependencies`, `GetFileDependents`, `GetFullDependencyGraph` methods if not already present |
+
+## Out of Scope
+
+- Visualizing graphs (DOT/Graphviz output) — text adjacency list only for MVP.
+- Cross-project dependencies — only intra-project relationships.
+- Dependency version resolution — not applicable for source-level require/import.
+- Cycle detection reporting (listing cycles explicitly) — cycles are tolerated, not reported.
+
+## Notes / Decisions
+
+1. **BFS over DFS.** BFS gives a natural depth-limited traversal and returns results ordered by distance from root. This is more useful for AI agents that want to understand the immediate neighborhood of a file before expanding outward.
+2. **Circular dependency handling.** The visited set prevents infinite loops. Cycles are not explicitly reported — the graph simply shows edges as they exist. A future enhancement could add cycle detection.
+3. **Full project graph performance.** For large projects, the full adjacency list may be large. This is acceptable for MVP — the tool is primarily useful with `root_file` scoping. A future enhancement could add pagination or filtering.
+4. **Direction parameter as string.** Using a string enum rather than a dedicated C# enum because MCP tool parameters are JSON strings. Validation happens at the tool level with a clear error message for invalid values.

--- a/docs/11-integration-tests-and-samples/001-luau-sample-and-e2e-tests.md
+++ b/docs/11-integration-tests-and-samples/001-luau-sample-and-e2e-tests.md
@@ -1,0 +1,121 @@
+# 001 — Luau Sample Project and End-to-End Integration Tests
+
+## Summary
+
+Create a realistic Luau sample project representing a small Roblox game codebase, then write end-to-end integration tests that exercise the full pipeline — index, query, snapshot, re-index, delta, dependency graph, and file tree — using real components (real SQLite, real parsers, real IndexEngine) with no mocks.
+
+## Dependencies
+
+- **Feature 01** — Project scaffold, solution file.
+- **Feature 02** — Core models and interfaces.
+- **Feature 03** — SQLite storage layer (`SymbolStore`, `SqliteConnectionFactory`).
+- **Feature 04** — `PathValidator`.
+- **Feature 05** — `LuauParser`.
+- **Feature 06** — `IndexEngine`, `FileHasher`, `ChangeTracker`.
+- **Feature 07** — MCP server host and indexing tools (`index_project`, `snapshot_create`, `invalidate_cache`).
+- **Feature 08** — Query tools (`project_outline`, `get_symbol`, `get_symbols`, `get_module_api`, `search_symbols`, `search_text`).
+- **Feature 09** — Delta tools (`changes_since`, `file_tree`).
+- **Feature 10** — Dependency tools (`dependency_graph`).
+
+## Scope
+
+### 1. Luau Sample Project (`samples/luau-sample-project/`)
+
+A small but realistic Roblox project structure covering all Luau parser patterns:
+
+| File | Contents | Patterns Covered |
+|---|---|---|
+| `src/server/Services/CombatService.luau` | Combat system service class with methods, type annotations, require dependencies | Functions, methods, local functions, doc comments, require() |
+| `src/server/Services/AIService.luau` | AI behavior service with pathfinding and decision methods | Functions, generic types, require() |
+| `src/server/Services/InventoryService.luau` | Inventory management with CRUD operations | Methods, constants, require() |
+| `src/shared/Types/GameTypes.luau` | Shared type definitions for the game | Export types, local types, generic types |
+| `src/shared/Types/WeaponTypes.luau` | Weapon-specific type definitions | Export types, type unions/intersections |
+| `src/shared/Constants/Config.luau` | Game configuration constants | Constants, module table |
+| `src/server/init.server.luau` | Server entry point wiring services together | Top-level require() calls |
+| `src/client/init.client.luau` | Client entry point | Require() calls, local functions |
+
+Target: ~5-8 files, ~50-100 symbols total, covering functions, methods, local functions, export types, local types, constants, require() dependencies, doc comments, and generic types.
+
+### 2. End-to-End Integration Tests (`tests/CodeCompress.Integration.Tests/EndToEndTests.cs`)
+
+All tests use real components — real SQLite (temp file per test), real parsers, real IndexEngine. No mocks. Each test method is independent and creates its own database.
+
+| Test | Description |
+|---|---|
+| IndexProject_LuauSample_CorrectFilesAndSymbolCounts | Index the sample project, verify expected file count and total symbol count |
+| ProjectOutline_ReturnsGroupedSymbols | Call `project_outline`, verify symbols are grouped by file with correct kinds and signatures |
+| GetSymbol_SpecificFunction_ReturnsSourceCode | Call `get_symbol` for a known function, verify returned source code matches the sample file |
+| GetSymbols_BatchRetrieve_AllCorrect | Call `get_symbols` with multiple symbol names, verify all are returned correctly |
+| GetModuleApi_CombatService_ReturnsPublicApi | Call `get_module_api` for CombatService, verify complete public API surface |
+| SearchSymbols_ByName_ReturnsRankedResults | Search for a partial symbol name, verify results are ranked by relevance |
+| SearchText_FindsContentInFiles | Search for a text string, verify matching files and line numbers |
+| SnapshotCreate_StoresCurrentState | Create a snapshot, verify it is stored and retrievable |
+| ChangesSince_AfterModification_ReportsAccurateDelta | Create snapshot, simulate changes (copy modified file), re-index, call `changes_since`, verify delta report |
+| DependencyGraph_RequireRelationships_Correct | Call `dependency_graph`, verify require() relationships match sample project structure |
+| DependencyGraph_SingleFile_CorrectEdges | Call `dependency_graph` with root_file, verify edges for that file |
+| FileTree_MatchesSampleStructure | Call `file_tree`, verify directory structure matches sample project |
+| FileTree_RespectsMaxDepth | Call `file_tree` with max_depth=1, verify truncation |
+| InvalidateCache_ForcesFullReindex | Call `invalidate_cache`, re-index, verify all files re-processed |
+| FullRoundTrip_IndexQueryModifyReindexDelta | End-to-end: index, query, snapshot, modify, re-index, delta — verify entire flow |
+
+### 3. Test Infrastructure
+
+| Component | Detail |
+|---|---|
+| Database | Temp SQLite file per test, deleted in `[After(Test)]` cleanup |
+| File system | Sample project is read-only; modified files for delta tests are copied to a temp directory |
+| DI | Tests build a minimal service collection with real implementations (no host needed) |
+| Assertions | TUnit async/fluent: `await Assert.That(...)` |
+
+## Acceptance Criteria
+
+- [ ] Luau sample project exists at `samples/luau-sample-project/` with 5-8 `.luau` files covering all parser patterns.
+- [ ] Sample project contains ~50-100 symbols across all files.
+- [ ] All integration tests use real components — no mocks.
+- [ ] `IndexProject` test verifies correct file and symbol counts.
+- [ ] `ProjectOutline` test verifies grouped symbols with correct metadata.
+- [ ] `GetSymbol` test verifies source code retrieval matches actual file content.
+- [ ] `SearchSymbols` and `SearchText` tests verify FTS5 search functionality.
+- [ ] Snapshot and `changes_since` tests verify the full delta workflow.
+- [ ] `DependencyGraph` tests verify require() relationship extraction.
+- [ ] `FileTree` test verifies annotated directory structure.
+- [ ] Full round-trip test exercises index, query, modify, re-index, delta in sequence.
+- [ ] Each test is independent — no shared state between tests.
+- [ ] `dotnet build CodeCompress.slnx` succeeds with zero warnings.
+- [ ] All tests pass via `dotnet test tests/CodeCompress.Integration.Tests`.
+
+## Files to Create/Modify
+
+### Create
+
+| File | Description |
+|---|---|
+| `samples/luau-sample-project/src/server/Services/CombatService.luau` | Combat service with methods, types, requires |
+| `samples/luau-sample-project/src/server/Services/AIService.luau` | AI service with pathfinding methods |
+| `samples/luau-sample-project/src/server/Services/InventoryService.luau` | Inventory service with CRUD methods |
+| `samples/luau-sample-project/src/shared/Types/GameTypes.luau` | Shared game type definitions |
+| `samples/luau-sample-project/src/shared/Types/WeaponTypes.luau` | Weapon type definitions |
+| `samples/luau-sample-project/src/shared/Constants/Config.luau` | Game configuration constants |
+| `samples/luau-sample-project/src/server/init.server.luau` | Server entry point |
+| `samples/luau-sample-project/src/client/init.client.luau` | Client entry point |
+| `tests/CodeCompress.Integration.Tests/EndToEndTests.cs` | Full end-to-end integration test class |
+
+### Modify
+
+| File | Description |
+|---|---|
+| `tests/CodeCompress.Integration.Tests/CodeCompress.Integration.Tests.csproj` | Add project references to Core and Server if not already present |
+
+## Out of Scope
+
+- MCP protocol-level testing (stdin/stdout message framing) — tests call tool classes directly.
+- Performance benchmarks — functional correctness only.
+- Sample projects for other languages (C# sample is Feature 12-003).
+- Negative security tests (path traversal, injection) — those are unit tests in the respective feature plans.
+
+## Notes / Decisions
+
+1. **Real components, no mocks.** Integration tests are meant to verify that all components work together correctly. Mocking would defeat the purpose. Each test creates its own SQLite database in a temp directory to ensure isolation.
+2. **Sample project as test fixture.** The sample project files are committed to the repository and treated as read-only test fixtures. Delta tests that simulate modifications copy files to a temp directory and modify the copies.
+3. **Test independence.** Each test creates a fresh database and service instances. Tests can run in parallel without conflicts because they have separate temp directories.
+4. **Symbol count validation.** Exact symbol counts in assertions should match what the Luau parser extracts. If the parser is updated, these counts may need adjustment — this is intentional, as it catches unintended parser behavior changes.

--- a/docs/12-csharp-parser/001-core-csharp-patterns.md
+++ b/docs/12-csharp-parser/001-core-csharp-patterns.md
@@ -1,0 +1,151 @@
+# 001 — C# Parser: Core Patterns (Namespace, Class, Interface, Record, Enum, Struct)
+
+## Summary
+
+Phase 2 language parser for C# source files. Regex/pattern-based extraction of top-level and nested type declarations — namespaces, classes, interfaces, records, enums, and structs. Handles access modifiers, generic type parameters, inheritance, XML doc comments, and nested type parent tracking.
+
+## Dependencies
+
+- **Feature 01** — Project scaffold, `CodeCompress.Core.csproj`.
+- **Feature 02** — Core models and interfaces (`ILanguageParser`, `SymbolInfo`, `ParseResult`, `SymbolKind`, `Visibility`).
+
+## Scope
+
+### 1. CSharpParser Class (`src/CodeCompress.Core/Parsers/CSharpParser.cs`)
+
+Implements `ILanguageParser`:
+
+| Property/Method | Detail |
+|---|---|
+| `LanguageId` | `"csharp"` |
+| `FileExtensions` | `[".cs"]` |
+| `Parse(string filePath, ReadOnlySpan<byte> content)` | Returns `ParseResult` with extracted symbols and dependencies |
+
+### 2. Type Declaration Patterns
+
+| Pattern | Regex Target | SymbolKind | Notes |
+|---|---|---|---|
+| Namespace (file-scoped) | `namespace Foo.Bar;` | `Module` | Single per file; no brace tracking needed |
+| Namespace (block-scoped) | `namespace Foo.Bar { }` | `Module` | Brace-depth tracking for body extent |
+| Class | `[modifiers] class Name[<T>] [: Base, IFoo]` | `Class` | Includes generic parameters and constraints |
+| Interface | `[modifiers] interface IName[<T>] [: IBase]` | `Interface` | |
+| Record | `[modifiers] record [class\|struct] Name(params)` | `Class` | Primary constructor captured in signature |
+| Enum | `[modifiers] enum Name [: Type]` | `Type` | Underlying type captured if specified |
+| Struct | `[modifiers] struct Name[<T>]` | `Class` | |
+
+### 3. Modifier Detection
+
+Modifiers parsed from the declaration line: `public`, `internal`, `private`, `protected`, `static`, `abstract`, `sealed`, `partial`, `readonly`, `file`, `required`, `new`.
+
+### 4. Visibility Derivation
+
+| Modifier(s) | Visibility |
+|---|---|
+| `public` | `Public` |
+| `internal` | `Public` (visible within project) |
+| `protected internal` | `Public` |
+| `private` | `Private` |
+| `protected` | `Private` |
+| `private protected` | `Private` |
+| No modifier (top-level) | `Public` (C# default for top-level types is `internal`, mapped to `Public`) |
+| No modifier (nested) | `Private` (C# default for nested types) |
+
+### 5. Parent Tracking
+
+Nested types (class within class, enum within class, etc.) have their `ParentSymbol` set to the enclosing type's name. Tracked via a brace-depth stack during parsing — when entering a type's body, it is pushed onto the parent stack; when exiting, it is popped.
+
+### 6. Symbol Capture Fields
+
+| Field | Source |
+|---|---|
+| `Name` | Type name (without generic parameters for matching, with parameters in signature) |
+| `Kind` | As mapped above |
+| `Signature` | Full declaration line(s), trimmed, up to opening brace or semicolon |
+| `ByteOffset` | Byte position of the declaration start in the file |
+| `ByteLength` | Byte length from declaration start to closing brace (brace-depth tracking) |
+| `LineStart` | 1-based line number of the declaration |
+| `LineEnd` | 1-based line number of the closing brace |
+| `Visibility` | Derived from modifiers as above |
+| `DocComment` | `///` XML comments immediately preceding the declaration, joined into a single string |
+
+### 7. Brace-Depth Tracking
+
+A state machine tracks brace depth to determine symbol body boundaries:
+- Increment on `{`, decrement on `}`.
+- Skip braces inside string literals (`"..."`, `@"..."`, `$"..."`, `"""..."""`), character literals, and comments (`//`, `/* */`).
+- When depth returns to the level before the type declaration, the type's body ends.
+
+### 8. Tests (`tests/CodeCompress.Core.Tests/Parsers/CSharpParserTests.cs`)
+
+| Test | Description |
+|---|---|
+| FileScopedNamespace_Extracted | `namespace Foo.Bar;` parsed as Module |
+| BlockScopedNamespace_Extracted | `namespace Foo.Bar { }` parsed as Module with correct extent |
+| PublicClass_WithBaseAndInterfaces | `public class Foo : Bar, IBaz` — Name, Kind, Signature, Visibility |
+| InternalClass_VisibilityPublic | `internal class Foo` — Visibility is Public |
+| AbstractClass_Extracted | `abstract class Foo` — modifiers in signature |
+| SealedClass_Extracted | `sealed class Foo` — modifiers in signature |
+| StaticClass_Extracted | `static class Foo` — modifiers in signature |
+| PartialClass_Extracted | `partial class Foo` — modifiers in signature |
+| Interface_WithIPrefix | `public interface IFoo` — Kind is Interface |
+| Record_WithPrimaryConstructor | `public record Foo(int X, string Y)` — constructor in signature |
+| RecordStruct_Extracted | `public record struct Point(int X, int Y)` — Kind is Class |
+| Enum_Extracted | `public enum Color { Red, Green, Blue }` — Kind is Type |
+| Enum_WithUnderlyingType | `public enum Flags : byte` — underlying type in signature |
+| Struct_Extracted | `public struct Vector3` — Kind is Class |
+| GenericClass_WithConstraints | `public class Repo<T> where T : IEntity` — generics in signature |
+| NestedClass_ParentSet | Class inside class — ParentSymbol is outer class name |
+| NestedEnum_ParentSet | Enum inside class — ParentSymbol is enclosing class name |
+| XmlDocComment_Captured | `///` comments before a class are captured in DocComment |
+| MultiLineXmlDoc_Captured | Multiple `///` lines joined correctly |
+| PrivateNestedClass_VisibilityPrivate | No modifier on nested class — Visibility is Private |
+| EmptyFile_ReturnsEmptyResult | Empty `.cs` file — ParseResult with no symbols |
+| CommentOnlyFile_ReturnsEmptyResult | File with only comments — no symbols extracted |
+| MultipleNamespaces_BlockScoped | File with multiple block-scoped namespaces — both extracted |
+| GenericInterface_Extracted | `interface IRepo<T>` — generics captured |
+
+## Acceptance Criteria
+
+- [ ] `CSharpParser` implements `ILanguageParser` with `LanguageId = "csharp"` and `FileExtensions = [".cs"]`.
+- [ ] File-scoped and block-scoped namespaces are extracted as `SymbolKind.Module`.
+- [ ] Classes, interfaces, records, enums, and structs are extracted with correct `SymbolKind`.
+- [ ] Generic type parameters and constraints are captured in the signature.
+- [ ] Inheritance (base class, interfaces) is captured in the signature.
+- [ ] Access modifiers are parsed and mapped to `Visibility` correctly.
+- [ ] Nested types have `ParentSymbol` set to the enclosing type.
+- [ ] XML doc comments (`///`) are captured in `DocComment`.
+- [ ] Brace-depth tracking correctly determines `ByteLength`, `LineStart`, `LineEnd`.
+- [ ] Braces inside strings, character literals, and comments are ignored by the depth tracker.
+- [ ] `dotnet build CodeCompress.slnx` succeeds with zero warnings.
+- [ ] All tests pass via `dotnet test tests/CodeCompress.Core.Tests`.
+- [ ] 95%+ code coverage for `CSharpParser` core patterns.
+
+## Files to Create/Modify
+
+### Create
+
+| File | Description |
+|---|---|
+| `src/CodeCompress.Core/Parsers/CSharpParser.cs` | C# language parser implementing `ILanguageParser` |
+| `tests/CodeCompress.Core.Tests/Parsers/CSharpParserTests.cs` | Unit tests for core C# patterns |
+
+### Modify
+
+| File | Description |
+|---|---|
+| `src/CodeCompress.Server/Program.cs` | Register `CSharpParser` in DI: `AddSingleton<ILanguageParser, CSharpParser>()` |
+
+## Out of Scope
+
+- Methods, properties, constructors — covered in 12-002.
+- Using statements as dependencies — covered in 12-002.
+- Roslyn-based parsing — regex/pattern-based only per project architecture.
+- Preprocessor directives (`#if`, `#region`) — not tracked.
+- Attribute extraction — attributes on types are not captured as separate symbols.
+
+## Notes / Decisions
+
+1. **Regex-based, not Roslyn.** Per project architecture, all parsers are regex/pattern-based for zero-dependency, cross-platform operation. This means some edge cases (deeply nested generics, complex preprocessor branches) may not be perfectly handled. The parser targets ~95% accuracy on real-world C# code.
+2. **Record mapped to Class.** Records are semantically classes in C# and are mapped to `SymbolKind.Class`. The signature preserves the `record` keyword so consumers can distinguish them.
+3. **Visibility mapping.** `internal` is mapped to `Public` because within a CodeCompress project context, internal types are part of the project's API surface. The distinction between `public` and `internal` is less meaningful when the goal is to show "what symbols exist in this codebase."
+4. **Brace-depth state machine.** This is the most complex part of the parser. It must handle string interpolation (`$"...{expr}..."`), raw string literals (`"""..."""`), verbatim strings (`@"..."`), and their combinations. Edge cases should be covered by specific tests.

--- a/docs/12-csharp-parser/002-methods-properties-usings.md
+++ b/docs/12-csharp-parser/002-methods-properties-usings.md
@@ -1,0 +1,147 @@
+# 002 — C# Parser: Methods, Properties, Using Statements, Nested Types
+
+## Summary
+
+Extends the C# parser with extraction of methods (including constructors, operators, and extension methods), properties (auto, expression-bodied, init-only), and using statements (as dependency information). Handles complex real-world patterns such as async methods, generic methods with constraints, attributes on members, nullable return types, and tuple returns.
+
+## Dependencies
+
+- **Feature 12-001** — `CSharpParser` with core type patterns, brace-depth tracking, modifier detection, and visibility derivation.
+
+## Scope
+
+### 1. Method Extraction
+
+| Pattern | Regex Target | SymbolKind | Notes |
+|---|---|---|---|
+| Regular method | `[modifiers] ReturnType Name(params)` | `Method` | Includes body via brace-depth tracking |
+| Async method | `async Task<T> Name(params)` | `Method` | `async` in modifiers, full return type in signature |
+| Generic method | `T Name<U>(params) where U : IFoo` | `Method` | Generic params and constraints in signature |
+| Constructor | `ClassName(params)` | `Method` | Detected by name matching enclosing type |
+| Static constructor | `static ClassName()` | `Method` | |
+| Finalizer | `~ClassName()` | `Method` | |
+| Operator | `static ReturnType operator +(Type a, Type b)` | `Method` | `operator` keyword in name |
+| Indexer | `Type this[int index]` | `Method` | |
+| Expression-bodied | `ReturnType Name(params) => expr;` | `Method` | Body is the expression |
+| Extension method | `static ReturnType Name(this Type param, ...)` | `Method` | `this` keyword on first parameter noted |
+| Void method | `void Name(params)` | `Method` | |
+
+Method extraction rules:
+- Methods are children of the enclosing type — `ParentSymbol` set via the brace-depth parent stack.
+- Attributes (`[HttpGet]`, `[Obsolete]`, etc.) on lines immediately preceding the method are skipped — the signature starts at the method declaration line, not the attribute.
+- Visibility derived from modifiers, defaulting to `Private` for members within a type.
+
+### 2. Property Extraction
+
+| Pattern | Regex Target | SymbolKind | Notes |
+|---|---|---|---|
+| Auto-property | `[modifiers] Type Name { get; set; }` | `Constant` | Accessor pattern detected |
+| Init-only | `[modifiers] Type Name { get; init; }` | `Constant` | |
+| Expression-bodied | `[modifiers] Type Name => expr;` | `Constant` | Arrow syntax |
+| Full property | `[modifiers] Type Name { get { } set { } }` | `Constant` | Brace-depth tracking for body |
+| Required property | `required Type Name { get; set; }` | `Constant` | `required` modifier captured |
+
+Property detection heuristic: a line matching `[modifiers] Type Identifier { get` or `[modifiers] Type Identifier =>` that is not a method (no parentheses before `{` or `=>`).
+
+### 3. Using Statements as Dependencies
+
+| Pattern | DependencyInfo | Notes |
+|---|---|---|
+| `using Namespace;` | `ModulePath = "Namespace"` | Standard using |
+| `using Alias = Type;` | `ModulePath = "Type"`, alias captured | Using alias |
+| `global using Namespace;` | `ModulePath = "Namespace"`, global flag | Global using |
+| `using static Namespace.Type;` | `ModulePath = "Namespace.Type"`, static flag | Static using |
+
+Using statements are captured as `DependencyInfo` entries on the `ParseResult`, enabling the dependency graph to show namespace/type relationships between C# files.
+
+### 4. Edge Cases and Complex Patterns
+
+| Pattern | Handling |
+|---|---|
+| Attributes before methods | Attribute lines (`[...]`) are not part of the method signature; parser skips them |
+| Generic methods with constraints | `where T : class, new()` captured in signature |
+| Nullable return types | `string?`, `Task<int?>` — `?` included in return type |
+| Tuple return types | `(int X, string Y)` — parenthesized tuple in return type |
+| Extension methods | `this` keyword on first parameter — noted in signature |
+| Nested type methods | Methods inside nested classes have correct parent chain |
+| Partial methods | Each declaration captured independently |
+| `new` modifier on methods | `new void DoSomething()` — modifier captured |
+| Explicit interface impl | `void IFoo.Bar()` — interface name included in method name |
+
+### 5. Tests (`tests/CodeCompress.Core.Tests/Parsers/CSharpParserTests.cs` — additional tests)
+
+| Test | Description |
+|---|---|
+| PublicMethod_Extracted | `public void DoSomething()` — Name, Kind, Signature, Visibility |
+| PrivateMethod_VisibilityPrivate | `private int Calculate()` — Visibility is Private |
+| ProtectedMethod_Extracted | `protected virtual void OnEvent()` — modifiers in signature |
+| AsyncMethod_TaskReturn | `public async Task<int> GetAsync()` — async and return type captured |
+| GenericMethod_WithConstraints | `public T Find<T>(int id) where T : class` — generics in signature |
+| Constructor_Extracted | `public MyClass(int x, string y)` — Kind is Method, name is class name |
+| StaticConstructor_Extracted | `static MyClass()` — captured correctly |
+| Finalizer_Extracted | `~MyClass()` — captured correctly |
+| OperatorOverload_Extracted | `public static MyClass operator +(...)` — operator in name |
+| Indexer_Extracted | `public int this[int i]` — `this[]` captured |
+| ExpressionBodiedMethod_Extracted | `public int Sum() => X + Y;` — body is expression |
+| ExtensionMethod_ThisParameter | `public static int Count(this IEnumerable<T> source)` — `this` noted |
+| VoidMethod_Extracted | `public void Execute()` — void return type |
+| AutoProperty_Extracted | `public string Name { get; set; }` — Kind is Constant |
+| InitOnlyProperty_Extracted | `public string Name { get; init; }` — init captured |
+| ExpressionBodiedProperty_Extracted | `public int Total => Items.Count;` — arrow syntax |
+| RequiredProperty_Extracted | `required string Name { get; set; }` — required modifier |
+| UsingStatement_AsDependency | `using System.Collections.Generic;` — DependencyInfo created |
+| GlobalUsing_AsDependency | `global using System.Linq;` — global flag set |
+| UsingAlias_AsDependency | `using Dict = System.Collections.Generic.Dictionary<string, int>;` — alias captured |
+| UsingStatic_AsDependency | `using static System.Math;` — static flag set |
+| MethodWithAttributes_AttributeSkipped | `[HttpGet] public IActionResult Get()` — signature starts at method, not attribute |
+| NullableReturnType_Captured | `public string? GetName()` — `?` in return type |
+| TupleReturnType_Captured | `public (int X, string Y) GetPair()` — tuple in return type |
+| NestedTypeMethod_CorrectParent | Method in nested class — ParentSymbol is `OuterClass.InnerClass` |
+| ExplicitInterfaceImpl_Captured | `void IDisposable.Dispose()` — interface name in method name |
+| ComplexRealWorldFile_AllSymbolsExtracted | A realistic C# file with mixed patterns — all symbols found |
+
+## Acceptance Criteria
+
+- [ ] Methods are extracted with correct Name, Kind (`Method`), Signature, Visibility, and parent tracking.
+- [ ] Constructors, static constructors, finalizers, operators, and indexers are all captured as `Method`.
+- [ ] Async methods preserve `async` and full return type (`Task<T>`) in signature.
+- [ ] Generic methods with constraints are captured completely.
+- [ ] Expression-bodied methods and properties are handled.
+- [ ] Properties are extracted as `SymbolKind.Constant` with accessor pattern noted.
+- [ ] Using statements are captured as `DependencyInfo` with correct module path and flags.
+- [ ] Attributes on lines before methods are not included in the method signature.
+- [ ] Nullable return types, tuple returns, and extension methods are handled.
+- [ ] Nested type members have the correct parent chain.
+- [ ] `dotnet build CodeCompress.slnx` succeeds with zero warnings.
+- [ ] All tests pass via `dotnet test tests/CodeCompress.Core.Tests`.
+- [ ] 95%+ cumulative code coverage for `CSharpParser`.
+
+## Files to Create/Modify
+
+### Create
+
+None — all additions are to existing files.
+
+### Modify
+
+| File | Description |
+|---|---|
+| `src/CodeCompress.Core/Parsers/CSharpParser.cs` | Add method, property, and using statement extraction patterns |
+| `tests/CodeCompress.Core.Tests/Parsers/CSharpParserTests.cs` | Add tests for methods, properties, usings, and edge cases |
+
+## Out of Scope
+
+- Field extraction (`private int _count;`) — fields are not tracked as symbols for MVP.
+- Event extraction (`public event EventHandler Changed;`) — not tracked for MVP.
+- Delegate extraction (`public delegate void Handler(int x);`) — not tracked for MVP.
+- Local functions inside methods — only top-level members of types are extracted.
+- Lambda expressions — not tracked as symbols.
+- LINQ query expressions — not tracked.
+
+## Notes / Decisions
+
+1. **Properties as Constant.** `SymbolKind` does not have a `Property` variant. Mapping properties to `Constant` is a pragmatic choice — both represent named values on a type. The signature distinguishes them (properties have `{ get; set; }` or `=>`).
+2. **Attribute skipping.** Attributes are detected by `[` at the start of a line (after whitespace). Multiple attribute lines are skipped until the actual declaration line is found. This heuristic may misfire on array initializers at class level, but that is rare enough to be acceptable.
+3. **Using statements as dependencies.** This is a coarser dependency signal than Luau's `require()` — C# usings reference namespaces, not files. However, it still provides useful information for the dependency graph (which namespaces a file depends on). File-to-file resolution would require Roslyn and is out of scope.
+4. **Extension method detection.** The `this` keyword on the first parameter is a heuristic. The parser checks for `this` followed by a type name as the first parameter. This is sufficient for real-world code.
+5. **Explicit interface implementations.** `void IFoo.Bar()` has no access modifier and is always public (implicitly). The parser detects the dotted name pattern and captures `IFoo.Bar` as the method name.

--- a/docs/12-csharp-parser/003-csharp-sample-and-integration.md
+++ b/docs/12-csharp-parser/003-csharp-sample-and-integration.md
@@ -1,0 +1,120 @@
+# 003 — C# Sample Project and Integration Tests
+
+## Summary
+
+Create a realistic C# sample project and integration tests that verify the C# parser works correctly through the full pipeline. Also includes a mixed-language test confirming that Luau and C# parsers coexist and both contribute symbols when indexing a project containing both file types.
+
+## Dependencies
+
+- **Feature 12-001** — `CSharpParser` core patterns (namespace, class, interface, record, enum, struct).
+- **Feature 12-002** — `CSharpParser` methods, properties, using statements.
+- **Feature 11** — Integration test infrastructure and conventions (EndToEndTests pattern).
+
+## Scope
+
+### 1. C# Sample Project (`samples/csharp-sample-project/`)
+
+A small .NET project with realistic patterns covering all C# parser extraction targets:
+
+| File | Contents | Patterns Covered |
+|---|---|---|
+| `Models/Player.cs` | Record with properties, constructor | Record, primary constructor, namespace, properties |
+| `Models/Inventory.cs` | Class with properties, nested enum | Class, properties, nested enum, XML doc comments |
+| `Models/GameEvent.cs` | Abstract class, generic class, interfaces | Abstract class, generics, constraints, interface |
+| `Services/ICombatService.cs` | Interface with method signatures | Interface, method declarations, XML doc comments |
+| `Services/CombatService.cs` | Class implementing interface, DI, async methods | Class, constructor injection, async Task<T>, using statements |
+| `Services/InventoryService.cs` | Service with CRUD operations, extension methods | Methods, expression-bodied members, extension method |
+| `Handlers/GameHandler.cs` | Public API handler with attributes | Methods with attributes, nullable returns, tuples |
+| `Enums/GameState.cs` | Enum with underlying type | Enum, flags |
+
+Target: ~5-8 files, ~50-100 symbols, covering namespaces, classes, interfaces, records, enums, structs, methods, properties, constructors, generics, async, using statements, XML doc comments, attributes, and nested types.
+
+### 2. Integration Tests (`tests/CodeCompress.Integration.Tests/CSharpEndToEndTests.cs`)
+
+All tests use real components — real SQLite, real `CSharpParser`, real `IndexEngine`. No mocks.
+
+| Test | Description |
+|---|---|
+| IndexProject_CSharpSample_CorrectFilesAndSymbolCounts | Index the C# sample project, verify expected file and symbol counts |
+| ProjectOutline_CSharpSymbols_GroupedCorrectly | Call `project_outline`, verify C# symbols grouped by file with correct kinds |
+| GetSymbol_CSharpMethod_ReturnsSourceCode | Call `get_symbol` for a known C# method, verify source code matches |
+| GetSymbol_CSharpRecord_ReturnsDeclaration | Retrieve a record declaration, verify signature includes primary constructor |
+| SearchSymbols_CSharpNames_ReturnsRankedResults | Search for C# symbol names, verify results ranked by relevance |
+| GetModuleApi_CSharpService_ReturnsPublicApi | Call `get_module_api` for a C# service file, verify public API surface |
+| DependencyGraph_UsingStatements_Captured | Call `dependency_graph`, verify using statement relationships appear |
+| NamespaceExtraction_AllFilesHaveNamespace | Verify all C# files have their namespace extracted as a Module symbol |
+| NestedTypes_ParentChainCorrect | Verify nested class/enum has correct ParentSymbol |
+| XmlDocComments_CapturedOnSymbols | Verify XML doc comments are present on documented symbols |
+
+### 3. Mixed-Language Integration Test (`tests/CodeCompress.Integration.Tests/MixedLanguageTests.cs`)
+
+Tests that both parsers coexist when indexing a project with `.luau` and `.cs` files:
+
+| Test | Description |
+|---|---|
+| MixedProject_BothParsersContribute | Create temp directory with both `.luau` and `.cs` files, index it, verify symbols from both languages |
+| MixedProject_ProjectOutline_ShowsBothLanguages | `project_outline` includes Luau functions and C# classes |
+| MixedProject_SearchSymbols_FindsBothLanguages | Search returns results from both `.luau` and `.cs` files |
+| ParserSelection_ByExtension_Correct | `.cs` files use CSharpParser, `.luau` files use LuauParser — no cross-contamination |
+
+### 4. Test Infrastructure
+
+| Component | Detail |
+|---|---|
+| Database | Temp SQLite file per test, cleaned up in `[After(Test)]` |
+| DI | Real service collection with both `LuauParser` and `CSharpParser` registered |
+| Sample files | C# sample project committed to repo; mixed-language tests create temp files |
+| Assertions | TUnit async/fluent style |
+
+## Acceptance Criteria
+
+- [ ] C# sample project exists at `samples/csharp-sample-project/` with 5-8 `.cs` files.
+- [ ] Sample project covers: namespaces, classes, interfaces, records, enums, methods, properties, generics, using statements, XML doc comments, nested types, async patterns.
+- [ ] Sample project contains ~50-100 symbols.
+- [ ] All C# integration tests use real components — no mocks.
+- [ ] Index test verifies correct file and symbol counts for the C# sample.
+- [ ] `project_outline` shows C# symbols with correct kinds and signatures.
+- [ ] `get_symbol` retrieves C# source code accurately.
+- [ ] `search_symbols` finds C# symbols by name.
+- [ ] `dependency_graph` reflects using statement relationships.
+- [ ] Mixed-language tests verify both parsers contribute symbols in a shared project.
+- [ ] Parser selection by file extension is correct (no `.cs` files parsed by Luau parser or vice versa).
+- [ ] `dotnet build CodeCompress.slnx` succeeds with zero warnings.
+- [ ] All tests pass via `dotnet test tests/CodeCompress.Integration.Tests`.
+
+## Files to Create/Modify
+
+### Create
+
+| File | Description |
+|---|---|
+| `samples/csharp-sample-project/Models/Player.cs` | Record with properties |
+| `samples/csharp-sample-project/Models/Inventory.cs` | Class with nested enum |
+| `samples/csharp-sample-project/Models/GameEvent.cs` | Abstract class, generics, interfaces |
+| `samples/csharp-sample-project/Services/ICombatService.cs` | Interface with method signatures |
+| `samples/csharp-sample-project/Services/CombatService.cs` | Service implementation with async methods |
+| `samples/csharp-sample-project/Services/InventoryService.cs` | Service with extension methods |
+| `samples/csharp-sample-project/Handlers/GameHandler.cs` | Handler with attributes and complex signatures |
+| `samples/csharp-sample-project/Enums/GameState.cs` | Enum with underlying type |
+| `tests/CodeCompress.Integration.Tests/CSharpEndToEndTests.cs` | C# parser integration tests |
+| `tests/CodeCompress.Integration.Tests/MixedLanguageTests.cs` | Mixed-language integration tests |
+
+### Modify
+
+| File | Description |
+|---|---|
+| `tests/CodeCompress.Integration.Tests/CodeCompress.Integration.Tests.csproj` | Ensure project references to Core and Server are present |
+
+## Out of Scope
+
+- C# project file parsing (`.csproj`) — only source files are indexed.
+- NuGet dependency resolution — using statements are the dependency signal, not package references.
+- Generated files (`*.g.cs`, `*.designer.cs`) — not explicitly excluded but not specifically tested.
+- Solution-level indexing (multiple C# projects) — each project is indexed independently.
+
+## Notes / Decisions
+
+1. **Sample project without `.csproj`.** The sample C# files are standalone — they do not need to compile as a real .NET project. They are test fixtures for the parser, not build targets. This avoids needing a second SDK or build step.
+2. **Mixed-language tests.** These are critical for verifying the `IndexEngine`'s parser dispatch logic — it must correctly select the parser based on file extension. A `.cs` file must go to `CSharpParser` and a `.luau` file to `LuauParser`, with no interference.
+3. **Using statements as dependency graph edges.** The C# dependency graph will be namespace-based rather than file-based. This is less precise than Luau's `require()` but still useful for understanding project structure. A file that has `using MyApp.Services;` depends on the namespace `MyApp.Services`.
+4. **Symbol count stability.** As with the Luau integration tests, exact symbol counts in assertions serve as regression guards. If the parser changes behavior, these tests catch it immediately.

--- a/docs/13-ci-cd-and-distribution/001-github-actions-ci.md
+++ b/docs/13-ci-cd-and-distribution/001-github-actions-ci.md
@@ -1,0 +1,105 @@
+# 001 — GitHub Actions CI Workflow
+
+## Summary
+
+Automated continuous integration pipeline that builds the solution, runs all tests across multiple platforms, and enforces zero-warning compilation. Triggered on every push to `main` and on all pull requests. Ensures the codebase stays green with SonarAnalyzer static analysis enforced at build time.
+
+## Dependencies
+
+- **All features** — CI runs the full `dotnet build` + `dotnet test` across the entire solution, so all projects must be present and buildable.
+
+## Scope
+
+### 1. CI Workflow (`.github/workflows/ci.yml`)
+
+| Aspect | Detail |
+|---|---|
+| Trigger | `push` to `main` branch; `pull_request` targeting `main` |
+| Matrix | `ubuntu-latest` (primary), `windows-latest`, `macos-latest` |
+| .NET SDK | `10.0.x` (matching `global.json` constraint) |
+| Fail-fast | `false` — run all matrix entries even if one fails |
+
+### 2. Workflow Steps
+
+| Step | Command/Action | Notes |
+|---|---|---|
+| Checkout | `actions/checkout@v4` | Full clone for accurate diffs |
+| Setup .NET | `actions/setup-dotnet@v4` with `dotnet-version: '10.0.x'` | Matches `global.json` rollForward: latestFeature |
+| Restore | `dotnet restore CodeCompress.slnx` | Restore NuGet packages |
+| Build | `dotnet build CodeCompress.slnx --no-restore -c Release` | `TreatWarningsAsErrors` ensures zero warnings = zero SonarAnalyzer violations |
+| Test | `dotnet test CodeCompress.slnx --no-build -c Release --logger "trx;LogFileName=results.trx" --results-directory ./test-results` | TRX format for artifact upload |
+| Upload test results | `actions/upload-artifact@v4` with `path: ./test-results/*.trx` | Available for download on failed runs |
+
+### 3. Zero-Warning Enforcement
+
+The solution's `Directory.Build.props` sets `TreatWarningsAsErrors=true` and `AnalysisLevel=latest-all` with `SonarAnalyzer.CSharp`. This means the `dotnet build` step will fail if any analyzer warning is produced. No additional static analysis step is needed — it is built into compilation.
+
+### 4. Optional Code Coverage
+
+| Aspect | Detail |
+|---|---|
+| Collection | `dotnet test` with `--collect:"XPlat Code Coverage"` and `coverlet.collector` |
+| Report | `reportgenerator` tool to produce HTML/Cobertura summary |
+| Upload | Upload coverage report as artifact; optionally publish to Codecov or similar |
+| Thresholds | Not enforced in CI for MVP — targets are documented in CLAUDE.md |
+
+Coverage collection is a stretch goal — the workflow should work without it and can be added later.
+
+### 5. Status Badge
+
+Add a CI status badge to the repository's README (if one exists):
+
+```markdown
+![CI](https://github.com/{owner}/{repo}/actions/workflows/ci.yml/badge.svg)
+```
+
+### 6. Workflow Validation
+
+The YAML file should be validated for correctness. Options:
+- Use `actionlint` locally before committing.
+- Manual review against GitHub Actions documentation.
+- Push to a branch and verify the workflow runs.
+
+## Acceptance Criteria
+
+- [ ] `.github/workflows/ci.yml` exists and is valid GitHub Actions YAML.
+- [ ] Workflow triggers on push to `main` and on pull requests targeting `main`.
+- [ ] Matrix includes `ubuntu-latest`, `windows-latest`, and `macos-latest`.
+- [ ] .NET 10 SDK is set up correctly.
+- [ ] `dotnet restore`, `dotnet build`, and `dotnet test` steps execute in order.
+- [ ] Build uses `-c Release` and `--no-restore` for efficiency.
+- [ ] Test results are saved in TRX format and uploaded as artifacts.
+- [ ] Build step fails on any compiler or analyzer warning (via existing `TreatWarningsAsErrors`).
+- [ ] Workflow passes on a clean build with all tests green.
+- [ ] `fail-fast: false` ensures all matrix entries run even if one fails.
+
+## Files to Create/Modify
+
+### Create
+
+| File | Description |
+|---|---|
+| `.github/workflows/ci.yml` | GitHub Actions CI workflow definition |
+
+### Modify
+
+| File | Description |
+|---|---|
+| `README.md` | Add CI status badge (if README exists) |
+
+## Out of Scope
+
+- Release workflow (covered in 13-002).
+- Deployment to any hosting environment — CodeCompress is a local tool.
+- Docker image building — not needed for a dotnet tool.
+- Branch protection rules — those are configured in GitHub settings, not in workflow files.
+- Dependabot or Renovate configuration for dependency updates.
+- Performance or benchmarking CI steps.
+
+## Notes / Decisions
+
+1. **Matrix strategy.** Running on all three major platforms ensures cross-platform compatibility. The `macos-latest` runner may be slower or have limited .NET 10 support initially — it can be removed from the matrix if it causes issues.
+2. **No separate linting step.** SonarAnalyzer runs during `dotnet build` and `TreatWarningsAsErrors` enforces zero violations. This is simpler and faster than a separate analysis step.
+3. **TRX test results.** The TRX format is natively supported by .NET and can be viewed in Visual Studio or converted to other formats. Uploading as artifacts allows debugging failed CI runs.
+4. **No caching.** NuGet package caching via `actions/cache` could speed up CI but adds complexity. For MVP, the `dotnet restore` step runs fresh each time. Caching can be added if CI times become a problem.
+5. **.NET 10 availability.** As of the project's target date, .NET 10 may still be in preview. The `setup-dotnet` action supports preview versions via `include-prerelease: true` if needed.

--- a/docs/13-ci-cd-and-distribution/002-release-workflow.md
+++ b/docs/13-ci-cd-and-distribution/002-release-workflow.md
@@ -1,0 +1,143 @@
+# 002 — Release Workflow and dotnet Tool Packaging
+
+## Summary
+
+Automated release pipeline triggered by version tags that builds, tests, packs the CLI as a `dotnet tool`, and publishes to NuGet. Also covers the CLI project's packaging configuration and a basic command-line interface that exposes the same functionality as the MCP server tools via console commands.
+
+## Dependencies
+
+- **Feature 07** — MCP server host and DI registration pattern (reused by CLI).
+- **Feature 13-001** — CI workflow (release workflow extends the CI pattern).
+- **All core features** — The CLI exercises all core functionality.
+
+## Scope
+
+### 1. Release Workflow (`.github/workflows/release.yml`)
+
+| Aspect | Detail |
+|---|---|
+| Trigger | `push` with tag matching `v*` (e.g., `v1.0.0`, `v0.1.0-preview.1`) |
+| Runner | `ubuntu-latest` (single platform — the package is platform-independent) |
+| .NET SDK | `10.0.x` |
+
+### 2. Release Workflow Steps
+
+| Step | Command/Action | Notes |
+|---|---|---|
+| Checkout | `actions/checkout@v4` | |
+| Setup .NET | `actions/setup-dotnet@v4` with `dotnet-version: '10.0.x'` | |
+| Restore | `dotnet restore CodeCompress.slnx` | |
+| Build | `dotnet build CodeCompress.slnx --no-restore -c Release` | Zero warnings enforced |
+| Test | `dotnet test CodeCompress.slnx --no-build -c Release` | All tests must pass before publishing |
+| Determine version | Extract version from tag: `echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV` | Tag `v1.0.0` → version `1.0.0` |
+| Pack | `dotnet pack src/CodeCompress.Cli/CodeCompress.Cli.csproj -c Release -o ./nupkg /p:Version=$VERSION` | Produces `.nupkg` |
+| Publish to NuGet | `dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json` | Requires `NUGET_API_KEY` secret |
+| Create GitHub Release | `gh release create ${{ github.ref_name }} ./nupkg/*.nupkg --generate-notes` | Attaches nupkg as release asset |
+
+### 3. CLI Project Packaging (`src/CodeCompress.Cli/CodeCompress.Cli.csproj`)
+
+Add the following properties to enable `dotnet tool` packaging:
+
+| Property | Value | Purpose |
+|---|---|---|
+| `PackAsTool` | `true` | Marks project as a dotnet tool |
+| `ToolCommandName` | `codecompress` | CLI command name after `dotnet tool install` |
+| `PackageId` | `CodeCompress` | NuGet package identifier |
+| `Description` | `CLI tool for indexing codebases and querying code symbols with compressed, token-efficient output` | NuGet description |
+| `Authors` | Project authors | |
+| `License` | `MIT` | Matches repository license |
+| `PackageProjectUrl` | Repository URL | |
+| `RepositoryUrl` | Repository URL | |
+| `PackageReadmeFile` | `README.md` (if included in package) | |
+| `PackageTags` | `code-index;mcp;ai;codebase;symbols` | Discoverability |
+
+### 4. CLI Program.cs (`src/CodeCompress.Cli/Program.cs`)
+
+A command-line interface that exercises the same core services as the MCP server but with console output instead of MCP protocol. Uses the same DI setup.
+
+| Command | Description | Maps to MCP Tool |
+|---|---|---|
+| `codecompress index <path>` | Index a project directory | `index_project` |
+| `codecompress outline <path>` | Show project outline | `project_outline` |
+| `codecompress get-symbol <path> <name>` | Retrieve a specific symbol | `get_symbol` |
+| `codecompress search <path> <query>` | Search symbols by name | `search_symbols` |
+| `codecompress search-text <path> <query>` | Full-text search in files | `search_text` |
+| `codecompress changes <path> <label>` | Show changes since snapshot | `changes_since` |
+| `codecompress snapshot <path> [label]` | Create a snapshot | `snapshot_create` |
+| `codecompress file-tree <path>` | Show annotated file tree | `file_tree` |
+| `codecompress deps <path> [file]` | Show dependency graph | `dependency_graph` |
+
+Command-line parsing: Use `System.CommandLine` library or simple manual `args` parsing. Each command creates a service collection, resolves the needed services, calls the core logic, and prints results to stdout.
+
+### 5. DI Setup for CLI
+
+Reuse the same service registrations as the MCP server (extract a shared `ServiceRegistration` class or extension method):
+
+```csharp
+services.AddSingleton<ILanguageParser, LuauParser>();
+services.AddSingleton<ILanguageParser, CSharpParser>();
+services.AddSingleton<IndexEngine>();
+services.AddSingleton<SymbolStore>();
+services.AddSingleton<SqliteConnectionFactory>();
+services.AddSingleton<FileHasher>();
+services.AddSingleton<ChangeTracker>();
+services.AddSingleton<PathValidator>();
+```
+
+### 6. Tests
+
+| Test | Description | Location |
+|---|---|---|
+| CliPackage_HasCorrectMetadata | Verify `.csproj` has `PackAsTool`, `ToolCommandName`, required metadata | `tests/CodeCompress.Cli.Tests/` or manual |
+| CliBuilds_InReleaseConfiguration | `dotnet build -c Release` succeeds for CLI project | CI workflow |
+| CliPack_ProducesNupkg | `dotnet pack` produces a valid `.nupkg` | CI workflow or test |
+| ReleaseWorkflow_YamlValid | Release workflow YAML is syntactically valid | Manual or actionlint |
+
+## Acceptance Criteria
+
+- [ ] `.github/workflows/release.yml` exists and is valid GitHub Actions YAML.
+- [ ] Release workflow triggers on `v*` tag push.
+- [ ] Workflow runs build and tests before packing/publishing.
+- [ ] Version is extracted from the git tag and applied to the package.
+- [ ] `dotnet pack` produces a valid `.nupkg` for the CLI tool.
+- [ ] Package is published to NuGet via `dotnet nuget push` with API key secret.
+- [ ] GitHub Release is created with the nupkg attached.
+- [ ] `CodeCompress.Cli.csproj` has `PackAsTool=true` and `ToolCommandName=codecompress`.
+- [ ] Package metadata (description, license, tags, URLs) is populated.
+- [ ] CLI `Program.cs` provides commands for all major operations (index, outline, get-symbol, search, changes, snapshot, file-tree, deps).
+- [ ] CLI reuses the same DI service registrations as the MCP server.
+- [ ] `dotnet build CodeCompress.slnx` succeeds with zero warnings.
+- [ ] `dotnet tool install --global` works from the produced nupkg (manual verification).
+
+## Files to Create/Modify
+
+### Create
+
+| File | Description |
+|---|---|
+| `.github/workflows/release.yml` | GitHub Actions release workflow |
+
+### Modify
+
+| File | Description |
+|---|---|
+| `src/CodeCompress.Cli/CodeCompress.Cli.csproj` | Add `PackAsTool`, `ToolCommandName`, package metadata properties |
+| `src/CodeCompress.Cli/Program.cs` | Implement CLI commands with DI and console output |
+| `src/CodeCompress.Server/Program.cs` | Extract shared service registration to a common method (optional — could also duplicate) |
+
+## Out of Scope
+
+- Publishing to a private NuGet feed — public NuGet.org only.
+- Homebrew, APT, or Chocolatey packages — NuGet dotnet tool only for MVP.
+- Auto-versioning from commit history (GitVersion, Nerdbank.GitVersioning) — version comes from the tag.
+- Signed NuGet packages — not required for MVP.
+- Platform-specific native builds (self-contained, trimmed, AOT) — the dotnet tool requires the .NET runtime.
+- Changelog generation — GitHub's `--generate-notes` provides basic release notes.
+
+## Notes / Decisions
+
+1. **Shared service registration.** Extracting DI registrations into a shared extension method (`IServiceCollection.AddCodeCompressCore()`) avoids duplication between `Server/Program.cs` and `Cli/Program.cs`. This could live in `CodeCompress.Core` as an extension. However, if the CLI's needs diverge (e.g., different logging), keeping them separate is also acceptable.
+2. **System.CommandLine vs. manual parsing.** `System.CommandLine` provides argument parsing, help text, and tab completion for free. However, it adds a dependency. For MVP, simple manual `args` parsing with a `switch` statement is sufficient. `System.CommandLine` can be adopted later if the CLI grows.
+3. **NuGet API key security.** The `NUGET_API_KEY` must be stored as a GitHub Actions secret. The release workflow uses `${{ secrets.NUGET_API_KEY }}` — it is never logged or exposed.
+4. **Tag-based versioning.** The tag `v1.0.0` becomes version `1.0.0` in the package. Pre-release versions use tags like `v0.1.0-preview.1`. This is simple and explicit — no magic versioning tools needed.
+5. **Single-platform release.** The dotnet tool is platform-independent (it is a NuGet package containing managed assemblies). Building on `ubuntu-latest` only is sufficient for the release workflow. The CI workflow already verifies cross-platform compatibility.


### PR DESCRIPTION
## Summary
- Break the PRD into 13 dependency-ordered features with 25 scoped mini-plan documents for incremental implementation
- Add README.md with project overview, installation, usage, and MCP tool reference
- Update CLAUDE.md and all docs to use `.slnx` format (new .NET 10 default instead of `.sln`)

## Features Covered
1. Project Scaffold (2 plans)
2. Core Models & Interfaces (1 plan)
3. SQLite Storage Layer (3 plans)
4. Path Validation (1 plan)
5. Luau Parser (2 plans)
6. Index Engine (3 plans)
7. MCP Server & Indexing Tools (2 plans)
8. Query Tools (3 plans)
9. Delta Tools (1 plan)
10. Dependency Tools (1 plan)
11. Integration Tests & Samples (1 plan)
12. C# Parser (3 plans)
13. CI/CD & Distribution (2 plans)

## Test plan
- [x] All markdown files render correctly
- [x] Feature ordering is dependency-correct (each feature only depends on prior features)
- [x] All `.sln` references updated to `.slnx` (except PRD reference doc)
- [x] No broken cross-references between plans

🤖 Generated with [Claude Code](https://claude.com/claude-code)