### PR TITLE
Add core models, enums, and ILanguageParser interface

### DIFF
--- a/src/CodeCompress.Core/Models/DependencyInfo.cs
+++ b/src/CodeCompress.Core/Models/DependencyInfo.cs
@@ -1,0 +1,5 @@
+namespace CodeCompress.Core.Models;
+
+public sealed record DependencyInfo(
+    string RequirePath,
+    string? Alias);

--- a/src/CodeCompress.Core/Models/ParseResult.cs
+++ b/src/CodeCompress.Core/Models/ParseResult.cs
@@ -1,0 +1,5 @@
+namespace CodeCompress.Core.Models;
+
+public sealed record ParseResult(
+    IReadOnlyList<SymbolInfo> Symbols,
+    IReadOnlyList<DependencyInfo> Dependencies);

--- a/src/CodeCompress.Core/Models/SymbolInfo.cs
+++ b/src/CodeCompress.Core/Models/SymbolInfo.cs
@@ -1,0 +1,13 @@
+namespace CodeCompress.Core.Models;
+
+public sealed record SymbolInfo(
+    string Name,
+    SymbolKind Kind,
+    string Signature,
+    string? ParentSymbol,
+    int ByteOffset,
+    int ByteLength,
+    int LineStart,
+    int LineEnd,
+    Visibility Visibility,
+    string? DocComment);

--- a/src/CodeCompress.Core/Models/SymbolKind.cs
+++ b/src/CodeCompress.Core/Models/SymbolKind.cs
@@ -1,0 +1,13 @@
+namespace CodeCompress.Core.Models;
+
+public enum SymbolKind
+{
+    Function,
+    Method,
+    Type,
+    Class,
+    Interface,
+    Export,
+    Constant,
+    Module
+}

--- a/src/CodeCompress.Core/Models/Visibility.cs
+++ b/src/CodeCompress.Core/Models/Visibility.cs
@@ -1,0 +1,8 @@
+namespace CodeCompress.Core.Models;
+
+public enum Visibility
+{
+    Public,
+    Private,
+    Local
+}

--- a/src/CodeCompress.Core/Parsers/ILanguageParser.cs
+++ b/src/CodeCompress.Core/Parsers/ILanguageParser.cs
@@ -1,0 +1,10 @@
+using CodeCompress.Core.Models;
+
+namespace CodeCompress.Core.Parsers;
+
+public interface ILanguageParser
+{
+    public string LanguageId { get; }
+    public IReadOnlyList<string> FileExtensions { get; }
+    public ParseResult Parse(string filePath, ReadOnlySpan<byte> content);
+}

--- a/src/CodeCompress.Core/Placeholder.cs
+++ b/src/CodeCompress.Core/Placeholder.cs
@@ -1,9 +1,0 @@
-namespace CodeCompress.Core;
-
-/// <summary>
-/// Placeholder to allow empty project to compile. Remove when real types are added.
-/// </summary>
-internal static class Placeholder
-{
-    internal const string ProjectName = "CodeCompress.Core";
-}

