### PR TITLE
Add SQLite storage layer: connection factory, CRUD, and queries

### DIFF
--- a/src/CodeCompress.Core/Models/ChangedFilesResult.cs
+++ b/src/CodeCompress.Core/Models/ChangedFilesResult.cs
@@ -1,0 +1,6 @@
+namespace CodeCompress.Core.Models;
+
+public sealed record ChangedFilesResult(
+    IReadOnlyList<FileRecord> Added,
+    IReadOnlyList<FileRecord> Modified,
+    IReadOnlyList<string> Removed);

--- a/src/CodeCompress.Core/Models/Dependency.cs
+++ b/src/CodeCompress.Core/Models/Dependency.cs
@@ -1,0 +1,8 @@
+namespace CodeCompress.Core.Models;
+
+public sealed record Dependency(
+    long Id,
+    long FileId,
+    string RequiresPath,
+    long? ResolvedFileId,
+    string? Alias);

--- a/src/CodeCompress.Core/Models/DependencyEdge.cs
+++ b/src/CodeCompress.Core/Models/DependencyEdge.cs
@@ -1,0 +1,6 @@
+namespace CodeCompress.Core.Models;
+
+public sealed record DependencyEdge(
+    string From,
+    string To,
+    string? Alias);

--- a/src/CodeCompress.Core/Models/DependencyGraph.cs
+++ b/src/CodeCompress.Core/Models/DependencyGraph.cs
@@ -1,0 +1,5 @@
+namespace CodeCompress.Core.Models;
+
+public sealed record DependencyGraph(
+    IReadOnlyList<string> Nodes,
+    IReadOnlyList<DependencyEdge> Edges);

--- a/src/CodeCompress.Core/Models/FileRecord.cs
+++ b/src/CodeCompress.Core/Models/FileRecord.cs
@@ -1,0 +1,11 @@
+namespace CodeCompress.Core.Models;
+
+public sealed record FileRecord(
+    long Id,
+    string RepoId,
+    string RelativePath,
+    string ContentHash,
+    long ByteLength,
+    int LineCount,
+    long LastModified,
+    long IndexedAt);

--- a/src/CodeCompress.Core/Models/IndexSnapshot.cs
+++ b/src/CodeCompress.Core/Models/IndexSnapshot.cs
@@ -1,0 +1,8 @@
+namespace CodeCompress.Core.Models;
+
+public sealed record IndexSnapshot(
+    long Id,
+    string RepoId,
+    string SnapshotLabel,
+    long CreatedAt,
+    string FileHashes);

--- a/src/CodeCompress.Core/Models/ModuleApi.cs
+++ b/src/CodeCompress.Core/Models/ModuleApi.cs
@@ -1,0 +1,6 @@
+namespace CodeCompress.Core.Models;
+
+public sealed record ModuleApi(
+    FileRecord File,
+    IReadOnlyList<Symbol> Symbols,
+    IReadOnlyList<Dependency> Dependencies);

--- a/src/CodeCompress.Core/Models/OutlineGroup.cs
+++ b/src/CodeCompress.Core/Models/OutlineGroup.cs
@@ -1,0 +1,6 @@
+namespace CodeCompress.Core.Models;
+
+public sealed record OutlineGroup(
+    string Name,
+    IReadOnlyList<Symbol> Symbols,
+    IReadOnlyList<OutlineGroup> Children);

--- a/src/CodeCompress.Core/Models/ProjectOutline.cs
+++ b/src/CodeCompress.Core/Models/ProjectOutline.cs
@@ -1,0 +1,5 @@
+namespace CodeCompress.Core.Models;
+
+public sealed record ProjectOutline(
+    string RepoId,
+    IReadOnlyList<OutlineGroup> Groups);

--- a/src/CodeCompress.Core/Models/Repository.cs
+++ b/src/CodeCompress.Core/Models/Repository.cs
@@ -1,0 +1,10 @@
+namespace CodeCompress.Core.Models;
+
+public sealed record Repository(
+    string Id,
+    string RootPath,
+    string Name,
+    string Language,
+    long LastIndexed,
+    int FileCount,
+    int SymbolCount);

--- a/src/CodeCompress.Core/Models/Symbol.cs
+++ b/src/CodeCompress.Core/Models/Symbol.cs
@@ -1,0 +1,15 @@
+namespace CodeCompress.Core.Models;
+
+public sealed record Symbol(
+    long Id,
+    long FileId,
+    string Name,
+    string Kind,
+    string Signature,
+    string? ParentSymbol,
+    int ByteOffset,
+    int ByteLength,
+    int LineStart,
+    int LineEnd,
+    string Visibility,
+    string? DocComment);

--- a/src/CodeCompress.Core/Models/SymbolSearchResult.cs
+++ b/src/CodeCompress.Core/Models/SymbolSearchResult.cs
@@ -1,0 +1,6 @@
+namespace CodeCompress.Core.Models;
+
+public sealed record SymbolSearchResult(
+    Symbol Symbol,
+    string FilePath,
+    double Rank);

--- a/src/CodeCompress.Core/Models/TextSearchResult.cs
+++ b/src/CodeCompress.Core/Models/TextSearchResult.cs
@@ -1,0 +1,6 @@
+namespace CodeCompress.Core.Models;
+
+public sealed record TextSearchResult(
+    string FilePath,
+    string Snippet,
+    double Rank);

--- a/src/CodeCompress.Core/Properties/AssemblyInfo.cs
+++ b/src/CodeCompress.Core/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("CodeCompress.Core.Tests")]

--- a/src/CodeCompress.Core/Storage/Fts5Sanitizer.cs
+++ b/src/CodeCompress.Core/Storage/Fts5Sanitizer.cs
@@ -1,0 +1,50 @@
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace CodeCompress.Core.Storage;
+
+public static partial class Fts5Sanitizer
+{
+    [GeneratedRegex(@"[*""()+\-^:{}\\]", RegexOptions.Compiled)]
+    private static partial Regex SpecialCharsPattern();
+
+    public static string Sanitize(string? rawQuery)
+    {
+        if (string.IsNullOrWhiteSpace(rawQuery))
+        {
+            return string.Empty;
+        }
+
+        // 1. Strip special FTS5 characters
+        var cleaned = SpecialCharsPattern().Replace(rawQuery, " ");
+
+        // 2. Split into terms
+        var terms = cleaned.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        if (terms.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        // 3. Quote each term — wrapping in double quotes makes FTS5 treat them as literals,
+        //    which neutralizes operators like AND, OR, NOT, NEAR
+        var builder = new StringBuilder();
+        for (int i = 0; i < terms.Length; i++)
+        {
+            if (i > 0)
+            {
+                builder.Append(' ');
+            }
+
+            var term = terms[i].Replace("\"", "", StringComparison.Ordinal);
+            if (term.Length > 0)
+            {
+                builder.Append('"');
+                builder.Append(term);
+                builder.Append('"');
+            }
+        }
+
+        return builder.ToString();
+    }
+}

--- a/src/CodeCompress.Core/Storage/IConnectionFactory.cs
+++ b/src/CodeCompress.Core/Storage/IConnectionFactory.cs
@@ -1,0 +1,8 @@
+using Microsoft.Data.Sqlite;
+
+namespace CodeCompress.Core.Storage;
+
+public interface IConnectionFactory
+{
+    public Task<SqliteConnection> CreateConnectionAsync(string projectRootPath);
+}

--- a/src/CodeCompress.Core/Storage/ISymbolStore.cs
+++ b/src/CodeCompress.Core/Storage/ISymbolStore.cs
@@ -1,0 +1,33 @@
+using CodeCompress.Core.Models;
+
+namespace CodeCompress.Core.Storage;
+
+public interface ISymbolStore
+{
+    // Repository
+    public Task UpsertRepositoryAsync(Repository repo);
+    public Task<Repository?> GetRepositoryAsync(string repoId);
+    public Task DeleteRepositoryAsync(string repoId);
+
+    // Files
+    public Task InsertFilesAsync(IReadOnlyList<FileRecord> files);
+    public Task<IReadOnlyList<FileRecord>> GetFilesByRepoAsync(string repoId);
+    public Task<FileRecord?> GetFileByPathAsync(string repoId, string relativePath);
+    public Task UpdateFileAsync(FileRecord file);
+    public Task DeleteFileAsync(long fileId);
+
+    // Symbols
+    public Task InsertSymbolsAsync(IReadOnlyList<Symbol> symbols);
+    public Task<IReadOnlyList<Symbol>> GetSymbolsByFileAsync(long fileId);
+    public Task DeleteSymbolsByFileAsync(long fileId);
+
+    // Dependencies
+    public Task InsertDependenciesAsync(IReadOnlyList<Dependency> deps);
+    public Task<IReadOnlyList<Dependency>> GetDependenciesByFileAsync(long fileId);
+    public Task DeleteDependenciesByFileAsync(long fileId);
+
+    // Snapshots
+    public Task<long> CreateSnapshotAsync(IndexSnapshot snapshot);
+    public Task<IndexSnapshot?> GetSnapshotAsync(long snapshotId);
+    public Task<IReadOnlyList<IndexSnapshot>> GetSnapshotsByRepoAsync(string repoId);
+}

--- a/src/CodeCompress.Core/Storage/ISymbolStore.cs
+++ b/src/CodeCompress.Core/Storage/ISymbolStore.cs
@@ -30,4 +30,18 @@ public interface ISymbolStore
     public Task<long> CreateSnapshotAsync(IndexSnapshot snapshot);
     public Task<IndexSnapshot?> GetSnapshotAsync(long snapshotId);
     public Task<IReadOnlyList<IndexSnapshot>> GetSnapshotsByRepoAsync(string repoId);
+
+    // Search
+    public Task<IReadOnlyList<SymbolSearchResult>> SearchSymbolsAsync(string repoId, string query, string? kind, int limit);
+    public Task<IReadOnlyList<TextSearchResult>> SearchTextAsync(string repoId, string query, string? glob, int limit);
+
+    // Lookups
+    public Task<Symbol?> GetSymbolByNameAsync(string repoId, string symbolName);
+    public Task<IReadOnlyList<Symbol>> GetSymbolsByNamesAsync(string repoId, IReadOnlyList<string> symbolNames);
+
+    // Aggregation
+    public Task<ProjectOutline> GetProjectOutlineAsync(string repoId, bool includePrivate, string groupBy, int maxDepth);
+    public Task<ModuleApi> GetModuleApiAsync(string repoId, string filePath);
+    public Task<DependencyGraph> GetDependencyGraphAsync(string repoId, string? rootFile, string direction, int depth);
+    public Task<ChangedFilesResult> GetChangedFilesAsync(string repoId, long snapshotId);
 }

--- a/src/CodeCompress.Core/Storage/Migrations.cs
+++ b/src/CodeCompress.Core/Storage/Migrations.cs
@@ -74,6 +74,26 @@ public static class Migrations
         "CREATE INDEX IF NOT EXISTS ix_snapshots_repo_id ON index_snapshots(repo_id)",
         "CREATE VIRTUAL TABLE IF NOT EXISTS symbols_fts USING fts5(name, signature, doc_comment, content=symbols, content_rowid=id)",
         "CREATE VIRTUAL TABLE IF NOT EXISTS file_content_fts USING fts5(relative_path, content)",
+        """
+        CREATE TRIGGER IF NOT EXISTS symbols_ai AFTER INSERT ON symbols BEGIN
+            INSERT INTO symbols_fts(rowid, name, signature, doc_comment)
+            VALUES (new.id, new.name, new.signature, new.doc_comment);
+        END
+        """,
+        """
+        CREATE TRIGGER IF NOT EXISTS symbols_ad AFTER DELETE ON symbols BEGIN
+            INSERT INTO symbols_fts(symbols_fts, rowid, name, signature, doc_comment)
+            VALUES ('delete', old.id, old.name, old.signature, old.doc_comment);
+        END
+        """,
+        """
+        CREATE TRIGGER IF NOT EXISTS symbols_au AFTER UPDATE ON symbols BEGIN
+            INSERT INTO symbols_fts(symbols_fts, rowid, name, signature, doc_comment)
+            VALUES ('delete', old.id, old.name, old.signature, old.doc_comment);
+            INSERT INTO symbols_fts(rowid, name, signature, doc_comment)
+            VALUES (new.id, new.name, new.signature, new.doc_comment);
+        END
+        """,
     ];
 
     public static async Task ApplyAsync(SqliteConnection connection)

--- a/src/CodeCompress.Core/Storage/Migrations.cs
+++ b/src/CodeCompress.Core/Storage/Migrations.cs
@@ -1,0 +1,98 @@
+using Microsoft.Data.Sqlite;
+
+namespace CodeCompress.Core.Storage;
+
+public static class Migrations
+{
+    private static readonly string[] DdlStatements =
+    [
+        """
+        CREATE TABLE IF NOT EXISTS repositories (
+            id TEXT PRIMARY KEY,
+            root_path TEXT NOT NULL,
+            name TEXT NOT NULL,
+            language TEXT NOT NULL,
+            last_indexed INTEGER NOT NULL,
+            file_count INTEGER NOT NULL DEFAULT 0,
+            symbol_count INTEGER NOT NULL DEFAULT 0
+        )
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS files (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            repo_id TEXT NOT NULL REFERENCES repositories(id) ON DELETE CASCADE,
+            relative_path TEXT NOT NULL,
+            content_hash TEXT NOT NULL,
+            byte_length INTEGER NOT NULL,
+            line_count INTEGER NOT NULL,
+            last_modified INTEGER NOT NULL,
+            indexed_at INTEGER NOT NULL
+        )
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS symbols (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            file_id INTEGER NOT NULL REFERENCES files(id) ON DELETE CASCADE,
+            name TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            signature TEXT NOT NULL,
+            parent_symbol TEXT,
+            byte_offset INTEGER NOT NULL,
+            byte_length INTEGER NOT NULL,
+            line_start INTEGER NOT NULL,
+            line_end INTEGER NOT NULL,
+            visibility TEXT NOT NULL,
+            doc_comment TEXT
+        )
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS dependencies (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            file_id INTEGER NOT NULL REFERENCES files(id) ON DELETE CASCADE,
+            requires_path TEXT NOT NULL,
+            resolved_file_id INTEGER REFERENCES files(id) ON DELETE SET NULL,
+            alias TEXT
+        )
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS index_snapshots (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            repo_id TEXT NOT NULL REFERENCES repositories(id) ON DELETE CASCADE,
+            snapshot_label TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            file_hashes TEXT NOT NULL
+        )
+        """,
+        "CREATE INDEX IF NOT EXISTS ix_files_repo_id ON files(repo_id)",
+        "CREATE INDEX IF NOT EXISTS ix_files_content_hash ON files(content_hash)",
+        "CREATE UNIQUE INDEX IF NOT EXISTS ix_files_repo_path ON files(repo_id, relative_path)",
+        "CREATE INDEX IF NOT EXISTS ix_symbols_file_id ON symbols(file_id)",
+        "CREATE INDEX IF NOT EXISTS ix_symbols_name ON symbols(name)",
+        "CREATE INDEX IF NOT EXISTS ix_symbols_kind ON symbols(kind)",
+        "CREATE INDEX IF NOT EXISTS ix_dependencies_file_id ON dependencies(file_id)",
+        "CREATE INDEX IF NOT EXISTS ix_dependencies_resolved ON dependencies(resolved_file_id)",
+        "CREATE INDEX IF NOT EXISTS ix_snapshots_repo_id ON index_snapshots(repo_id)",
+        "CREATE VIRTUAL TABLE IF NOT EXISTS symbols_fts USING fts5(name, signature, doc_comment, content=symbols, content_rowid=id)",
+        "CREATE VIRTUAL TABLE IF NOT EXISTS file_content_fts USING fts5(relative_path, content)",
+    ];
+
+    public static async Task ApplyAsync(SqliteConnection connection)
+    {
+        ArgumentNullException.ThrowIfNull(connection);
+
+        var transaction = await connection.BeginTransactionAsync().ConfigureAwait(false);
+        await using var _ = transaction.ConfigureAwait(false);
+
+        foreach (var ddl in DdlStatements)
+        {
+            using var command = connection.CreateCommand();
+            command.Transaction = (SqliteTransaction)transaction;
+#pragma warning disable CA2100 // DDL statements are static literals, not user input
+            command.CommandText = ddl;
+#pragma warning restore CA2100
+            await command.ExecuteNonQueryAsync().ConfigureAwait(false);
+        }
+
+        await transaction.CommitAsync().ConfigureAwait(false);
+    }
+}