--- a/tests/CodeCompress.Core.Tests/Models/DependencyInfoTests.cs
+++ b/tests/CodeCompress.Core.Tests/Models/DependencyInfoTests.cs
@@ -1,0 +1,46 @@
+using CodeCompress.Core.Models;
+
+namespace CodeCompress.Core.Tests.Models;
+
+internal sealed class DependencyInfoTests
+{
+    [Test]
+    public async Task ConstructionWithAliasSetsPropertiesCorrectly()
+    {
+        var dependency = new DependencyInfo(
+            RequirePath: "game/ReplicatedStorage/Utils",
+            Alias: "Utils");
+
+        await Assert.That(dependency.RequirePath).IsEqualTo("game/ReplicatedStorage/Utils");
+        await Assert.That(dependency.Alias).IsEqualTo("Utils");
+    }
+
+    [Test]
+    public async Task ConstructionWithNullAliasAllowsNull()
+    {
+        var dependency = new DependencyInfo(
+            RequirePath: "game/ServerScriptService/Main",
+            Alias: null);
+
+        await Assert.That(dependency.RequirePath).IsEqualTo("game/ServerScriptService/Main");
+        await Assert.That(dependency.Alias).IsNull();
+    }
+
+    [Test]
+    public async Task EqualityIdenticalInstancesAreEqual()
+    {
+        var dep1 = new DependencyInfo("path/to/module", "Mod");
+        var dep2 = new DependencyInfo("path/to/module", "Mod");
+
+        await Assert.That(dep1).IsEqualTo(dep2);
+    }
+
+    [Test]
+    public async Task EqualityDifferentRequirePathAreNotEqual()
+    {
+        var dep1 = new DependencyInfo("path/to/moduleA", "Mod");
+        var dep2 = new DependencyInfo("path/to/moduleB", "Mod");
+
+        await Assert.That(dep1).IsNotEqualTo(dep2);
+    }
+}

--- a/tests/CodeCompress.Core.Tests/Models/ParseResultTests.cs
+++ b/tests/CodeCompress.Core.Tests/Models/ParseResultTests.cs
@@ -1,0 +1,81 @@
+using CodeCompress.Core.Models;
+
+namespace CodeCompress.Core.Tests.Models;
+
+internal sealed class ParseResultTests
+{
+    [Test]
+    public async Task ConstructionWithEmptyListsCreatesValidInstance()
+    {
+        var result = new ParseResult(
+            Symbols: [],
+            Dependencies: []);
+
+        await Assert.That(result.Symbols).Count().IsEqualTo(0);
+        await Assert.That(result.Dependencies).Count().IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ConstructionWithPopulatedListsContainsExpectedItems()
+    {
+        var symbol = CreateSampleSymbol("Init", SymbolKind.Function);
+        var dependency = new DependencyInfo("game/ReplicatedStorage/Config", "Config");
+
+        var result = new ParseResult(
+            Symbols: [symbol],
+            Dependencies: [dependency]);
+
+        await Assert.That(result.Symbols).Count().IsEqualTo(1);
+        await Assert.That(result.Dependencies).Count().IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task SymbolsContainsCorrectSymbolInfo()
+    {
+        var symbol = CreateSampleSymbol("Calculate", SymbolKind.Method);
+        var result = new ParseResult(Symbols: [symbol], Dependencies: []);
+
+        await Assert.That(result.Symbols[0].Name).IsEqualTo("Calculate");
+        await Assert.That(result.Symbols[0].Kind).IsEqualTo(SymbolKind.Method);
+    }
+
+    [Test]
+    public async Task DependenciesContainsCorrectDependencyInfo()
+    {
+        var dependency = new DependencyInfo("shared/Utils", "Utils");
+        var result = new ParseResult(Symbols: [], Dependencies: [dependency]);
+
+        await Assert.That(result.Dependencies[0].RequirePath).IsEqualTo("shared/Utils");
+        await Assert.That(result.Dependencies[0].Alias).IsEqualTo("Utils");
+    }
+
+    [Test]
+    public async Task EqualitySameListInstancesAreEqual()
+    {
+        var symbol = CreateSampleSymbol("Run", SymbolKind.Function);
+        var dependency = new DependencyInfo("lib/Core", "Core");
+
+        IReadOnlyList<SymbolInfo> symbols = [symbol];
+        IReadOnlyList<DependencyInfo> dependencies = [dependency];
+
+        var result1 = new ParseResult(Symbols: symbols, Dependencies: dependencies);
+        var result2 = new ParseResult(Symbols: symbols, Dependencies: dependencies);
+
+        await Assert.That(result1).IsEqualTo(result2);
+    }
+
+    private static SymbolInfo CreateSampleSymbol(string name, SymbolKind kind)
+    {
+        return new SymbolInfo(
+            Name: name,
+            Kind: kind,
+            Signature: $"function {name}()",
+            ParentSymbol: null,
+            ByteOffset: 0,
+            ByteLength: 50,
+            LineStart: 1,
+            LineEnd: 5,
+            Visibility: Visibility.Public,
+            DocComment: null);
+    }
+}

--- a/tests/CodeCompress.Core.Tests/Models/SymbolInfoTests.cs
+++ b/tests/CodeCompress.Core.Tests/Models/SymbolInfoTests.cs
@@ -1,0 +1,98 @@
+using CodeCompress.Core.Models;
+
+namespace CodeCompress.Core.Tests.Models;
+
+internal sealed class SymbolInfoTests
+{
+    [Test]
+    public async Task ConstructionWithAllPropertiesSetsValuesCorrectly()
+    {
+        var symbol = new SymbolInfo(
+            Name: "DoWork",
+            Kind: SymbolKind.Method,
+            Signature: "public void DoWork(int count)",
+            ParentSymbol: "MyClass",
+            ByteOffset: 100,
+            ByteLength: 250,
+            LineStart: 10,
+            LineEnd: 20,
+            Visibility: Visibility.Public,
+            DocComment: "/// Does some work.");
+
+        await Assert.That(symbol.Name).IsEqualTo("DoWork");
+        await Assert.That(symbol.Kind).IsEqualTo(SymbolKind.Method);
+        await Assert.That(symbol.Signature).IsEqualTo("public void DoWork(int count)");
+        await Assert.That(symbol.ParentSymbol).IsEqualTo("MyClass");
+        await Assert.That(symbol.ByteOffset).IsEqualTo(100);
+        await Assert.That(symbol.ByteLength).IsEqualTo(250);
+        await Assert.That(symbol.LineStart).IsEqualTo(10);
+        await Assert.That(symbol.LineEnd).IsEqualTo(20);
+        await Assert.That(symbol.Visibility).IsEqualTo(Visibility.Public);
+        await Assert.That(symbol.DocComment).IsEqualTo("/// Does some work.");
+    }
+
+    [Test]
+    public async Task ConstructionWithNullOptionalPropertiesAllowsNulls()
+    {
+        var symbol = new SymbolInfo(
+            Name: "TopLevelFunction",
+            Kind: SymbolKind.Function,
+            Signature: "local function TopLevelFunction()",
+            ParentSymbol: null,
+            ByteOffset: 0,
+            ByteLength: 50,
+            LineStart: 1,
+            LineEnd: 5,
+            Visibility: Visibility.Local,
+            DocComment: null);
+
+        await Assert.That(symbol.ParentSymbol).IsNull();
+        await Assert.That(symbol.DocComment).IsNull();
+    }
+
+    [Test]
+    public async Task EqualityIdenticalInstancesAreEqual()
+    {
+        var symbol1 = CreateSampleSymbol();
+        var symbol2 = CreateSampleSymbol();
+
+        await Assert.That(symbol1).IsEqualTo(symbol2);
+    }
+
+    [Test]
+    public async Task EqualityDifferentNameAreNotEqual()
+    {
+        var symbol1 = CreateSampleSymbol();
+        var symbol2 = symbol1 with { Name = "DifferentName" };
+
+        await Assert.That(symbol1).IsNotEqualTo(symbol2);
+    }
+
+    [Test]
+    public async Task WithExpressionCreatesModifiedCopy()
+    {
+        var original = CreateSampleSymbol();
+        var modified = original with { Kind = SymbolKind.Class, LineEnd = 99 };
+
+        await Assert.That(modified.Name).IsEqualTo(original.Name);
+        await Assert.That(modified.Kind).IsEqualTo(SymbolKind.Class);
+        await Assert.That(modified.LineEnd).IsEqualTo(99);
+        await Assert.That(original.Kind).IsEqualTo(SymbolKind.Function);
+        await Assert.That(original.LineEnd).IsEqualTo(10);
+    }
+
+    private static SymbolInfo CreateSampleSymbol()
+    {
+        return new SymbolInfo(
+            Name: "SampleFunc",
+            Kind: SymbolKind.Function,
+            Signature: "function SampleFunc()",
+            ParentSymbol: "SampleModule",
+            ByteOffset: 0,
+            ByteLength: 100,
+            LineStart: 1,
+            LineEnd: 10,
+            Visibility: Visibility.Public,
+            DocComment: "A sample function.");
+    }
+}

--- a/tests/CodeCompress.Core.Tests/Models/SymbolKindTests.cs
+++ b/tests/CodeCompress.Core.Tests/Models/SymbolKindTests.cs
@@ -1,0 +1,30 @@
+using CodeCompress.Core.Models;
+
+namespace CodeCompress.Core.Tests.Models;
+
+internal sealed class SymbolKindTests
+{
+    [Test]
+    [Arguments(SymbolKind.Function, 0)]
+    [Arguments(SymbolKind.Method, 1)]
+    [Arguments(SymbolKind.Type, 2)]
+    [Arguments(SymbolKind.Class, 3)]
+    [Arguments(SymbolKind.Interface, 4)]
+    [Arguments(SymbolKind.Export, 5)]
+    [Arguments(SymbolKind.Constant, 6)]
+    [Arguments(SymbolKind.Module, 7)]
+    public async Task EnumMemberHasExpectedIntValue(SymbolKind kind, int expectedValue)
+    {
+        var actualValue = (int)kind;
+
+        await Assert.That(actualValue).IsEqualTo(expectedValue);
+    }
+
+    [Test]
+    public async Task GetValuesReturnsExactlyEightMembers()
+    {
+        var values = Enum.GetValues<SymbolKind>();
+
+        await Assert.That(values).Count().IsEqualTo(8);
+    }
+}

--- a/tests/CodeCompress.Core.Tests/Models/VisibilityTests.cs
+++ b/tests/CodeCompress.Core.Tests/Models/VisibilityTests.cs
@@ -1,0 +1,25 @@
+using CodeCompress.Core.Models;
+
+namespace CodeCompress.Core.Tests.Models;
+
+internal sealed class VisibilityTests
+{
+    [Test]
+    [Arguments(Visibility.Public, 0)]
+    [Arguments(Visibility.Private, 1)]
+    [Arguments(Visibility.Local, 2)]
+    public async Task EnumMemberHasExpectedIntValue(Visibility visibility, int expectedValue)
+    {
+        var actualValue = (int)visibility;
+
+        await Assert.That(actualValue).IsEqualTo(expectedValue);
+    }
+
+    [Test]
+    public async Task GetValuesReturnsExactlyThreeMembers()
+    {
+        var values = Enum.GetValues<Visibility>();
+
+        await Assert.That(values).Count().IsEqualTo(3);
+    }
+}

--- a/tests/CodeCompress.Core.Tests/Placeholder.cs
+++ b/tests/CodeCompress.Core.Tests/Placeholder.cs
@@ -1,9 +1,0 @@
-namespace CodeCompress.Core.Tests;
-
-/// <summary>
-/// Placeholder to allow empty test project to compile. Remove when real tests are added.
-/// </summary>
-internal static class Placeholder
-{
-    internal const string ProjectName = "CodeCompress.Core.Tests";
-}


### PR DESCRIPTION
## Summary
- Implements mini-plan 02-001: core models and interfaces
- Defines all foundational types for the CodeCompress pipeline: enums (`SymbolKind`, `Visibility`), records (`SymbolInfo`, `DependencyInfo`, `ParseResult`), and the `ILanguageParser` interface
- 27 TUnit tests covering construction, property access, equality, inequality, nullability, and `with` expressions

## Test plan
- [x] `dotnet build CodeCompress.slnx` — zero warnings
- [x] `dotnet test --solution CodeCompress.slnx` — 27 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)