--- a/src/CodeCompress.Core/Storage/SqliteConnectionFactory.cs
+++ b/src/CodeCompress.Core/Storage/SqliteConnectionFactory.cs
@@ -1,0 +1,61 @@
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Data.Sqlite;
+
+namespace CodeCompress.Core.Storage;
+
+public sealed class SqliteConnectionFactory : IConnectionFactory
+{
+    public async Task<SqliteConnection> CreateConnectionAsync(string projectRootPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectRootPath);
+
+        var fullPath = Path.GetFullPath(projectRootPath);
+        if (!Path.IsPathRooted(fullPath))
+        {
+            throw new ArgumentException("Project root path must be an absolute path.", nameof(projectRootPath));
+        }
+
+        if (projectRootPath.Contains("..", StringComparison.Ordinal))
+        {
+            throw new ArgumentException("Project root path must not contain path traversal.", nameof(projectRootPath));
+        }
+
+        var repoHash = ComputeRepoHash(fullPath);
+
+        var dbDirectory = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            ".codecompress");
+        Directory.CreateDirectory(dbDirectory);
+
+        var dbPath = Path.Combine(dbDirectory, $"{repoHash}.db");
+        var connection = new SqliteConnection($"Data Source={dbPath};Foreign Keys=True");
+        await connection.OpenAsync().ConfigureAwait(false);
+
+        await ExecutePragmaAsync(connection, "PRAGMA journal_mode=WAL;").ConfigureAwait(false);
+        await ExecutePragmaAsync(connection, "PRAGMA synchronous=NORMAL;").ConfigureAwait(false);
+
+        await Migrations.ApplyAsync(connection).ConfigureAwait(false);
+
+        return connection;
+    }
+
+    internal static string ComputeRepoHash(string fullPath)
+    {
+        var normalized = fullPath
+            .Replace('\\', '/')
+            .TrimEnd('/');
+
+        var hashBytes = SHA256.HashData(Encoding.UTF8.GetBytes(normalized));
+        return Convert.ToHexStringLower(hashBytes);
+    }
+
+    private static async Task ExecutePragmaAsync(SqliteConnection connection, string pragma)
+    {
+        using var command = connection.CreateCommand();
+#pragma warning disable CA2100 // PRAGMA strings are static literals, not user input
+        command.CommandText = pragma;
+#pragma warning restore CA2100
+        await command.ExecuteNonQueryAsync().ConfigureAwait(false);
+    }
+}

--- a/src/CodeCompress.Core/Storage/SqliteSymbolStore.cs
+++ b/src/CodeCompress.Core/Storage/SqliteSymbolStore.cs
@@ -1,3 +1,5 @@
+using System.Text;
+using System.Text.Json;
 using CodeCompress.Core.Models;
 using Microsoft.Data.Sqlite;
 
@@ -551,5 +553,572 @@ public sealed class SqliteSymbolStore : ISymbolStore
         }
 
         return results;
+    }
+
+    // ── Search ──────────────────────────────────────────────────────────
+
+    public async Task<IReadOnlyList<SymbolSearchResult>> SearchSymbolsAsync(string repoId, string query, string? kind, int limit)
+    {
+        ArgumentNullException.ThrowIfNull(repoId);
+        ArgumentNullException.ThrowIfNull(query);
+
+        var sanitized = Fts5Sanitizer.Sanitize(query);
+        if (sanitized.Length == 0)
+        {
+            return [];
+        }
+
+        var clampedLimit = Math.Min(Math.Max(limit, 1), 100);
+
+        using var command = _connection.CreateCommand();
+
+        var sql = new StringBuilder();
+        sql.Append(
+            """
+            SELECT s.id, s.file_id, s.name, s.kind, s.signature, s.parent_symbol,
+                   s.byte_offset, s.byte_length, s.line_start, s.line_end, s.visibility, s.doc_comment,
+                   f.relative_path, bm25(symbols_fts) AS rank
+            FROM symbols_fts
+            JOIN symbols s ON s.id = symbols_fts.rowid
+            JOIN files f ON f.id = s.file_id
+            WHERE symbols_fts MATCH @query AND f.repo_id = @repoId
+            """);
+
+        if (kind is not null)
+        {
+            sql.Append(" AND s.kind = @kind");
+        }
+
+        sql.Append(" ORDER BY rank LIMIT @limit");
+
+#pragma warning disable CA2100 // SQL is built from static literals and parameterized placeholders only
+        command.CommandText = sql.ToString();
+#pragma warning restore CA2100
+
+        command.Parameters.AddWithValue("@query", sanitized);
+        command.Parameters.AddWithValue("@repoId", repoId);
+        command.Parameters.AddWithValue("@limit", clampedLimit);
+
+        if (kind is not null)
+        {
+            command.Parameters.AddWithValue("@kind", kind);
+        }
+
+        using var reader = await command.ExecuteReaderAsync().ConfigureAwait(false);
+        var results = new List<SymbolSearchResult>();
+
+        while (await reader.ReadAsync().ConfigureAwait(false))
+        {
+            var symbol = new Symbol(
+                reader.GetInt64(0),
+                reader.GetInt64(1),
+                reader.GetString(2),
+                reader.GetString(3),
+                reader.GetString(4),
+                await reader.IsDBNullAsync(5).ConfigureAwait(false) ? null : reader.GetString(5),
+                reader.GetInt32(6),
+                reader.GetInt32(7),
+                reader.GetInt32(8),
+                reader.GetInt32(9),
+                reader.GetString(10),
+                await reader.IsDBNullAsync(11).ConfigureAwait(false) ? null : reader.GetString(11));
+
+            results.Add(new SymbolSearchResult(symbol, reader.GetString(12), reader.GetDouble(13)));
+        }
+
+        return results;
+    }
+
+    public async Task<IReadOnlyList<TextSearchResult>> SearchTextAsync(string repoId, string query, string? glob, int limit)
+    {
+        ArgumentNullException.ThrowIfNull(repoId);
+        ArgumentNullException.ThrowIfNull(query);
+
+        var sanitized = Fts5Sanitizer.Sanitize(query);
+        if (sanitized.Length == 0)
+        {
+            return [];
+        }
+
+        var clampedLimit = Math.Min(Math.Max(limit, 1), 100);
+
+        using var command = _connection.CreateCommand();
+
+        var sql = new StringBuilder();
+        sql.Append(
+            """
+            SELECT fts.relative_path, snippet(file_content_fts, 1, '<b>', '</b>', '...', 32) AS snippet,
+                   bm25(file_content_fts) AS rank
+            FROM file_content_fts AS fts
+            WHERE file_content_fts MATCH @query
+              AND fts.relative_path IN (SELECT relative_path FROM files WHERE repo_id = @repoId)
+            """);
+
+        if (glob is not null)
+        {
+            sql.Append(" AND fts.relative_path GLOB @glob");
+        }
+
+        sql.Append(" ORDER BY rank LIMIT @limit");
+
+#pragma warning disable CA2100 // SQL is built from static literals and parameterized placeholders only
+        command.CommandText = sql.ToString();
+#pragma warning restore CA2100
+
+        command.Parameters.AddWithValue("@query", sanitized);
+        command.Parameters.AddWithValue("@repoId", repoId);
+        command.Parameters.AddWithValue("@limit", clampedLimit);
+
+        if (glob is not null)
+        {
+            command.Parameters.AddWithValue("@glob", glob);
+        }
+
+        using var reader = await command.ExecuteReaderAsync().ConfigureAwait(false);
+        var results = new List<TextSearchResult>();
+
+        while (await reader.ReadAsync().ConfigureAwait(false))
+        {
+            results.Add(new TextSearchResult(
+                reader.GetString(0),
+                reader.GetString(1),
+                reader.GetDouble(2)));
+        }
+
+        return results;
+    }
+
+    // ── Lookups ─────────────────────────────────────────────────────────
+
+    public async Task<Symbol?> GetSymbolByNameAsync(string repoId, string symbolName)
+    {
+        ArgumentNullException.ThrowIfNull(repoId);
+        ArgumentNullException.ThrowIfNull(symbolName);
+
+        using var command = _connection.CreateCommand();
+
+        // Check for qualified name (e.g. "Module.Func" or "Module:Method")
+        var separatorIndex = symbolName.IndexOfAny(['.', ':']);
+
+        if (separatorIndex > 0 && separatorIndex < symbolName.Length - 1)
+        {
+            var parent = symbolName[..separatorIndex];
+            var child = symbolName[(separatorIndex + 1)..];
+
+#pragma warning disable CA2100
+            command.CommandText =
+                """
+                SELECT s.id, s.file_id, s.name, s.kind, s.signature, s.parent_symbol,
+                       s.byte_offset, s.byte_length, s.line_start, s.line_end, s.visibility, s.doc_comment
+                FROM symbols s
+                JOIN files f ON f.id = s.file_id
+                WHERE s.parent_symbol = @parent AND s.name = @child AND f.repo_id = @repoId
+                LIMIT 1
+                """;
+#pragma warning restore CA2100
+
+            command.Parameters.AddWithValue("@parent", parent);
+            command.Parameters.AddWithValue("@child", child);
+        }
+        else
+        {
+#pragma warning disable CA2100
+            command.CommandText =
+                """
+                SELECT s.id, s.file_id, s.name, s.kind, s.signature, s.parent_symbol,
+                       s.byte_offset, s.byte_length, s.line_start, s.line_end, s.visibility, s.doc_comment
+                FROM symbols s
+                JOIN files f ON f.id = s.file_id
+                WHERE s.name = @name AND f.repo_id = @repoId
+                LIMIT 1
+                """;
+#pragma warning restore CA2100
+
+            command.Parameters.AddWithValue("@name", symbolName);
+        }
+
+        command.Parameters.AddWithValue("@repoId", repoId);
+
+        using var reader = await command.ExecuteReaderAsync().ConfigureAwait(false);
+
+        if (await reader.ReadAsync().ConfigureAwait(false))
+        {
+            return new Symbol(
+                reader.GetInt64(0),
+                reader.GetInt64(1),
+                reader.GetString(2),
+                reader.GetString(3),
+                reader.GetString(4),
+                await reader.IsDBNullAsync(5).ConfigureAwait(false) ? null : reader.GetString(5),
+                reader.GetInt32(6),
+                reader.GetInt32(7),
+                reader.GetInt32(8),
+                reader.GetInt32(9),
+                reader.GetString(10),
+                await reader.IsDBNullAsync(11).ConfigureAwait(false) ? null : reader.GetString(11));
+        }
+
+        return null;
+    }
+
+    public async Task<IReadOnlyList<Symbol>> GetSymbolsByNamesAsync(string repoId, IReadOnlyList<string> symbolNames)
+    {
+        ArgumentNullException.ThrowIfNull(repoId);
+        ArgumentNullException.ThrowIfNull(symbolNames);
+
+        if (symbolNames.Count == 0)
+        {
+            return [];
+        }
+
+        using var command = _connection.CreateCommand();
+
+        var placeholders = new StringBuilder();
+        for (int i = 0; i < symbolNames.Count; i++)
+        {
+            if (i > 0)
+            {
+                placeholders.Append(", ");
+            }
+
+            var paramName = $"@p{i}";
+            placeholders.Append(paramName);
+            command.Parameters.AddWithValue(paramName, symbolNames[i]);
+        }
+
+#pragma warning disable CA2100 // SQL is built from static literals and parameterized placeholder names only
+        command.CommandText =
+            $"""
+             SELECT s.id, s.file_id, s.name, s.kind, s.signature, s.parent_symbol,
+                    s.byte_offset, s.byte_length, s.line_start, s.line_end, s.visibility, s.doc_comment
+             FROM symbols s
+             JOIN files f ON f.id = s.file_id
+             WHERE s.name IN ({placeholders}) AND f.repo_id = @repoId
+             """;
+#pragma warning restore CA2100
+
+        command.Parameters.AddWithValue("@repoId", repoId);
+
+        using var reader = await command.ExecuteReaderAsync().ConfigureAwait(false);
+        var results = new List<Symbol>();
+
+        while (await reader.ReadAsync().ConfigureAwait(false))
+        {
+            results.Add(new Symbol(
+                reader.GetInt64(0),
+                reader.GetInt64(1),
+                reader.GetString(2),
+                reader.GetString(3),
+                reader.GetString(4),
+                await reader.IsDBNullAsync(5).ConfigureAwait(false) ? null : reader.GetString(5),
+                reader.GetInt32(6),
+                reader.GetInt32(7),
+                reader.GetInt32(8),
+                reader.GetInt32(9),
+                reader.GetString(10),
+                await reader.IsDBNullAsync(11).ConfigureAwait(false) ? null : reader.GetString(11)));
+        }
+
+        return results;
+    }
+
+    // ── Aggregation ─────────────────────────────────────────────────────
+
+    public async Task<ProjectOutline> GetProjectOutlineAsync(string repoId, bool includePrivate, string groupBy, int maxDepth)
+    {
+        ArgumentNullException.ThrowIfNull(repoId);
+        ArgumentNullException.ThrowIfNull(groupBy);
+
+        var clampedDepth = Math.Min(Math.Max(maxDepth, 1), 10);
+
+        using var command = _connection.CreateCommand();
+
+        var sql = new StringBuilder();
+        sql.Append(
+            """
+            SELECT s.id, s.file_id, s.name, s.kind, s.signature, s.parent_symbol,
+                   s.byte_offset, s.byte_length, s.line_start, s.line_end, s.visibility, s.doc_comment,
+                   f.relative_path
+            FROM symbols s
+            JOIN files f ON f.id = s.file_id
+            WHERE f.repo_id = @repoId
+            """);
+
+        if (!includePrivate)
+        {
+            sql.Append(" AND s.visibility != 'Private'");
+        }
+
+        sql.Append(" ORDER BY f.relative_path, s.line_start");
+
+#pragma warning disable CA2100 // SQL is built from static literals and parameterized placeholders only
+        command.CommandText = sql.ToString();
+#pragma warning restore CA2100
+
+        command.Parameters.AddWithValue("@repoId", repoId);
+
+        using var reader = await command.ExecuteReaderAsync().ConfigureAwait(false);
+
+        var symbolsByKey = new Dictionary<string, List<Symbol>>(StringComparer.Ordinal);
+
+        while (await reader.ReadAsync().ConfigureAwait(false))
+        {
+            var symbol = new Symbol(
+                reader.GetInt64(0),
+                reader.GetInt64(1),
+                reader.GetString(2),
+                reader.GetString(3),
+                reader.GetString(4),
+                await reader.IsDBNullAsync(5).ConfigureAwait(false) ? null : reader.GetString(5),
+                reader.GetInt32(6),
+                reader.GetInt32(7),
+                reader.GetInt32(8),
+                reader.GetInt32(9),
+                reader.GetString(10),
+                await reader.IsDBNullAsync(11).ConfigureAwait(false) ? null : reader.GetString(11));
+
+            var key = string.Equals(groupBy, "kind", StringComparison.OrdinalIgnoreCase)
+                ? symbol.Kind
+                : reader.GetString(12);
+
+            if (!symbolsByKey.TryGetValue(key, out var list))
+            {
+                list = [];
+                symbolsByKey[key] = list;
+            }
+
+            list.Add(symbol);
+        }
+
+        var groups = new List<OutlineGroup>();
+
+        foreach (var (key, symbols) in symbolsByKey.OrderBy(kvp => kvp.Key, StringComparer.Ordinal))
+        {
+            if (clampedDepth >= 2)
+            {
+                // Build nested groups: top-level symbols and children grouped by parent
+                var topLevel = new List<Symbol>();
+                var childrenByParent = new Dictionary<string, List<Symbol>>(StringComparer.Ordinal);
+
+                foreach (var sym in symbols)
+                {
+                    if (sym.ParentSymbol is null)
+                    {
+                        topLevel.Add(sym);
+                    }
+                    else
+                    {
+                        if (!childrenByParent.TryGetValue(sym.ParentSymbol, out var children))
+                        {
+                            children = [];
+                            childrenByParent[sym.ParentSymbol] = children;
+                        }
+
+                        children.Add(sym);
+                    }
+                }
+
+                var childGroups = new List<OutlineGroup>();
+                foreach (var (parentName, children) in childrenByParent.OrderBy(kvp => kvp.Key, StringComparer.Ordinal))
+                {
+                    childGroups.Add(new OutlineGroup(parentName, children, []));
+                }
+
+                groups.Add(new OutlineGroup(key, topLevel, childGroups));
+            }
+            else
+            {
+                groups.Add(new OutlineGroup(key, symbols, []));
+            }
+        }
+
+        return new ProjectOutline(repoId, groups);
+    }
+
+    public async Task<ModuleApi> GetModuleApiAsync(string repoId, string filePath)
+    {
+        ArgumentNullException.ThrowIfNull(repoId);
+        ArgumentNullException.ThrowIfNull(filePath);
+
+        var file = await GetFileByPathAsync(repoId, filePath).ConfigureAwait(false);
+
+        if (file is null)
+        {
+            throw new ArgumentException($"File not found: {filePath}", nameof(filePath));
+        }
+
+        var symbols = await GetSymbolsByFileAsync(file.Id).ConfigureAwait(false);
+        var dependencies = await GetDependenciesByFileAsync(file.Id).ConfigureAwait(false);
+
+        return new ModuleApi(file, symbols, dependencies);
+    }
+
+    public async Task<DependencyGraph> GetDependencyGraphAsync(string repoId, string? rootFile, string direction, int depth)
+    {
+        ArgumentNullException.ThrowIfNull(repoId);
+        ArgumentNullException.ThrowIfNull(direction);
+
+        var clampedDepth = Math.Min(Math.Max(depth, 1), 10);
+
+        // Load all files for this repo into a lookup
+        var allFiles = await GetFilesByRepoAsync(repoId).ConfigureAwait(false);
+        var fileById = new Dictionary<long, FileRecord>();
+        var fileByPath = new Dictionary<string, FileRecord>(StringComparer.Ordinal);
+
+        foreach (var f in allFiles)
+        {
+            fileById[f.Id] = f;
+            fileByPath[f.RelativePath] = f;
+        }
+
+        var nodes = new HashSet<string>(StringComparer.Ordinal);
+        var edges = new List<DependencyEdge>();
+        var visited = new HashSet<long>();
+
+        // Determine starting file IDs
+        var frontier = new List<long>();
+
+        if (rootFile is not null)
+        {
+            if (fileByPath.TryGetValue(rootFile, out var root))
+            {
+                frontier.Add(root.Id);
+            }
+            else
+            {
+                return new DependencyGraph([], []);
+            }
+        }
+        else
+        {
+            frontier.AddRange(allFiles.Select(f => f.Id));
+        }
+
+        var isDependencies = string.Equals(direction, "dependencies", StringComparison.OrdinalIgnoreCase);
+
+        for (int level = 0; level < clampedDepth && frontier.Count > 0; level++)
+        {
+            var nextFrontier = new List<long>();
+
+            foreach (var fileId in frontier)
+            {
+                if (!visited.Add(fileId))
+                {
+                    continue;
+                }
+
+                if (!fileById.TryGetValue(fileId, out var currentFile))
+                {
+                    continue;
+                }
+
+                nodes.Add(currentFile.RelativePath);
+
+                if (isDependencies)
+                {
+                    var deps = await GetDependenciesByFileAsync(fileId).ConfigureAwait(false);
+
+                    foreach (var dep in deps)
+                    {
+                        var toPath = dep.RequiresPath;
+
+                        if (dep.ResolvedFileId.HasValue && fileById.TryGetValue(dep.ResolvedFileId.Value, out var resolved))
+                        {
+                            toPath = resolved.RelativePath;
+                            nodes.Add(toPath);
+                            nextFrontier.Add(dep.ResolvedFileId.Value);
+                        }
+                        else
+                        {
+                            nodes.Add(toPath);
+                        }
+
+                        edges.Add(new DependencyEdge(currentFile.RelativePath, toPath, dep.Alias));
+                    }
+                }
+                else
+                {
+                    // Dependents: find files that depend on the current file
+                    using var command = _connection.CreateCommand();
+
+#pragma warning disable CA2100
+                    command.CommandText =
+                        """
+                        SELECT d.id, d.file_id, d.requires_path, d.resolved_file_id, d.alias
+                        FROM dependencies d
+                        WHERE d.resolved_file_id = @fileId
+                        """;
+#pragma warning restore CA2100
+
+                    command.Parameters.AddWithValue("@fileId", fileId);
+
+                    using var reader = await command.ExecuteReaderAsync().ConfigureAwait(false);
+
+                    while (await reader.ReadAsync().ConfigureAwait(false))
+                    {
+                        var depFileId = reader.GetInt64(1);
+                        var alias = await reader.IsDBNullAsync(4).ConfigureAwait(false) ? null : reader.GetString(4);
+
+                        if (fileById.TryGetValue(depFileId, out var dependentFile))
+                        {
+                            nodes.Add(dependentFile.RelativePath);
+                            edges.Add(new DependencyEdge(dependentFile.RelativePath, currentFile.RelativePath, alias));
+                            nextFrontier.Add(depFileId);
+                        }
+                    }
+                }
+            }
+
+            frontier = nextFrontier;
+        }
+
+        return new DependencyGraph(
+            nodes.OrderBy(n => n, StringComparer.Ordinal).ToList(),
+            edges);
+    }
+
+    public async Task<ChangedFilesResult> GetChangedFilesAsync(string repoId, long snapshotId)
+    {
+        ArgumentNullException.ThrowIfNull(repoId);
+
+        var snapshot = await GetSnapshotAsync(snapshotId).ConfigureAwait(false);
+
+        if (snapshot is null)
+        {
+            return new ChangedFilesResult([], [], []);
+        }
+
+        var snapshotHashes = JsonSerializer.Deserialize<Dictionary<string, string>>(snapshot.FileHashes)
+            ?? new Dictionary<string, string>();
+
+        var currentFiles = await GetFilesByRepoAsync(repoId).ConfigureAwait(false);
+        var currentByPath = new Dictionary<string, FileRecord>(StringComparer.Ordinal);
+
+        foreach (var file in currentFiles)
+        {
+            currentByPath[file.RelativePath] = file;
+        }
+
+        var added = new List<FileRecord>();
+        var modified = new List<FileRecord>();
+        var removed = new List<string>();
+
+        // Files in current but not in snapshot = added; in both but hash differs = modified
+        foreach (var file in currentFiles)
+        {
+            if (!snapshotHashes.TryGetValue(file.RelativePath, out var oldHash))
+            {
+                added.Add(file);
+            }
+            else if (!string.Equals(oldHash, file.ContentHash, StringComparison.Ordinal))
+            {
+                modified.Add(file);
+            }
+        }
+
+        // Files in snapshot but not in current = removed
+        removed.AddRange(snapshotHashes.Keys.Where(path => !currentByPath.ContainsKey(path)));
+
+        return new ChangedFilesResult(added, modified, removed);
     }
 }

--- a/src/CodeCompress.Core/Storage/SqliteSymbolStore.cs
+++ b/src/CodeCompress.Core/Storage/SqliteSymbolStore.cs
@@ -1,0 +1,555 @@
+using CodeCompress.Core.Models;
+using Microsoft.Data.Sqlite;
+
+namespace CodeCompress.Core.Storage;
+
+public sealed class SqliteSymbolStore : ISymbolStore
+{
+    private readonly SqliteConnection _connection;
+
+    public SqliteSymbolStore(SqliteConnection connection)
+    {
+        ArgumentNullException.ThrowIfNull(connection);
+        _connection = connection;
+    }
+
+    // ── Repository ──────────────────────────────────────────────────────
+
+    public async Task UpsertRepositoryAsync(Repository repo)
+    {
+        ArgumentNullException.ThrowIfNull(repo);
+
+        using var command = _connection.CreateCommand();
+
+#pragma warning disable CA2100 // SQL is a static literal, not user input
+        command.CommandText =
+            """
+            INSERT OR REPLACE INTO repositories (id, root_path, name, language, last_indexed, file_count, symbol_count)
+            VALUES (@id, @rootPath, @name, @language, @lastIndexed, @fileCount, @symbolCount)
+            """;
+#pragma warning restore CA2100
+
+        command.Parameters.AddWithValue("@id", repo.Id);
+        command.Parameters.AddWithValue("@rootPath", repo.RootPath);
+        command.Parameters.AddWithValue("@name", repo.Name);
+        command.Parameters.AddWithValue("@language", repo.Language);
+        command.Parameters.AddWithValue("@lastIndexed", repo.LastIndexed);
+        command.Parameters.AddWithValue("@fileCount", repo.FileCount);
+        command.Parameters.AddWithValue("@symbolCount", repo.SymbolCount);
+
+        await command.ExecuteNonQueryAsync().ConfigureAwait(false);
+    }
+
+    public async Task<Repository?> GetRepositoryAsync(string repoId)
+    {
+        ArgumentNullException.ThrowIfNull(repoId);
+
+        using var command = _connection.CreateCommand();
+
+#pragma warning disable CA2100
+        command.CommandText =
+            """
+            SELECT id, root_path, name, language, last_indexed, file_count, symbol_count
+            FROM repositories WHERE id = @id
+            """;
+#pragma warning restore CA2100
+
+        command.Parameters.AddWithValue("@id", repoId);
+
+        using var reader = await command.ExecuteReaderAsync().ConfigureAwait(false);
+
+        if (await reader.ReadAsync().ConfigureAwait(false))
+        {
+            return new Repository(
+                reader.GetString(0),
+                reader.GetString(1),
+                reader.GetString(2),
+                reader.GetString(3),
+                reader.GetInt64(4),
+                reader.GetInt32(5),
+                reader.GetInt32(6));
+        }
+
+        return null;
+    }
+
+    public async Task DeleteRepositoryAsync(string repoId)
+    {
+        ArgumentNullException.ThrowIfNull(repoId);
+
+        using var command = _connection.CreateCommand();
+
+#pragma warning disable CA2100
+        command.CommandText = "DELETE FROM repositories WHERE id = @id";
+#pragma warning restore CA2100
+
+        command.Parameters.AddWithValue("@id", repoId);
+
+        await command.ExecuteNonQueryAsync().ConfigureAwait(false);
+    }
+
+    // ── Files ───────────────────────────────────────────────────────────
+
+    public async Task InsertFilesAsync(IReadOnlyList<FileRecord> files)
+    {
+        ArgumentNullException.ThrowIfNull(files);
+
+        if (files.Count == 0)
+        {
+            return;
+        }
+
+        var transaction = await _connection.BeginTransactionAsync().ConfigureAwait(false);
+        await using var _ = transaction.ConfigureAwait(false);
+
+        try
+        {
+            using var command = _connection.CreateCommand();
+            command.Transaction = (SqliteTransaction)transaction;
+
+#pragma warning disable CA2100
+            command.CommandText =
+                """
+                INSERT INTO files (repo_id, relative_path, content_hash, byte_length, line_count, last_modified, indexed_at)
+                VALUES (@repoId, @relativePath, @contentHash, @byteLength, @lineCount, @lastModified, @indexedAt)
+                """;
+#pragma warning restore CA2100
+
+            var pRepoId = command.Parameters.Add(new SqliteParameter("@repoId", ""));
+            var pRelativePath = command.Parameters.Add(new SqliteParameter("@relativePath", ""));
+            var pContentHash = command.Parameters.Add(new SqliteParameter("@contentHash", ""));
+            var pByteLength = command.Parameters.Add(new SqliteParameter("@byteLength", 0L));
+            var pLineCount = command.Parameters.Add(new SqliteParameter("@lineCount", 0));
+            var pLastModified = command.Parameters.Add(new SqliteParameter("@lastModified", 0L));
+            var pIndexedAt = command.Parameters.Add(new SqliteParameter("@indexedAt", 0L));
+
+            foreach (var file in files)
+            {
+                pRepoId.Value = file.RepoId;
+                pRelativePath.Value = file.RelativePath;
+                pContentHash.Value = file.ContentHash;
+                pByteLength.Value = file.ByteLength;
+                pLineCount.Value = file.LineCount;
+                pLastModified.Value = file.LastModified;
+                pIndexedAt.Value = file.IndexedAt;
+
+                await command.ExecuteNonQueryAsync().ConfigureAwait(false);
+            }
+
+            await transaction.CommitAsync().ConfigureAwait(false);
+        }
+        catch
+        {
+            await transaction.RollbackAsync().ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    public async Task<IReadOnlyList<FileRecord>> GetFilesByRepoAsync(string repoId)
+    {
+        ArgumentNullException.ThrowIfNull(repoId);
+
+        using var command = _connection.CreateCommand();
+
+#pragma warning disable CA2100
+        command.CommandText =
+            """
+            SELECT id, repo_id, relative_path, content_hash, byte_length, line_count, last_modified, indexed_at
+            FROM files WHERE repo_id = @repoId ORDER BY relative_path
+            """;
+#pragma warning restore CA2100
+
+        command.Parameters.AddWithValue("@repoId", repoId);
+
+        using var reader = await command.ExecuteReaderAsync().ConfigureAwait(false);
+        var results = new List<FileRecord>();
+
+        while (await reader.ReadAsync().ConfigureAwait(false))
+        {
+            results.Add(new FileRecord(
+                reader.GetInt64(0),
+                reader.GetString(1),
+                reader.GetString(2),
+                reader.GetString(3),
+                reader.GetInt64(4),
+                reader.GetInt32(5),
+                reader.GetInt64(6),
+                reader.GetInt64(7)));
+        }
+
+        return results;
+    }
+
+    public async Task<FileRecord?> GetFileByPathAsync(string repoId, string relativePath)
+    {
+        ArgumentNullException.ThrowIfNull(repoId);
+        ArgumentNullException.ThrowIfNull(relativePath);
+
+        using var command = _connection.CreateCommand();
+
+#pragma warning disable CA2100
+        command.CommandText =
+            """
+            SELECT id, repo_id, relative_path, content_hash, byte_length, line_count, last_modified, indexed_at
+            FROM files WHERE repo_id = @repoId AND relative_path = @relativePath
+            """;
+#pragma warning restore CA2100
+
+        command.Parameters.AddWithValue("@repoId", repoId);
+        command.Parameters.AddWithValue("@relativePath", relativePath);
+
+        using var reader = await command.ExecuteReaderAsync().ConfigureAwait(false);
+
+        if (await reader.ReadAsync().ConfigureAwait(false))
+        {
+            return new FileRecord(
+                reader.GetInt64(0),
+                reader.GetString(1),
+                reader.GetString(2),
+                reader.GetString(3),
+                reader.GetInt64(4),
+                reader.GetInt32(5),
+                reader.GetInt64(6),
+                reader.GetInt64(7));
+        }
+
+        return null;
+    }
+
+    public async Task UpdateFileAsync(FileRecord file)
+    {
+        ArgumentNullException.ThrowIfNull(file);
+
+        using var command = _connection.CreateCommand();
+
+#pragma warning disable CA2100
+        command.CommandText =
+            """
+            UPDATE files
+            SET repo_id = @repoId, relative_path = @relativePath, content_hash = @contentHash,
+                byte_length = @byteLength, line_count = @lineCount, last_modified = @lastModified, indexed_at = @indexedAt
+            WHERE id = @id
+            """;
+#pragma warning restore CA2100
+
+        command.Parameters.AddWithValue("@id", file.Id);
+        command.Parameters.AddWithValue("@repoId", file.RepoId);
+        command.Parameters.AddWithValue("@relativePath", file.RelativePath);
+        command.Parameters.AddWithValue("@contentHash", file.ContentHash);
+        command.Parameters.AddWithValue("@byteLength", file.ByteLength);
+        command.Parameters.AddWithValue("@lineCount", file.LineCount);
+        command.Parameters.AddWithValue("@lastModified", file.LastModified);
+        command.Parameters.AddWithValue("@indexedAt", file.IndexedAt);
+
+        await command.ExecuteNonQueryAsync().ConfigureAwait(false);
+    }
+
+    public async Task DeleteFileAsync(long fileId)
+    {
+        using var command = _connection.CreateCommand();
+
+#pragma warning disable CA2100
+        command.CommandText = "DELETE FROM files WHERE id = @id";
+#pragma warning restore CA2100
+
+        command.Parameters.AddWithValue("@id", fileId);
+
+        await command.ExecuteNonQueryAsync().ConfigureAwait(false);
+    }
+
+    // ── Symbols ─────────────────────────────────────────────────────────
+
+    public async Task InsertSymbolsAsync(IReadOnlyList<Symbol> symbols)
+    {
+        ArgumentNullException.ThrowIfNull(symbols);
+
+        if (symbols.Count == 0)
+        {
+            return;
+        }
+
+        var transaction = await _connection.BeginTransactionAsync().ConfigureAwait(false);
+        await using var _ = transaction.ConfigureAwait(false);
+
+        try
+        {
+            using var command = _connection.CreateCommand();
+            command.Transaction = (SqliteTransaction)transaction;
+
+#pragma warning disable CA2100
+            command.CommandText =
+                """
+                INSERT INTO symbols (file_id, name, kind, signature, parent_symbol, byte_offset, byte_length, line_start, line_end, visibility, doc_comment)
+                VALUES (@fileId, @name, @kind, @signature, @parentSymbol, @byteOffset, @byteLength, @lineStart, @lineEnd, @visibility, @docComment)
+                """;
+#pragma warning restore CA2100
+
+            var pFileId = command.Parameters.Add(new SqliteParameter("@fileId", 0L));
+            var pName = command.Parameters.Add(new SqliteParameter("@name", ""));
+            var pKind = command.Parameters.Add(new SqliteParameter("@kind", ""));
+            var pSignature = command.Parameters.Add(new SqliteParameter("@signature", ""));
+            var pParentSymbol = command.Parameters.Add(new SqliteParameter("@parentSymbol", ""));
+            var pByteOffset = command.Parameters.Add(new SqliteParameter("@byteOffset", 0));
+            var pByteLength = command.Parameters.Add(new SqliteParameter("@byteLength", 0));
+            var pLineStart = command.Parameters.Add(new SqliteParameter("@lineStart", 0));
+            var pLineEnd = command.Parameters.Add(new SqliteParameter("@lineEnd", 0));
+            var pVisibility = command.Parameters.Add(new SqliteParameter("@visibility", ""));
+            var pDocComment = command.Parameters.Add(new SqliteParameter("@docComment", ""));
+
+            foreach (var symbol in symbols)
+            {
+                pFileId.Value = symbol.FileId;
+                pName.Value = symbol.Name;
+                pKind.Value = symbol.Kind;
+                pSignature.Value = symbol.Signature;
+                pParentSymbol.Value = (object?)symbol.ParentSymbol ?? DBNull.Value;
+                pByteOffset.Value = symbol.ByteOffset;
+                pByteLength.Value = symbol.ByteLength;
+                pLineStart.Value = symbol.LineStart;
+                pLineEnd.Value = symbol.LineEnd;
+                pVisibility.Value = symbol.Visibility;
+                pDocComment.Value = (object?)symbol.DocComment ?? DBNull.Value;
+
+                await command.ExecuteNonQueryAsync().ConfigureAwait(false);
+            }
+
+            await transaction.CommitAsync().ConfigureAwait(false);
+        }
+        catch
+        {
+            await transaction.RollbackAsync().ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    public async Task<IReadOnlyList<Symbol>> GetSymbolsByFileAsync(long fileId)
+    {
+        using var command = _connection.CreateCommand();
+
+#pragma warning disable CA2100
+        command.CommandText =
+            """
+            SELECT id, file_id, name, kind, signature, parent_symbol, byte_offset, byte_length, line_start, line_end, visibility, doc_comment
+            FROM symbols WHERE file_id = @fileId ORDER BY line_start
+            """;
+#pragma warning restore CA2100
+
+        command.Parameters.AddWithValue("@fileId", fileId);
+
+        using var reader = await command.ExecuteReaderAsync().ConfigureAwait(false);
+        var results = new List<Symbol>();
+
+        while (await reader.ReadAsync().ConfigureAwait(false))
+        {
+            results.Add(new Symbol(
+                reader.GetInt64(0),
+                reader.GetInt64(1),
+                reader.GetString(2),
+                reader.GetString(3),
+                reader.GetString(4),
+                await reader.IsDBNullAsync(5).ConfigureAwait(false) ? null : reader.GetString(5),
+                reader.GetInt32(6),
+                reader.GetInt32(7),
+                reader.GetInt32(8),
+                reader.GetInt32(9),
+                reader.GetString(10),
+                await reader.IsDBNullAsync(11).ConfigureAwait(false) ? null : reader.GetString(11)));
+        }
+
+        return results;
+    }
+
+    public async Task DeleteSymbolsByFileAsync(long fileId)
+    {
+        using var command = _connection.CreateCommand();
+
+#pragma warning disable CA2100
+        command.CommandText = "DELETE FROM symbols WHERE file_id = @fileId";
+#pragma warning restore CA2100
+
+        command.Parameters.AddWithValue("@fileId", fileId);
+
+        await command.ExecuteNonQueryAsync().ConfigureAwait(false);
+    }
+
+    // ── Dependencies ────────────────────────────────────────────────────
+
+    public async Task InsertDependenciesAsync(IReadOnlyList<Dependency> deps)
+    {
+        ArgumentNullException.ThrowIfNull(deps);
+
+        if (deps.Count == 0)
+        {
+            return;
+        }
+
+        var transaction = await _connection.BeginTransactionAsync().ConfigureAwait(false);
+        await using var _ = transaction.ConfigureAwait(false);
+
+        try
+        {
+            using var command = _connection.CreateCommand();
+            command.Transaction = (SqliteTransaction)transaction;
+
+#pragma warning disable CA2100
+            command.CommandText =
+                """
+                INSERT INTO dependencies (file_id, requires_path, resolved_file_id, alias)
+                VALUES (@fileId, @requiresPath, @resolvedFileId, @alias)
+                """;
+#pragma warning restore CA2100
+
+            var pFileId = command.Parameters.Add(new SqliteParameter("@fileId", 0L));
+            var pRequiresPath = command.Parameters.Add(new SqliteParameter("@requiresPath", ""));
+            var pResolvedFileId = command.Parameters.Add(new SqliteParameter("@resolvedFileId", 0L));
+            var pAlias = command.Parameters.Add(new SqliteParameter("@alias", ""));
+
+            foreach (var dep in deps)
+            {
+                pFileId.Value = dep.FileId;
+                pRequiresPath.Value = dep.RequiresPath;
+                pResolvedFileId.Value = dep.ResolvedFileId.HasValue ? dep.ResolvedFileId.Value : DBNull.Value;
+                pAlias.Value = (object?)dep.Alias ?? DBNull.Value;
+
+                await command.ExecuteNonQueryAsync().ConfigureAwait(false);
+            }
+
+            await transaction.CommitAsync().ConfigureAwait(false);
+        }
+        catch
+        {
+            await transaction.RollbackAsync().ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    public async Task<IReadOnlyList<Dependency>> GetDependenciesByFileAsync(long fileId)
+    {
+        using var command = _connection.CreateCommand();
+
+#pragma warning disable CA2100
+        command.CommandText =
+            """
+            SELECT id, file_id, requires_path, resolved_file_id, alias
+            FROM dependencies WHERE file_id = @fileId
+            """;
+#pragma warning restore CA2100
+
+        command.Parameters.AddWithValue("@fileId", fileId);
+
+        using var reader = await command.ExecuteReaderAsync().ConfigureAwait(false);
+        var results = new List<Dependency>();
+
+        while (await reader.ReadAsync().ConfigureAwait(false))
+        {
+            results.Add(new Dependency(
+                reader.GetInt64(0),
+                reader.GetInt64(1),
+                reader.GetString(2),
+                await reader.IsDBNullAsync(3).ConfigureAwait(false) ? null : reader.GetInt64(3),
+                await reader.IsDBNullAsync(4).ConfigureAwait(false) ? null : reader.GetString(4)));
+        }
+
+        return results;
+    }
+
+    public async Task DeleteDependenciesByFileAsync(long fileId)
+    {
+        using var command = _connection.CreateCommand();
+
+#pragma warning disable CA2100
+        command.CommandText = "DELETE FROM dependencies WHERE file_id = @fileId";
+#pragma warning restore CA2100
+
+        command.Parameters.AddWithValue("@fileId", fileId);
+
+        await command.ExecuteNonQueryAsync().ConfigureAwait(false);
+    }
+
+    // ── Snapshots ───────────────────────────────────────────────────────
+
+    public async Task<long> CreateSnapshotAsync(IndexSnapshot snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+
+        using var command = _connection.CreateCommand();
+
+#pragma warning disable CA2100
+        command.CommandText =
+            """
+            INSERT INTO index_snapshots (repo_id, snapshot_label, created_at, file_hashes)
+            VALUES (@repoId, @snapshotLabel, @createdAt, @fileHashes)
+            RETURNING id
+            """;
+#pragma warning restore CA2100
+
+        command.Parameters.AddWithValue("@repoId", snapshot.RepoId);
+        command.Parameters.AddWithValue("@snapshotLabel", snapshot.SnapshotLabel);
+        command.Parameters.AddWithValue("@createdAt", snapshot.CreatedAt);
+        command.Parameters.AddWithValue("@fileHashes", snapshot.FileHashes);
+
+        var result = await command.ExecuteScalarAsync().ConfigureAwait(false);
+        return (long)result!;
+    }
+
+    public async Task<IndexSnapshot?> GetSnapshotAsync(long snapshotId)
+    {
+        using var command = _connection.CreateCommand();
+
+#pragma warning disable CA2100
+        command.CommandText =
+            """
+            SELECT id, repo_id, snapshot_label, created_at, file_hashes
+            FROM index_snapshots WHERE id = @id
+            """;
+#pragma warning restore CA2100
+
+        command.Parameters.AddWithValue("@id", snapshotId);
+
+        using var reader = await command.ExecuteReaderAsync().ConfigureAwait(false);
+
+        if (await reader.ReadAsync().ConfigureAwait(false))
+        {
+            return new IndexSnapshot(
+                reader.GetInt64(0),
+                reader.GetString(1),
+                reader.GetString(2),
+                reader.GetInt64(3),
+                reader.GetString(4));
+        }
+
+        return null;
+    }
+
+    public async Task<IReadOnlyList<IndexSnapshot>> GetSnapshotsByRepoAsync(string repoId)
+    {
+        ArgumentNullException.ThrowIfNull(repoId);
+
+        using var command = _connection.CreateCommand();
+
+#pragma warning disable CA2100
+        command.CommandText =
+            """
+            SELECT id, repo_id, snapshot_label, created_at, file_hashes
+            FROM index_snapshots WHERE repo_id = @repoId ORDER BY created_at DESC
+            """;
+#pragma warning restore CA2100
+
+        command.Parameters.AddWithValue("@repoId", repoId);
+
+        using var reader = await command.ExecuteReaderAsync().ConfigureAwait(false);
+        var results = new List<IndexSnapshot>();
+
+        while (await reader.ReadAsync().ConfigureAwait(false))
+        {
+            results.Add(new IndexSnapshot(
+                reader.GetInt64(0),
+                reader.GetString(1),
+                reader.GetString(2),
+                reader.GetInt64(3),
+                reader.GetString(4)));
+        }
+
+        return results;
+    }
+}

--- a/tests/CodeCompress.Core.Tests/Storage/Fts5SanitizerTests.cs
+++ b/tests/CodeCompress.Core.Tests/Storage/Fts5SanitizerTests.cs
@@ -1,0 +1,131 @@
+using CodeCompress.Core.Storage;
+
+namespace CodeCompress.Core.Tests.Storage;
+
+internal sealed class Fts5SanitizerTests
+{
+    [Test]
+    public async Task SanitizeReturnsEmptyForNull()
+    {
+        var result = Fts5Sanitizer.Sanitize(null);
+
+        await Assert.That(result).IsEqualTo(string.Empty);
+    }
+
+    [Test]
+    public async Task SanitizeReturnsEmptyForEmptyString()
+    {
+        var result = Fts5Sanitizer.Sanitize("");
+
+        await Assert.That(result).IsEqualTo(string.Empty);
+    }
+
+    [Test]
+    public async Task SanitizeReturnsEmptyForWhitespace()
+    {
+        var result = Fts5Sanitizer.Sanitize("   ");
+
+        await Assert.That(result).IsEqualTo(string.Empty);
+    }
+
+    [Test]
+    public async Task SanitizeQuotesSingleTerm()
+    {
+        var result = Fts5Sanitizer.Sanitize("hello");
+
+        await Assert.That(result).IsEqualTo("\"hello\"");
+    }
+
+    [Test]
+    public async Task SanitizeQuotesMultipleTerms()
+    {
+        var result = Fts5Sanitizer.Sanitize("hello world");
+
+        await Assert.That(result).IsEqualTo("\"hello\" \"world\"");
+    }
+
+    [Test]
+    public async Task SanitizeStripsSpecialCharacters()
+    {
+        var result = Fts5Sanitizer.Sanitize("name:*");
+
+        await Assert.That(result).IsEqualTo("\"name\"");
+    }
+
+    [Test]
+    public async Task SanitizeNeutralizesOperators()
+    {
+        var result = Fts5Sanitizer.Sanitize("foo OR bar");
+
+        await Assert.That(result).IsEqualTo("\"foo\" \"OR\" \"bar\"");
+    }
+
+    [Test]
+    public async Task SanitizeHandlesAdversarialInput()
+    {
+        var result = Fts5Sanitizer.Sanitize("NEAR/3 OR DROP TABLE");
+
+        await Assert.That(result.Length).IsGreaterThan(0);
+        await Assert.That(result).Contains("\"");
+    }
+
+    [Test]
+    public async Task SanitizeStripsParenthesesAndDashes()
+    {
+        var result = Fts5Sanitizer.Sanitize(")(--");
+
+        await Assert.That(result).IsEqualTo(string.Empty);
+    }
+
+    [Test]
+    public async Task SanitizeStripsQuotesAndQuotesTerms()
+    {
+        var result = Fts5Sanitizer.Sanitize("\"injected phrase\"");
+
+        await Assert.That(result).IsEqualTo("\"injected\" \"phrase\"");
+    }
+
+    [Test]
+    [Arguments("AND")]
+    [Arguments("OR")]
+    [Arguments("NOT")]
+    [Arguments("NEAR")]
+    public async Task SanitizeQuotesReservedKeyword(string keyword)
+    {
+        var result = Fts5Sanitizer.Sanitize(keyword);
+
+        await Assert.That(result).IsEqualTo($"\"{keyword}\"");
+    }
+
+    [Test]
+    public async Task SanitizeStripsPlusAndCaret()
+    {
+        var result = Fts5Sanitizer.Sanitize("+prefix ^boost");
+
+        await Assert.That(result).IsEqualTo("\"prefix\" \"boost\"");
+    }
+
+    [Test]
+    public async Task SanitizeStripsCurlyBraces()
+    {
+        var result = Fts5Sanitizer.Sanitize("{col1 col2}:term");
+
+        await Assert.That(result).IsEqualTo("\"col1\" \"col2\" \"term\"");
+    }
+
+    [Test]
+    public async Task SanitizeStripsBackslash()
+    {
+        var result = Fts5Sanitizer.Sanitize("path\\to\\file");
+
+        await Assert.That(result).IsEqualTo("\"path\" \"to\" \"file\"");
+    }
+
+    [Test]
+    public async Task SanitizePreservesAlphanumericTerms()
+    {
+        var result = Fts5Sanitizer.Sanitize("MyClass123 method42");
+
+        await Assert.That(result).IsEqualTo("\"MyClass123\" \"method42\"");
+    }
+}

--- a/tests/CodeCompress.Core.Tests/Storage/MigrationsTests.cs
+++ b/tests/CodeCompress.Core.Tests/Storage/MigrationsTests.cs
@@ -1,0 +1,189 @@
+using CodeCompress.Core.Storage;
+using Microsoft.Data.Sqlite;
+
+namespace CodeCompress.Core.Tests.Storage;
+
+internal sealed class MigrationsTests
+{
+    private static async Task<SqliteConnection> CreateInMemoryConnectionAsync()
+    {
+        var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync().ConfigureAwait(false);
+
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "PRAGMA foreign_keys=ON;";
+        await cmd.ExecuteNonQueryAsync().ConfigureAwait(false);
+
+        return connection;
+    }
+
+    private static async Task<bool> TableExistsAsync(SqliteConnection connection, string tableName)
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=@name;";
+        cmd.Parameters.AddWithValue("@name", tableName);
+        long count = (long)(await cmd.ExecuteScalarAsync().ConfigureAwait(false))!;
+        return count == 1;
+    }
+
+    [Test]
+    public async Task ApplyAsyncCreatesRepositoriesTable()
+    {
+        using var connection = await CreateInMemoryConnectionAsync().ConfigureAwait(false);
+
+        await Migrations.ApplyAsync(connection).ConfigureAwait(false);
+
+        bool exists = await TableExistsAsync(connection, "repositories").ConfigureAwait(false);
+        await Assert.That(exists).IsTrue();
+    }
+
+    [Test]
+    public async Task ApplyAsyncCreatesFilesTable()
+    {
+        using var connection = await CreateInMemoryConnectionAsync().ConfigureAwait(false);
+
+        await Migrations.ApplyAsync(connection).ConfigureAwait(false);
+
+        bool exists = await TableExistsAsync(connection, "files").ConfigureAwait(false);
+        await Assert.That(exists).IsTrue();
+    }
+
+    [Test]
+    public async Task ApplyAsyncCreatesSymbolsTable()
+    {
+        using var connection = await CreateInMemoryConnectionAsync().ConfigureAwait(false);
+
+        await Migrations.ApplyAsync(connection).ConfigureAwait(false);
+
+        bool exists = await TableExistsAsync(connection, "symbols").ConfigureAwait(false);
+        await Assert.That(exists).IsTrue();
+    }
+
+    [Test]
+    public async Task ApplyAsyncCreatesDependenciesTable()
+    {
+        using var connection = await CreateInMemoryConnectionAsync().ConfigureAwait(false);
+
+        await Migrations.ApplyAsync(connection).ConfigureAwait(false);
+
+        bool exists = await TableExistsAsync(connection, "dependencies").ConfigureAwait(false);
+        await Assert.That(exists).IsTrue();
+    }
+
+    [Test]
+    public async Task ApplyAsyncCreatesIndexSnapshotsTable()
+    {
+        using var connection = await CreateInMemoryConnectionAsync().ConfigureAwait(false);
+
+        await Migrations.ApplyAsync(connection).ConfigureAwait(false);
+
+        bool exists = await TableExistsAsync(connection, "index_snapshots").ConfigureAwait(false);
+        await Assert.That(exists).IsTrue();
+    }
+
+    [Test]
+    public async Task ApplyAsyncCreatesAllIndexes()
+    {
+        using var connection = await CreateInMemoryConnectionAsync().ConfigureAwait(false);
+
+        await Migrations.ApplyAsync(connection).ConfigureAwait(false);
+
+        var expectedIndexes = new[]
+        {
+            "ix_files_repo_id",
+            "ix_files_content_hash",
+            "ix_files_repo_path",
+            "ix_symbols_file_id",
+            "ix_symbols_name",
+            "ix_symbols_kind",
+            "ix_dependencies_file_id",
+            "ix_dependencies_resolved",
+            "ix_snapshots_repo_id",
+        };
+
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT name FROM sqlite_master WHERE type='index' AND name LIKE 'ix_%';";
+        using var reader = await cmd.ExecuteReaderAsync().ConfigureAwait(false);
+
+        var actualIndexes = new List<string>();
+        while (await reader.ReadAsync().ConfigureAwait(false))
+        {
+            actualIndexes.Add(reader.GetString(0));
+        }
+
+        foreach (string expected in expectedIndexes)
+        {
+            await Assert.That(actualIndexes).Contains(expected);
+        }
+
+        await Assert.That(actualIndexes).Count().IsEqualTo(expectedIndexes.Length);
+    }
+
+    [Test]
+    public async Task ApplyAsyncCreatesSymbolsFtsTable()
+    {
+        using var connection = await CreateInMemoryConnectionAsync().ConfigureAwait(false);
+
+        await Migrations.ApplyAsync(connection).ConfigureAwait(false);
+
+        bool exists = await TableExistsAsync(connection, "symbols_fts").ConfigureAwait(false);
+        await Assert.That(exists).IsTrue();
+    }
+
+    [Test]
+    public async Task ApplyAsyncCreatesFileContentFtsTable()
+    {
+        using var connection = await CreateInMemoryConnectionAsync().ConfigureAwait(false);
+
+        await Migrations.ApplyAsync(connection).ConfigureAwait(false);
+
+        bool exists = await TableExistsAsync(connection, "file_content_fts").ConfigureAwait(false);
+        await Assert.That(exists).IsTrue();
+    }
+
+    [Test]
+    public async Task ApplyAsyncIsIdempotent()
+    {
+        using var connection = await CreateInMemoryConnectionAsync().ConfigureAwait(false);
+
+        await Migrations.ApplyAsync(connection).ConfigureAwait(false);
+        await Migrations.ApplyAsync(connection).ConfigureAwait(false);
+
+        bool repositoriesExist = await TableExistsAsync(connection, "repositories").ConfigureAwait(false);
+        bool filesExist = await TableExistsAsync(connection, "files").ConfigureAwait(false);
+        bool symbolsExist = await TableExistsAsync(connection, "symbols").ConfigureAwait(false);
+        bool dependenciesExist = await TableExistsAsync(connection, "dependencies").ConfigureAwait(false);
+        bool snapshotsExist = await TableExistsAsync(connection, "index_snapshots").ConfigureAwait(false);
+
+        await Assert.That(repositoriesExist).IsTrue();
+        await Assert.That(filesExist).IsTrue();
+        await Assert.That(symbolsExist).IsTrue();
+        await Assert.That(dependenciesExist).IsTrue();
+        await Assert.That(snapshotsExist).IsTrue();
+    }
+
+    [Test]
+    public async Task ApplyAsyncCreatesAllFiveTables()
+    {
+        using var connection = await CreateInMemoryConnectionAsync().ConfigureAwait(false);
+
+        await Migrations.ApplyAsync(connection).ConfigureAwait(false);
+
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = """
+            SELECT COUNT(*) FROM sqlite_master
+            WHERE type='table'
+            AND name IN ('repositories', 'files', 'symbols', 'dependencies', 'index_snapshots');
+            """;
+        long count = (long)(await cmd.ExecuteScalarAsync().ConfigureAwait(false))!;
+
+        await Assert.That(count).IsEqualTo(5);
+    }
+
+    [Test]
+    public async Task ApplyAsyncRejectsNullConnection()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => Migrations.ApplyAsync(null!));
+    }
+}

--- a/tests/CodeCompress.Core.Tests/Storage/SqliteConnectionFactoryTests.cs
+++ b/tests/CodeCompress.Core.Tests/Storage/SqliteConnectionFactoryTests.cs
@@ -1,0 +1,87 @@
+using CodeCompress.Core.Storage;
+
+namespace CodeCompress.Core.Tests.Storage;
+
+internal sealed class SqliteConnectionFactoryTests
+{
+    [Test]
+    public async Task ComputeRepoHashIsDeterministic()
+    {
+        var hash1 = SqliteConnectionFactory.ComputeRepoHash("/home/user/project");
+        var hash2 = SqliteConnectionFactory.ComputeRepoHash("/home/user/project");
+
+        await Assert.That(hash1).IsEqualTo(hash2);
+    }
+
+    [Test]
+    public async Task ComputeRepoHashNormalizesSlashes()
+    {
+        var hashForward = SqliteConnectionFactory.ComputeRepoHash("C:/foo/bar");
+        var hashBackward = SqliteConnectionFactory.ComputeRepoHash(@"C:\foo\bar");
+
+        await Assert.That(hashForward).IsEqualTo(hashBackward);
+    }
+
+    [Test]
+    public async Task ComputeRepoHashRemovesTrailingSlash()
+    {
+        var hashWithout = SqliteConnectionFactory.ComputeRepoHash("/home/user/project");
+        var hashWithTrailing = SqliteConnectionFactory.ComputeRepoHash("/home/user/project/");
+
+        await Assert.That(hashWithout).IsEqualTo(hashWithTrailing);
+    }
+
+    [Test]
+    public async Task ComputeRepoHashProduces64CharHexString()
+    {
+        var hash = SqliteConnectionFactory.ComputeRepoHash("/some/path");
+
+        await Assert.That(hash.Length).IsEqualTo(64);
+        await Assert.That(hash).Matches("^[0-9a-f]{64}$");
+    }
+
+    [Test]
+    public async Task ComputeRepoHashDifferentPathsProduceDifferentHashes()
+    {
+        var hash1 = SqliteConnectionFactory.ComputeRepoHash("/home/user/projectA");
+        var hash2 = SqliteConnectionFactory.ComputeRepoHash("/home/user/projectB");
+
+        await Assert.That(hash1).IsNotEqualTo(hash2);
+    }
+
+    [Test]
+    public async Task CreateConnectionAsyncRejectsNullPath()
+    {
+        var factory = new SqliteConnectionFactory();
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => factory.CreateConnectionAsync(null!));
+    }
+
+    [Test]
+    public async Task CreateConnectionAsyncRejectsEmptyPath()
+    {
+        var factory = new SqliteConnectionFactory();
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => factory.CreateConnectionAsync(""));
+    }
+
+    [Test]
+    public async Task CreateConnectionAsyncRejectsWhitespacePath()
+    {
+        var factory = new SqliteConnectionFactory();
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => factory.CreateConnectionAsync("   "));
+    }
+
+    [Test]
+    public async Task CreateConnectionAsyncRejectsPathTraversal()
+    {
+        var factory = new SqliteConnectionFactory();
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => factory.CreateConnectionAsync("/valid/../../etc/passwd"));
+    }
+}

--- a/tests/CodeCompress.Core.Tests/Storage/SymbolStoreCrudTests.cs
+++ b/tests/CodeCompress.Core.Tests/Storage/SymbolStoreCrudTests.cs
@@ -1,0 +1,504 @@
+using CodeCompress.Core.Models;
+using CodeCompress.Core.Storage;
+using Microsoft.Data.Sqlite;
+
+namespace CodeCompress.Core.Tests.Storage;
+
+internal sealed class SymbolStoreCrudTests
+{
+    private static async Task<SqliteConnection> CreateTestConnectionAsync()
+    {
+        var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync().ConfigureAwait(false);
+
+        using var fkCmd = connection.CreateCommand();
+        fkCmd.CommandText = "PRAGMA foreign_keys=ON;";
+        await fkCmd.ExecuteNonQueryAsync().ConfigureAwait(false);
+
+        await Migrations.ApplyAsync(connection).ConfigureAwait(false);
+        return connection;
+    }
+
+    private static Repository CreateTestRepo(string id = "test-repo-id") =>
+        new(id, "/test/path", "TestProject", "luau", DateTimeOffset.UtcNow.ToUnixTimeSeconds(), 0, 0);
+
+    private static FileRecord CreateTestFile(string repoId, string path = "src/main.luau", long id = 0) =>
+        new(id, repoId, path, "abc123hash", 1024, 50, DateTimeOffset.UtcNow.ToUnixTimeSeconds(), DateTimeOffset.UtcNow.ToUnixTimeSeconds());
+
+    private static Symbol CreateTestSymbol(long fileId, string name = "TestFunction", int lineStart = 1, int lineEnd = 10) =>
+        new(0, fileId, name, "function", $"function {name}()", null, 0, 100, lineStart, lineEnd, "public", "A test function");
+
+    private static Dependency CreateTestDependency(long fileId, string requiresPath = "modules/utils", long? resolvedFileId = null, string? alias = null) =>
+        new(0, fileId, requiresPath, resolvedFileId, alias);
+
+    // ── Repository Tests ────────────────────────────────────────────────
+
+    [Test]
+    public async Task UpsertRepositoryAsyncInsertsNewRepository()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(connection);
+        var repo = CreateTestRepo();
+
+        await store.UpsertRepositoryAsync(repo).ConfigureAwait(false);
+
+        var result = await store.GetRepositoryAsync(repo.Id).ConfigureAwait(false);
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.Id).IsEqualTo(repo.Id);
+        await Assert.That(result.RootPath).IsEqualTo(repo.RootPath);
+        await Assert.That(result.Name).IsEqualTo(repo.Name);
+        await Assert.That(result.Language).IsEqualTo(repo.Language);
+        await Assert.That(result.LastIndexed).IsEqualTo(repo.LastIndexed);
+        await Assert.That(result.FileCount).IsEqualTo(repo.FileCount);
+        await Assert.That(result.SymbolCount).IsEqualTo(repo.SymbolCount);
+    }
+
+    [Test]
+    public async Task UpsertRepositoryAsyncUpdatesExistingRepository()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(connection);
+        var repo = CreateTestRepo();
+
+        await store.UpsertRepositoryAsync(repo).ConfigureAwait(false);
+
+        var updated = new Repository(repo.Id, "/updated/path", "UpdatedProject", "csharp", 999999L, 10, 42);
+        await store.UpsertRepositoryAsync(updated).ConfigureAwait(false);
+
+        var result = await store.GetRepositoryAsync(repo.Id).ConfigureAwait(false);
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.RootPath).IsEqualTo("/updated/path");
+        await Assert.That(result.Name).IsEqualTo("UpdatedProject");
+        await Assert.That(result.Language).IsEqualTo("csharp");
+        await Assert.That(result.FileCount).IsEqualTo(10);
+        await Assert.That(result.SymbolCount).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task GetRepositoryAsyncReturnsNullForMissingId()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(connection);
+
+        var result = await store.GetRepositoryAsync("nonexistent").ConfigureAwait(false);
+
+        await Assert.That(result).IsNull();
+    }
+
+    [Test]
+    public async Task DeleteRepositoryAsyncCascadesToChildRecords()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(connection);
+        var repo = CreateTestRepo();
+
+        await store.UpsertRepositoryAsync(repo).ConfigureAwait(false);
+        await store.InsertFilesAsync([CreateTestFile(repo.Id)]).ConfigureAwait(false);
+
+        var files = await store.GetFilesByRepoAsync(repo.Id).ConfigureAwait(false);
+        long fileId = files[0].Id;
+
+        await store.InsertSymbolsAsync([CreateTestSymbol(fileId)]).ConfigureAwait(false);
+
+        // Delete the repository - should cascade to files and symbols
+        await store.DeleteRepositoryAsync(repo.Id).ConfigureAwait(false);
+
+        var deletedRepo = await store.GetRepositoryAsync(repo.Id).ConfigureAwait(false);
+        var remainingFiles = await store.GetFilesByRepoAsync(repo.Id).ConfigureAwait(false);
+        var remainingSymbols = await store.GetSymbolsByFileAsync(fileId).ConfigureAwait(false);
+
+        await Assert.That(deletedRepo).IsNull();
+        await Assert.That(remainingFiles).Count().IsEqualTo(0);
+        await Assert.That(remainingSymbols).Count().IsEqualTo(0);
+    }
+
+    // ── File Tests ──────────────────────────────────────────────────────
+
+    [Test]
+    public async Task InsertFilesAsyncInsertsMultipleFiles()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(connection);
+        var repo = CreateTestRepo();
+        await store.UpsertRepositoryAsync(repo).ConfigureAwait(false);
+
+        var files = new List<FileRecord>
+        {
+            CreateTestFile(repo.Id, "src/a.luau"),
+            CreateTestFile(repo.Id, "src/b.luau"),
+            CreateTestFile(repo.Id, "src/c.luau"),
+        };
+
+        await store.InsertFilesAsync(files).ConfigureAwait(false);
+
+        var result = await store.GetFilesByRepoAsync(repo.Id).ConfigureAwait(false);
+        await Assert.That(result).Count().IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task GetFileByPathAsyncReturnsCorrectFile()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(connection);
+        var repo = CreateTestRepo();
+        await store.UpsertRepositoryAsync(repo).ConfigureAwait(false);
+
+        await store.InsertFilesAsync([CreateTestFile(repo.Id, "src/main.luau")]).ConfigureAwait(false);
+
+        var result = await store.GetFileByPathAsync(repo.Id, "src/main.luau").ConfigureAwait(false);
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.RelativePath).IsEqualTo("src/main.luau");
+        await Assert.That(result.RepoId).IsEqualTo(repo.Id);
+        await Assert.That(result.ContentHash).IsEqualTo("abc123hash");
+    }
+
+    [Test]
+    public async Task GetFileByPathAsyncReturnsNullForMissingPath()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(connection);
+        var repo = CreateTestRepo();
+        await store.UpsertRepositoryAsync(repo).ConfigureAwait(false);
+
+        var result = await store.GetFileByPathAsync(repo.Id, "nonexistent.luau").ConfigureAwait(false);
+
+        await Assert.That(result).IsNull();
+    }
+
+    [Test]
+    public async Task UpdateFileAsyncUpdatesFields()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(connection);
+        var repo = CreateTestRepo();
+        await store.UpsertRepositoryAsync(repo).ConfigureAwait(false);
+
+        await store.InsertFilesAsync([CreateTestFile(repo.Id, "src/main.luau")]).ConfigureAwait(false);
+
+        var files = await store.GetFilesByRepoAsync(repo.Id).ConfigureAwait(false);
+        var original = files[0];
+
+        var updated = new FileRecord(original.Id, original.RepoId, original.RelativePath, "newhash999", 2048, 100, original.LastModified, DateTimeOffset.UtcNow.ToUnixTimeSeconds());
+        await store.UpdateFileAsync(updated).ConfigureAwait(false);
+
+        var result = await store.GetFileByPathAsync(repo.Id, "src/main.luau").ConfigureAwait(false);
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.ContentHash).IsEqualTo("newhash999");
+        await Assert.That(result.ByteLength).IsEqualTo(2048L);
+        await Assert.That(result.LineCount).IsEqualTo(100);
+    }
+
+    [Test]
+    public async Task DeleteFileAsyncRemovesFile()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(connection);
+        var repo = CreateTestRepo();
+        await store.UpsertRepositoryAsync(repo).ConfigureAwait(false);
+
+        await store.InsertFilesAsync([CreateTestFile(repo.Id, "src/main.luau")]).ConfigureAwait(false);
+
+        var files = await store.GetFilesByRepoAsync(repo.Id).ConfigureAwait(false);
+        long fileId = files[0].Id;
+
+        await store.DeleteFileAsync(fileId).ConfigureAwait(false);
+
+        var remaining = await store.GetFilesByRepoAsync(repo.Id).ConfigureAwait(false);
+        await Assert.That(remaining).Count().IsEqualTo(0);
+    }
+
+    // ── Symbol Tests ────────────────────────────────────────────────────
+
+    [Test]
+    public async Task InsertSymbolsAsyncInsertsMultipleSymbols()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(connection);
+        var repo = CreateTestRepo();
+        await store.UpsertRepositoryAsync(repo).ConfigureAwait(false);
+        await store.InsertFilesAsync([CreateTestFile(repo.Id)]).ConfigureAwait(false);
+
+        var files = await store.GetFilesByRepoAsync(repo.Id).ConfigureAwait(false);
+        long fileId = files[0].Id;
+
+        var symbols = new List<Symbol>
+        {
+            CreateTestSymbol(fileId, "FuncA", 1, 10),
+            CreateTestSymbol(fileId, "FuncB", 12, 20),
+            CreateTestSymbol(fileId, "FuncC", 22, 30),
+        };
+
+        await store.InsertSymbolsAsync(symbols).ConfigureAwait(false);
+
+        var result = await store.GetSymbolsByFileAsync(fileId).ConfigureAwait(false);
+        await Assert.That(result).Count().IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task GetSymbolsByFileAsyncReturnsOrderedByLineStart()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(connection);
+        var repo = CreateTestRepo();
+        await store.UpsertRepositoryAsync(repo).ConfigureAwait(false);
+        await store.InsertFilesAsync([CreateTestFile(repo.Id)]).ConfigureAwait(false);
+
+        var files = await store.GetFilesByRepoAsync(repo.Id).ConfigureAwait(false);
+        long fileId = files[0].Id;
+
+        // Insert in reverse order
+        var symbols = new List<Symbol>
+        {
+            CreateTestSymbol(fileId, "Third", 30, 40),
+            CreateTestSymbol(fileId, "First", 1, 10),
+            CreateTestSymbol(fileId, "Second", 15, 25),
+        };
+
+        await store.InsertSymbolsAsync(symbols).ConfigureAwait(false);
+
+        var result = await store.GetSymbolsByFileAsync(fileId).ConfigureAwait(false);
+        await Assert.That(result[0].Name).IsEqualTo("First");
+        await Assert.That(result[1].Name).IsEqualTo("Second");
+        await Assert.That(result[2].Name).IsEqualTo("Third");
+    }
+
+    [Test]
+    public async Task DeleteSymbolsByFileAsyncRemovesAllSymbols()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(connection);
+        var repo = CreateTestRepo();
+        await store.UpsertRepositoryAsync(repo).ConfigureAwait(false);
+        await store.InsertFilesAsync([CreateTestFile(repo.Id)]).ConfigureAwait(false);
+
+        var files = await store.GetFilesByRepoAsync(repo.Id).ConfigureAwait(false);
+        long fileId = files[0].Id;
+
+        await store.InsertSymbolsAsync([CreateTestSymbol(fileId, "A"), CreateTestSymbol(fileId, "B", 11, 20)]).ConfigureAwait(false);
+
+        await store.DeleteSymbolsByFileAsync(fileId).ConfigureAwait(false);
+
+        var result = await store.GetSymbolsByFileAsync(fileId).ConfigureAwait(false);
+        await Assert.That(result).Count().IsEqualTo(0);
+    }
+
+    // ── Dependency Tests ────────────────────────────────────────────────
+
+    [Test]
+    public async Task InsertDependenciesAsyncInsertsMultipleDependencies()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(connection);
+        var repo = CreateTestRepo();
+        await store.UpsertRepositoryAsync(repo).ConfigureAwait(false);
+        await store.InsertFilesAsync([CreateTestFile(repo.Id)]).ConfigureAwait(false);
+
+        var files = await store.GetFilesByRepoAsync(repo.Id).ConfigureAwait(false);
+        long fileId = files[0].Id;
+
+        var deps = new List<Dependency>
+        {
+            CreateTestDependency(fileId, "modules/utils"),
+            CreateTestDependency(fileId, "modules/config", null, "Config"),
+        };
+
+        await store.InsertDependenciesAsync(deps).ConfigureAwait(false);
+
+        var result = await store.GetDependenciesByFileAsync(fileId).ConfigureAwait(false);
+        await Assert.That(result).Count().IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task GetDependenciesByFileAsyncReturnsCorrectDependencies()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(connection);
+        var repo = CreateTestRepo();
+        await store.UpsertRepositoryAsync(repo).ConfigureAwait(false);
+        await store.InsertFilesAsync([CreateTestFile(repo.Id)]).ConfigureAwait(false);
+
+        var files = await store.GetFilesByRepoAsync(repo.Id).ConfigureAwait(false);
+        long fileId = files[0].Id;
+
+        await store.InsertDependenciesAsync([CreateTestDependency(fileId, "modules/utils", null, "Utils")]).ConfigureAwait(false);
+
+        var result = await store.GetDependenciesByFileAsync(fileId).ConfigureAwait(false);
+        await Assert.That(result).Count().IsEqualTo(1);
+        await Assert.That(result[0].RequiresPath).IsEqualTo("modules/utils");
+        await Assert.That(result[0].Alias).IsEqualTo("Utils");
+        await Assert.That(result[0].ResolvedFileId).IsNull();
+    }
+
+    [Test]
+    public async Task DeleteDependenciesByFileAsyncRemovesAllDependencies()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(connection);
+        var repo = CreateTestRepo();
+        await store.UpsertRepositoryAsync(repo).ConfigureAwait(false);
+        await store.InsertFilesAsync([CreateTestFile(repo.Id)]).ConfigureAwait(false);
+
+        var files = await store.GetFilesByRepoAsync(repo.Id).ConfigureAwait(false);
+        long fileId = files[0].Id;
+
+        await store.InsertDependenciesAsync(
+        [
+            CreateTestDependency(fileId, "a"),
+            CreateTestDependency(fileId, "b"),
+        ]).ConfigureAwait(false);
+
+        await store.DeleteDependenciesByFileAsync(fileId).ConfigureAwait(false);
+
+        var result = await store.GetDependenciesByFileAsync(fileId).ConfigureAwait(false);
+        await Assert.That(result).Count().IsEqualTo(0);
+    }
+
+    // ── Snapshot Tests ──────────────────────────────────────────────────
+
+    [Test]
+    public async Task CreateSnapshotAsyncReturnsAutoIncrementedId()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(connection);
+        var repo = CreateTestRepo();
+        await store.UpsertRepositoryAsync(repo).ConfigureAwait(false);
+
+        long now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+        var snapshot1 = new IndexSnapshot(0, repo.Id, "v1", now, "{}");
+        var snapshot2 = new IndexSnapshot(0, repo.Id, "v2", now + 1, "{}");
+
+        long id1 = await store.CreateSnapshotAsync(snapshot1).ConfigureAwait(false);
+        long id2 = await store.CreateSnapshotAsync(snapshot2).ConfigureAwait(false);
+
+        await Assert.That(id1).IsGreaterThan(0L);
+        await Assert.That(id2).IsGreaterThan(id1);
+    }
+
+    [Test]
+    public async Task GetSnapshotAsyncReturnsCorrectSnapshot()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(connection);
+        var repo = CreateTestRepo();
+        await store.UpsertRepositoryAsync(repo).ConfigureAwait(false);
+
+        long now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+        var snapshot = new IndexSnapshot(0, repo.Id, "my-snapshot", now, "{\"hash\":\"abc\"}");
+        long id = await store.CreateSnapshotAsync(snapshot).ConfigureAwait(false);
+
+        var result = await store.GetSnapshotAsync(id).ConfigureAwait(false);
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.Id).IsEqualTo(id);
+        await Assert.That(result.RepoId).IsEqualTo(repo.Id);
+        await Assert.That(result.SnapshotLabel).IsEqualTo("my-snapshot");
+        await Assert.That(result.CreatedAt).IsEqualTo(now);
+        await Assert.That(result.FileHashes).IsEqualTo("{\"hash\":\"abc\"}");
+    }
+
+    [Test]
+    public async Task GetSnapshotAsyncReturnsNullForMissingId()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(connection);
+
+        var result = await store.GetSnapshotAsync(99999L).ConfigureAwait(false);
+
+        await Assert.That(result).IsNull();
+    }
+
+    [Test]
+    public async Task GetSnapshotsByRepoAsyncReturnsOrderedByCreatedAtDesc()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(connection);
+        var repo = CreateTestRepo();
+        await store.UpsertRepositoryAsync(repo).ConfigureAwait(false);
+
+        long now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+        await store.CreateSnapshotAsync(new IndexSnapshot(0, repo.Id, "oldest", now - 100, "{}")).ConfigureAwait(false);
+        await store.CreateSnapshotAsync(new IndexSnapshot(0, repo.Id, "newest", now, "{}")).ConfigureAwait(false);
+        await store.CreateSnapshotAsync(new IndexSnapshot(0, repo.Id, "middle", now - 50, "{}")).ConfigureAwait(false);
+
+        var result = await store.GetSnapshotsByRepoAsync(repo.Id).ConfigureAwait(false);
+
+        await Assert.That(result).Count().IsEqualTo(3);
+        await Assert.That(result[0].SnapshotLabel).IsEqualTo("newest");
+        await Assert.That(result[1].SnapshotLabel).IsEqualTo("middle");
+        await Assert.That(result[2].SnapshotLabel).IsEqualTo("oldest");
+    }
+
+    // ── FTS5 Test ───────────────────────────────────────────────────────
+
+    [Test]
+    public async Task Fts5TriggersKeepSymbolsFtsInSync()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(connection);
+        var repo = CreateTestRepo();
+        await store.UpsertRepositoryAsync(repo).ConfigureAwait(false);
+        await store.InsertFilesAsync([CreateTestFile(repo.Id)]).ConfigureAwait(false);
+
+        var files = await store.GetFilesByRepoAsync(repo.Id).ConfigureAwait(false);
+        long fileId = files[0].Id;
+
+        // Insert a symbol and verify it appears in FTS
+        await store.InsertSymbolsAsync([CreateTestSymbol(fileId, "UniqueSearchableName")]).ConfigureAwait(false);
+
+        using var searchCmd = connection.CreateCommand();
+        searchCmd.CommandText = "SELECT COUNT(*) FROM symbols_fts WHERE symbols_fts MATCH @query";
+        searchCmd.Parameters.AddWithValue("@query", "UniqueSearchableName");
+        long ftsCount = (long)(await searchCmd.ExecuteScalarAsync().ConfigureAwait(false))!;
+        await Assert.That(ftsCount).IsEqualTo(1L);
+
+        // Delete the symbol and verify FTS is cleaned up
+        await store.DeleteSymbolsByFileAsync(fileId).ConfigureAwait(false);
+
+        using var searchCmd2 = connection.CreateCommand();
+        searchCmd2.CommandText = "SELECT COUNT(*) FROM symbols_fts WHERE symbols_fts MATCH @query";
+        searchCmd2.Parameters.AddWithValue("@query", "UniqueSearchableName");
+        long ftsCountAfter = (long)(await searchCmd2.ExecuteScalarAsync().ConfigureAwait(false))!;
+        await Assert.That(ftsCountAfter).IsEqualTo(0L);
+    }
+
+    // ── Batch Rollback Test ─────────────────────────────────────────────
+
+    [Test]
+    public async Task InsertFilesAsyncRollsBackOnFailure()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(connection);
+        var repo = CreateTestRepo();
+        await store.UpsertRepositoryAsync(repo).ConfigureAwait(false);
+
+        // Insert one file successfully
+        await store.InsertFilesAsync([CreateTestFile(repo.Id, "src/existing.luau")]).ConfigureAwait(false);
+
+        // Try to batch-insert two files where the second has the same (repo_id, relative_path)
+        // as the first in this batch — violating the unique constraint
+        var duplicateBatch = new List<FileRecord>
+        {
+            CreateTestFile(repo.Id, "src/new.luau"),
+            CreateTestFile(repo.Id, "src/existing.luau"), // duplicate of already-inserted file
+        };
+
+        bool threw = false;
+        try
+        {
+            await store.InsertFilesAsync(duplicateBatch).ConfigureAwait(false);
+        }
+        catch (SqliteException)
+        {
+            threw = true;
+        }
+
+        await Assert.That(threw).IsTrue();
+
+        // The original file should still exist, but the batch should have been rolled back
+        var remaining = await store.GetFilesByRepoAsync(repo.Id).ConfigureAwait(false);
+        await Assert.That(remaining).Count().IsEqualTo(1);
+        await Assert.That(remaining[0].RelativePath).IsEqualTo("src/existing.luau");
+    }
+}

--- a/tests/CodeCompress.Core.Tests/Storage/SymbolStoreQueryTests.cs
+++ b/tests/CodeCompress.Core.Tests/Storage/SymbolStoreQueryTests.cs
@@ -1,0 +1,541 @@
+using CodeCompress.Core.Models;
+using CodeCompress.Core.Storage;
+using Microsoft.Data.Sqlite;
+
+namespace CodeCompress.Core.Tests.Storage;
+
+internal sealed class SymbolStoreQueryTests
+{
+    private static async Task<SqliteConnection> CreateTestConnectionAsync()
+    {
+        var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync().ConfigureAwait(false);
+
+        using var fkCmd = connection.CreateCommand();
+        fkCmd.CommandText = "PRAGMA foreign_keys=ON;";
+        await fkCmd.ExecuteNonQueryAsync().ConfigureAwait(false);
+
+        await Migrations.ApplyAsync(connection).ConfigureAwait(false);
+        return connection;
+    }
+
+    private static async Task<(SqliteSymbolStore Store, long FileId)> SeedTestDataAsync(SqliteConnection connection)
+    {
+        var store = new SqliteSymbolStore(connection);
+        var repo = new Repository("repo1", "/test/path", "TestProject", "luau", 1000, 0, 0);
+        await store.UpsertRepositoryAsync(repo).ConfigureAwait(false);
+
+        var file = new FileRecord(0, "repo1", "src/main.luau", "hash1", 1024, 50, 1000, 1000);
+        await store.InsertFilesAsync([file]).ConfigureAwait(false);
+
+        var insertedFile = await store.GetFileByPathAsync("repo1", "src/main.luau").ConfigureAwait(false);
+
+        var symbols = new List<Symbol>
+        {
+            new(0, insertedFile!.Id, "Initialize", "Function", "function Initialize()", null, 0, 100, 1, 10, "Public", "Initializes the module"),
+            new(0, insertedFile.Id, "Helper", "Function", "local function Helper()", null, 100, 50, 11, 15, "Private", null),
+            new(0, insertedFile.Id, "MyClass", "Class", "class MyClass", null, 150, 200, 16, 40, "Public", "A class"),
+            new(0, insertedFile.Id, "DoWork", "Method", "function MyClass:DoWork()", "MyClass", 200, 80, 20, 30, "Public", "Does work"),
+        };
+        await store.InsertSymbolsAsync(symbols).ConfigureAwait(false);
+
+        return (store, insertedFile.Id);
+    }
+
+    // ── SearchSymbolsAsync Tests ─────────────────────────────────────────
+
+    [Test]
+    public async Task SearchSymbolsAsyncReturnsMatchingResults()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var (store, _) = await SeedTestDataAsync(connection).ConfigureAwait(false);
+
+        var results = await store.SearchSymbolsAsync("repo1", "Initialize", null, 10).ConfigureAwait(false);
+
+        await Assert.That(results.Count).IsGreaterThan(0);
+        await Assert.That(results[0].Symbol.Name).IsEqualTo("Initialize");
+    }
+
+    [Test]
+    public async Task SearchSymbolsAsyncFiltersByKind()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var (store, _) = await SeedTestDataAsync(connection).ConfigureAwait(false);
+
+        var results = await store.SearchSymbolsAsync("repo1", "Initialize", "Method", 10).ConfigureAwait(false);
+
+        await Assert.That(results).Count().IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task SearchSymbolsAsyncRespectsLimit()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var (store, _) = await SeedTestDataAsync(connection).ConfigureAwait(false);
+
+        var results = await store.SearchSymbolsAsync("repo1", "function", null, 2).ConfigureAwait(false);
+
+        await Assert.That(results.Count).IsLessThanOrEqualTo(2);
+    }
+
+    [Test]
+    public async Task SearchSymbolsAsyncReturnsEmptyForSanitizedEmptyQuery()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var (store, _) = await SeedTestDataAsync(connection).ConfigureAwait(false);
+
+        var results = await store.SearchSymbolsAsync("repo1", ")(--", null, 10).ConfigureAwait(false);
+
+        await Assert.That(results).Count().IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task SearchSymbolsAsyncReturnsFilePathInResult()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var (store, _) = await SeedTestDataAsync(connection).ConfigureAwait(false);
+
+        var results = await store.SearchSymbolsAsync("repo1", "Initialize", null, 10).ConfigureAwait(false);
+
+        await Assert.That(results.Count).IsGreaterThan(0);
+        await Assert.That(results[0].FilePath).IsEqualTo("src/main.luau");
+    }
+
+    [Test]
+    public async Task SearchSymbolsAsyncReturnsEmptyForWrongRepo()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var (store, _) = await SeedTestDataAsync(connection).ConfigureAwait(false);
+
+        var results = await store.SearchSymbolsAsync("nonexistent", "Initialize", null, 10).ConfigureAwait(false);
+
+        await Assert.That(results).Count().IsEqualTo(0);
+    }
+
+    // ── GetSymbolByNameAsync Tests ───────────────────────────────────────
+
+    [Test]
+    public async Task GetSymbolByNameAsyncReturnsExactMatch()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var (store, _) = await SeedTestDataAsync(connection).ConfigureAwait(false);
+
+        var result = await store.GetSymbolByNameAsync("repo1", "Initialize").ConfigureAwait(false);
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.Name).IsEqualTo("Initialize");
+    }
+
+    [Test]
+    public async Task GetSymbolByNameAsyncReturnsNullForMissing()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var (store, _) = await SeedTestDataAsync(connection).ConfigureAwait(false);
+
+        var result = await store.GetSymbolByNameAsync("repo1", "NonExistent").ConfigureAwait(false);
+
+        await Assert.That(result).IsNull();
+    }
+
+    [Test]
+    public async Task GetSymbolByNameAsyncHandlesDotQualifiedName()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var (store, _) = await SeedTestDataAsync(connection).ConfigureAwait(false);
+
+        var result = await store.GetSymbolByNameAsync("repo1", "MyClass.DoWork").ConfigureAwait(false);
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.Name).IsEqualTo("DoWork");
+        await Assert.That(result.ParentSymbol).IsEqualTo("MyClass");
+    }
+
+    [Test]
+    public async Task GetSymbolByNameAsyncHandlesColonQualifiedName()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var (store, _) = await SeedTestDataAsync(connection).ConfigureAwait(false);
+
+        var result = await store.GetSymbolByNameAsync("repo1", "MyClass:DoWork").ConfigureAwait(false);
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.Name).IsEqualTo("DoWork");
+        await Assert.That(result.ParentSymbol).IsEqualTo("MyClass");
+    }
+
+    [Test]
+    public async Task GetSymbolByNameAsyncReturnsNullForWrongRepo()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var (store, _) = await SeedTestDataAsync(connection).ConfigureAwait(false);
+
+        var result = await store.GetSymbolByNameAsync("nonexistent", "Initialize").ConfigureAwait(false);
+
+        await Assert.That(result).IsNull();
+    }
+
+    // ── GetSymbolsByNamesAsync Tests ─────────────────────────────────────
+
+    [Test]
+    public async Task GetSymbolsByNamesAsyncReturnsBatchResults()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var (store, _) = await SeedTestDataAsync(connection).ConfigureAwait(false);
+
+        var results = await store.GetSymbolsByNamesAsync("repo1", ["Initialize", "DoWork"]).ConfigureAwait(false);
+
+        await Assert.That(results).Count().IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task GetSymbolsByNamesAsyncHandlesMissingNames()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var (store, _) = await SeedTestDataAsync(connection).ConfigureAwait(false);
+
+        var results = await store.GetSymbolsByNamesAsync("repo1", ["Initialize", "NonExistent"]).ConfigureAwait(false);
+
+        await Assert.That(results).Count().IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task GetSymbolsByNamesAsyncReturnsEmptyForEmptyInput()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var (store, _) = await SeedTestDataAsync(connection).ConfigureAwait(false);
+
+        var results = await store.GetSymbolsByNamesAsync("repo1", []).ConfigureAwait(false);
+
+        await Assert.That(results).Count().IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task GetSymbolsByNamesAsyncReturnsEmptyForWrongRepo()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var (store, _) = await SeedTestDataAsync(connection).ConfigureAwait(false);
+
+        var results = await store.GetSymbolsByNamesAsync("nonexistent", ["Initialize"]).ConfigureAwait(false);
+
+        await Assert.That(results).Count().IsEqualTo(0);
+    }
+
+    // ── GetProjectOutlineAsync Tests ─────────────────────────────────────
+
+    [Test]
+    public async Task GetProjectOutlineAsyncGroupsByFile()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var (store, _) = await SeedTestDataAsync(connection).ConfigureAwait(false);
+
+        var outline = await store.GetProjectOutlineAsync("repo1", true, "file", 1).ConfigureAwait(false);
+
+        await Assert.That(outline.RepoId).IsEqualTo("repo1");
+        await Assert.That(outline.Groups.Count).IsGreaterThan(0);
+        await Assert.That(outline.Groups[0].Name).IsEqualTo("src/main.luau");
+    }
+
+    [Test]
+    public async Task GetProjectOutlineAsyncGroupsByKind()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var (store, _) = await SeedTestDataAsync(connection).ConfigureAwait(false);
+
+        var outline = await store.GetProjectOutlineAsync("repo1", true, "kind", 1).ConfigureAwait(false);
+
+        await Assert.That(outline.Groups.Count).IsGreaterThan(0);
+        var groupNames = outline.Groups.Select(g => g.Name).ToList();
+        await Assert.That(groupNames).Contains("Function");
+    }
+
+    [Test]
+    public async Task GetProjectOutlineAsyncExcludesPrivateWhenFlagged()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var (store, _) = await SeedTestDataAsync(connection).ConfigureAwait(false);
+
+        var outline = await store.GetProjectOutlineAsync("repo1", false, "file", 1).ConfigureAwait(false);
+
+        var allSymbols = outline.Groups.SelectMany(g => g.Symbols).ToList();
+        var hasPrivate = allSymbols.Any(s => s.Visibility == "Private");
+        await Assert.That(hasPrivate).IsFalse();
+    }
+
+    [Test]
+    public async Task GetProjectOutlineAsyncIncludesPrivateWhenFlagged()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var (store, _) = await SeedTestDataAsync(connection).ConfigureAwait(false);
+
+        var outline = await store.GetProjectOutlineAsync("repo1", true, "file", 1).ConfigureAwait(false);
+
+        var allSymbols = outline.Groups.SelectMany(g => g.Symbols).ToList();
+        var hasPrivate = allSymbols.Any(s => s.Visibility == "Private");
+        await Assert.That(hasPrivate).IsTrue();
+    }
+
+    [Test]
+    public async Task GetProjectOutlineAsyncNestsChildrenAtDepthTwo()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var (store, _) = await SeedTestDataAsync(connection).ConfigureAwait(false);
+
+        var outline = await store.GetProjectOutlineAsync("repo1", true, "file", 2).ConfigureAwait(false);
+
+        var group = outline.Groups[0];
+        await Assert.That(group.Children.Count).IsGreaterThan(0);
+        var childGroup = group.Children.First(c => c.Name == "MyClass");
+        await Assert.That(childGroup.Symbols.Count).IsGreaterThan(0);
+        await Assert.That(childGroup.Symbols[0].Name).IsEqualTo("DoWork");
+    }
+
+    [Test]
+    public async Task GetProjectOutlineAsyncClampsMaxDepth()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var (store, _) = await SeedTestDataAsync(connection).ConfigureAwait(false);
+
+        var outline = await store.GetProjectOutlineAsync("repo1", true, "file", 999).ConfigureAwait(false);
+
+        await Assert.That(outline).IsNotNull();
+        await Assert.That(outline.Groups.Count).IsGreaterThan(0);
+    }
+
+    [Test]
+    public async Task GetProjectOutlineAsyncReturnsEmptyGroupsForMissingRepo()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var (store, _) = await SeedTestDataAsync(connection).ConfigureAwait(false);
+
+        var outline = await store.GetProjectOutlineAsync("nonexistent", true, "file", 1).ConfigureAwait(false);
+
+        await Assert.That(outline.RepoId).IsEqualTo("nonexistent");
+        await Assert.That(outline.Groups).Count().IsEqualTo(0);
+    }
+
+    // ── GetModuleApiAsync Tests ──────────────────────────────────────────
+
+    [Test]
+    public async Task GetModuleApiAsyncReturnsSymbolsAndDependencies()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var (store, fileId) = await SeedTestDataAsync(connection).ConfigureAwait(false);
+
+        var dep = new Dependency(0, fileId, "game/ReplicatedStorage/Utils", null, "Utils");
+        await store.InsertDependenciesAsync([dep]).ConfigureAwait(false);
+
+        var api = await store.GetModuleApiAsync("repo1", "src/main.luau").ConfigureAwait(false);
+
+        await Assert.That(api.File.RelativePath).IsEqualTo("src/main.luau");
+        await Assert.That(api.Symbols.Count).IsGreaterThan(0);
+        await Assert.That(api.Dependencies).Count().IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task GetModuleApiAsyncReturnsAllSymbolsForFile()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var (store, _) = await SeedTestDataAsync(connection).ConfigureAwait(false);
+
+        var api = await store.GetModuleApiAsync("repo1", "src/main.luau").ConfigureAwait(false);
+
+        await Assert.That(api.Symbols).Count().IsEqualTo(4);
+    }
+
+    [Test]
+    public async Task GetModuleApiAsyncThrowsForMissingFile()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var (store, _) = await SeedTestDataAsync(connection).ConfigureAwait(false);
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => store.GetModuleApiAsync("repo1", "nonexistent.luau"));
+    }
+
+    // ── GetDependencyGraphAsync Tests ────────────────────────────────────
+
+    [Test]
+    public async Task GetDependencyGraphAsyncReturnsDependencies()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(connection);
+        var repo = new Repository("repo1", "/test/path", "TestProject", "luau", 1000, 0, 0);
+        await store.UpsertRepositoryAsync(repo).ConfigureAwait(false);
+
+        var file1 = new FileRecord(0, "repo1", "src/main.luau", "h1", 100, 10, 1000, 1000);
+        var file2 = new FileRecord(0, "repo1", "src/utils.luau", "h2", 200, 20, 1000, 1000);
+        await store.InsertFilesAsync([file1, file2]).ConfigureAwait(false);
+
+        var f1 = await store.GetFileByPathAsync("repo1", "src/main.luau").ConfigureAwait(false);
+        var f2 = await store.GetFileByPathAsync("repo1", "src/utils.luau").ConfigureAwait(false);
+
+        var dep = new Dependency(0, f1!.Id, "src/utils.luau", f2!.Id, "Utils");
+        await store.InsertDependenciesAsync([dep]).ConfigureAwait(false);
+
+        var graph = await store.GetDependencyGraphAsync("repo1", "src/main.luau", "dependencies", 3).ConfigureAwait(false);
+
+        await Assert.That(graph.Nodes.Count).IsGreaterThan(0);
+        await Assert.That(graph.Edges.Count).IsGreaterThan(0);
+    }
+
+    [Test]
+    public async Task GetDependencyGraphAsyncReturnsDependents()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(connection);
+        var repo = new Repository("repo1", "/test/path", "TestProject", "luau", 1000, 0, 0);
+        await store.UpsertRepositoryAsync(repo).ConfigureAwait(false);
+
+        var file1 = new FileRecord(0, "repo1", "src/main.luau", "h1", 100, 10, 1000, 1000);
+        var file2 = new FileRecord(0, "repo1", "src/utils.luau", "h2", 200, 20, 1000, 1000);
+        await store.InsertFilesAsync([file1, file2]).ConfigureAwait(false);
+
+        var f1 = await store.GetFileByPathAsync("repo1", "src/main.luau").ConfigureAwait(false);
+        var f2 = await store.GetFileByPathAsync("repo1", "src/utils.luau").ConfigureAwait(false);
+
+        var dep = new Dependency(0, f1!.Id, "src/utils.luau", f2!.Id, "Utils");
+        await store.InsertDependenciesAsync([dep]).ConfigureAwait(false);
+
+        var graph = await store.GetDependencyGraphAsync("repo1", "src/utils.luau", "dependents", 3).ConfigureAwait(false);
+
+        await Assert.That(graph.Edges.Count).IsGreaterThan(0);
+    }
+
+    [Test]
+    public async Task GetDependencyGraphAsyncCapsDepthAt10()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(connection);
+        var repo = new Repository("repo1", "/test/path", "TestProject", "luau", 1000, 0, 0);
+        await store.UpsertRepositoryAsync(repo).ConfigureAwait(false);
+
+        var graph = await store.GetDependencyGraphAsync("repo1", null, "dependencies", 999).ConfigureAwait(false);
+
+        await Assert.That(graph).IsNotNull();
+    }
+
+    [Test]
+    public async Task GetDependencyGraphAsyncReturnsEmptyForMissingRootFile()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(connection);
+        var repo = new Repository("repo1", "/test/path", "TestProject", "luau", 1000, 0, 0);
+        await store.UpsertRepositoryAsync(repo).ConfigureAwait(false);
+
+        var graph = await store.GetDependencyGraphAsync("repo1", "nonexistent.luau", "dependencies", 3).ConfigureAwait(false);
+
+        await Assert.That(graph.Nodes).Count().IsEqualTo(0);
+        await Assert.That(graph.Edges).Count().IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task GetDependencyGraphAsyncReturnsNodesInSortedOrder()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(connection);
+        var repo = new Repository("repo1", "/test/path", "TestProject", "luau", 1000, 0, 0);
+        await store.UpsertRepositoryAsync(repo).ConfigureAwait(false);
+
+        var file1 = new FileRecord(0, "repo1", "src/zebra.luau", "h1", 100, 10, 1000, 1000);
+        var file2 = new FileRecord(0, "repo1", "src/alpha.luau", "h2", 200, 20, 1000, 1000);
+        await store.InsertFilesAsync([file1, file2]).ConfigureAwait(false);
+
+        var f1 = await store.GetFileByPathAsync("repo1", "src/zebra.luau").ConfigureAwait(false);
+        var f2 = await store.GetFileByPathAsync("repo1", "src/alpha.luau").ConfigureAwait(false);
+
+        var dep = new Dependency(0, f1!.Id, "src/alpha.luau", f2!.Id, null);
+        await store.InsertDependenciesAsync([dep]).ConfigureAwait(false);
+
+        var graph = await store.GetDependencyGraphAsync("repo1", "src/zebra.luau", "dependencies", 3).ConfigureAwait(false);
+
+        await Assert.That(graph.Nodes.Count).IsEqualTo(2);
+        await Assert.That(graph.Nodes[0]).IsEqualTo("src/alpha.luau");
+        await Assert.That(graph.Nodes[1]).IsEqualTo("src/zebra.luau");
+    }
+
+    [Test]
+    public async Task GetDependencyGraphAsyncIncludesEdgeAlias()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(connection);
+        var repo = new Repository("repo1", "/test/path", "TestProject", "luau", 1000, 0, 0);
+        await store.UpsertRepositoryAsync(repo).ConfigureAwait(false);
+
+        var file1 = new FileRecord(0, "repo1", "src/main.luau", "h1", 100, 10, 1000, 1000);
+        var file2 = new FileRecord(0, "repo1", "src/utils.luau", "h2", 200, 20, 1000, 1000);
+        await store.InsertFilesAsync([file1, file2]).ConfigureAwait(false);
+
+        var f1 = await store.GetFileByPathAsync("repo1", "src/main.luau").ConfigureAwait(false);
+        var f2 = await store.GetFileByPathAsync("repo1", "src/utils.luau").ConfigureAwait(false);
+
+        var dep = new Dependency(0, f1!.Id, "src/utils.luau", f2!.Id, "Utils");
+        await store.InsertDependenciesAsync([dep]).ConfigureAwait(false);
+
+        var graph = await store.GetDependencyGraphAsync("repo1", "src/main.luau", "dependencies", 1).ConfigureAwait(false);
+
+        await Assert.That(graph.Edges.Count).IsEqualTo(1);
+        await Assert.That(graph.Edges[0].From).IsEqualTo("src/main.luau");
+        await Assert.That(graph.Edges[0].To).IsEqualTo("src/utils.luau");
+        await Assert.That(graph.Edges[0].Alias).IsEqualTo("Utils");
+    }
+
+    // ── GetChangedFilesAsync Tests ───────────────────────────────────────
+
+    [Test]
+    public async Task GetChangedFilesAsyncIdentifiesAddedModifiedRemoved()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(connection);
+        var repo = new Repository("repo1", "/test/path", "TestProject", "luau", 1000, 0, 0);
+        await store.UpsertRepositoryAsync(repo).ConfigureAwait(false);
+
+        // Create initial files
+        await store.InsertFilesAsync([
+            new FileRecord(0, "repo1", "src/kept.luau", "hash_old", 100, 10, 1000, 1000),
+            new FileRecord(0, "repo1", "src/modified.luau", "hash_before", 200, 20, 1000, 1000),
+            new FileRecord(0, "repo1", "src/removed.luau", "hash_rem", 300, 30, 1000, 1000),
+        ]).ConfigureAwait(false);
+
+        // Create snapshot with current state
+        var snapshotHashes = System.Text.Json.JsonSerializer.Serialize(
+            new Dictionary<string, string>
+            {
+                ["src/kept.luau"] = "hash_old",
+                ["src/modified.luau"] = "hash_before",
+                ["src/removed.luau"] = "hash_rem",
+            });
+        long snapshotId = await store.CreateSnapshotAsync(
+            new IndexSnapshot(0, "repo1", "v1", 1000, snapshotHashes)).ConfigureAwait(false);
+
+        // Simulate changes: modify one file's hash, remove one file, add a new one
+        var modFile = await store.GetFileByPathAsync("repo1", "src/modified.luau").ConfigureAwait(false);
+        await store.UpdateFileAsync(modFile! with { ContentHash = "hash_after" }).ConfigureAwait(false);
+
+        var remFile = await store.GetFileByPathAsync("repo1", "src/removed.luau").ConfigureAwait(false);
+        await store.DeleteFileAsync(remFile!.Id).ConfigureAwait(false);
+
+        await store.InsertFilesAsync([new FileRecord(0, "repo1", "src/new.luau", "hash_new", 400, 40, 1000, 1000)]).ConfigureAwait(false);
+
+        // Detect changes
+        var changes = await store.GetChangedFilesAsync("repo1", snapshotId).ConfigureAwait(false);
+        await Assert.That(changes.Added).Count().IsEqualTo(1);
+        await Assert.That(changes.Modified).Count().IsEqualTo(1);
+        await Assert.That(changes.Removed).Count().IsEqualTo(1);
+        await Assert.That(changes.Added[0].RelativePath).IsEqualTo("src/new.luau");
+        await Assert.That(changes.Modified[0].RelativePath).IsEqualTo("src/modified.luau");
+        await Assert.That(changes.Removed[0]).IsEqualTo("src/removed.luau");
+    }
+
+    [Test]
+    public async Task GetChangedFilesAsyncReturnsEmptyForMissingSnapshot()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(connection);
+
+        var changes = await store.GetChangedFilesAsync("repo1", 9999).ConfigureAwait(false);
+
+        await Assert.That(changes.Added).Count().IsEqualTo(0);
+        await Assert.That(changes.Modified).Count().IsEqualTo(0);
+        await Assert.That(changes.Removed).Count().IsEqualTo(0);
+    }
+}


### PR DESCRIPTION
## Summary
- Implements all three mini-plans for feature 03 (SQLite storage layer)
- **03-001**: SqliteConnectionFactory with SHA-256 repo hashing, WAL mode, PRAGMAs, and idempotent schema migrations (5 tables, 9 indexes, 2 FTS5 virtual tables)
- **03-002**: SqliteSymbolStore CRUD with batch inserts (explicit transactions, prepared statements), FTS5 triggers for symbols_fts sync, and 5 storage model records
- **03-003**: 8 query methods (FTS5 search, project outline, module API, dependency graph, change detection), Fts5Sanitizer, and 8 result models

## Test plan
- [x] `dotnet build CodeCompress.slnx` — zero warnings
- [x] `dotnet test --solution CodeCompress.slnx` — 119 tests pass
- [x] All SQL uses parameterized queries — zero string concatenation
- [x] FTS5 queries pass through Fts5Sanitizer before reaching SQLite

🤖 Generated with [Claude Code](https://claude.com/claude-code)