### PR TITLE
Add PathValidator: OWASP A01 path traversal prevention

### DIFF
--- a/src/CodeCompress.Core/Validation/PathValidator.cs
+++ b/src/CodeCompress.Core/Validation/PathValidator.cs
@@ -1,0 +1,153 @@
+namespace CodeCompress.Core.Validation;
+
+/// <summary>
+/// Prevents path traversal attacks (OWASP A01) by canonicalizing paths
+/// and verifying they resolve within a declared project root.
+/// </summary>
+public static class PathValidator
+{
+    private static readonly StringComparison PathComparison = OperatingSystem.IsWindows()
+        ? StringComparison.OrdinalIgnoreCase
+        : StringComparison.Ordinal;
+
+    /// <summary>
+    /// Validates that an absolute path resolves within the project root.
+    /// Returns the canonicalized safe path if valid.
+    /// </summary>
+    public static string ValidatePath(string inputPath, string projectRoot)
+    {
+        ValidateInputNotEmpty(inputPath, nameof(inputPath));
+        ValidateInputNotEmpty(projectRoot, nameof(projectRoot));
+        RejectNullBytes(inputPath, nameof(inputPath));
+        RejectNullBytes(projectRoot, nameof(projectRoot));
+
+        string canonicalPath;
+        string canonicalRoot;
+
+        try
+        {
+            canonicalPath = Path.GetFullPath(inputPath);
+            canonicalRoot = Path.GetFullPath(projectRoot);
+        }
+        catch (Exception ex) when (ex is PathTooLongException or NotSupportedException)
+        {
+            throw new ArgumentException("The provided path is invalid.", ex);
+        }
+
+        // Reject UNC paths unless root is also UNC
+        if (IsUncPath(canonicalPath) && !IsUncPath(canonicalRoot))
+        {
+            throw new ArgumentException("UNC paths are not permitted.");
+        }
+
+        // Allow exact root match
+        if (string.Equals(canonicalPath, canonicalRoot, PathComparison))
+        {
+            return canonicalPath;
+        }
+
+        // Normalize root to include trailing separator to prevent prefix false positives
+        var rootWithSeparator = canonicalRoot.EndsWith(Path.DirectorySeparatorChar)
+            ? canonicalRoot
+            : canonicalRoot + Path.DirectorySeparatorChar;
+
+        if (!canonicalPath.StartsWith(rootWithSeparator, PathComparison))
+        {
+            throw new ArgumentException("Path resolves outside the project root.");
+        }
+
+        // If the path exists and is a symlink, resolve and re-validate the target
+        ValidateSymlinkTarget(canonicalPath, rootWithSeparator);
+
+        return canonicalPath;
+    }
+
+    /// <summary>
+    /// Resolves a relative path against the project root, then validates it.
+    /// Returns the canonicalized absolute path.
+    /// </summary>
+    public static string ValidateRelativePath(string relativePath, string projectRoot)
+    {
+        ValidateInputNotEmpty(relativePath, nameof(relativePath));
+        ValidateInputNotEmpty(projectRoot, nameof(projectRoot));
+
+        var absolutePath = Path.GetFullPath(relativePath, projectRoot);
+        return ValidatePath(absolutePath, projectRoot);
+    }
+
+    /// <summary>
+    /// Non-throwing variant that returns true if the candidate resolves within root.
+    /// </summary>
+    public static bool IsWithinRoot(string candidatePath, string projectRoot)
+    {
+        try
+        {
+            ValidatePath(candidatePath, projectRoot);
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+        catch (NotSupportedException)
+        {
+            return false;
+        }
+        catch (PathTooLongException)
+        {
+            return false;
+        }
+    }
+
+    private static void ValidateInputNotEmpty(string value, string paramName)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new ArgumentException("Value cannot be null, empty, or whitespace.", paramName);
+        }
+    }
+
+    private static void RejectNullBytes(string value, string paramName)
+    {
+        if (value.Contains('\0', StringComparison.Ordinal))
+        {
+            throw new ArgumentException("Path contains invalid null byte character.", paramName);
+        }
+    }
+
+    private static bool IsUncPath(string path)
+    {
+        return path.StartsWith(@"\\", StringComparison.Ordinal)
+            || path.StartsWith("//", StringComparison.Ordinal);
+    }
+
+    private static void ValidateSymlinkTarget(string canonicalPath, string rootWithSeparator)
+    {
+        if (!File.Exists(canonicalPath) && !Directory.Exists(canonicalPath))
+        {
+            return;
+        }
+
+        var fileInfo = new FileInfo(canonicalPath);
+
+        if (fileInfo.LinkTarget is null)
+        {
+            return;
+        }
+
+        var resolvedTarget = File.ResolveLinkTarget(canonicalPath, returnFinalTarget: true);
+
+        if (resolvedTarget is null)
+        {
+            return;
+        }
+
+        var resolvedPath = Path.GetFullPath(resolvedTarget.FullName);
+
+        if (!resolvedPath.StartsWith(rootWithSeparator, PathComparison)
+            && !string.Equals(resolvedPath, rootWithSeparator.TrimEnd(Path.DirectorySeparatorChar), PathComparison))
+        {
+            throw new ArgumentException("Symbolic link resolves outside the project root.");
+        }
+    }
+}

--- a/tests/CodeCompress.Core.Tests/Validation/PathValidatorTests.cs
+++ b/tests/CodeCompress.Core.Tests/Validation/PathValidatorTests.cs
@@ -1,0 +1,261 @@
+using CodeCompress.Core.Validation;
+
+namespace CodeCompress.Core.Tests.Validation;
+
+internal sealed class PathValidatorTests
+{
+    private static readonly string Root = OperatingSystem.IsWindows()
+        ? @"C:\project"
+        : "/project";
+
+    private static readonly string SubDir = OperatingSystem.IsWindows()
+        ? @"C:\project\src"
+        : "/project/src";
+
+    private static readonly string FileInRoot = OperatingSystem.IsWindows()
+        ? @"C:\project\src\Foo.cs"
+        : "/project/src/Foo.cs";
+
+    // ── Happy Path ──────────────────────────────────────────────
+
+    [Test]
+    public async Task ValidatePathAbsolutePathWithinRootReturnsCanonicalized()
+    {
+        var result = PathValidator.ValidatePath(FileInRoot, Root);
+
+        await Assert.That(result).IsEqualTo(FileInRoot);
+    }
+
+    [Test]
+    public async Task ValidatePathExactlyEqualToRootIsAccepted()
+    {
+        var result = PathValidator.ValidatePath(Root, Root);
+
+        await Assert.That(result).IsEqualTo(Root);
+    }
+
+    [Test]
+    public async Task ValidatePathSubdirectoryPathIsAccepted()
+    {
+        var result = PathValidator.ValidatePath(SubDir, Root);
+
+        await Assert.That(result).IsEqualTo(SubDir);
+    }
+
+    [Test]
+    public async Task ValidateRelativePathValidRelativeResolvesCorrectly()
+    {
+        var result = PathValidator.ValidateRelativePath("src/Foo.cs", Root);
+
+        var expected = Path.Combine(Root, "src", "Foo.cs");
+        await Assert.That(result).IsEqualTo(Path.GetFullPath(expected));
+    }
+
+    [Test]
+    public async Task IsWithinRootValidPathReturnsTrue()
+    {
+        var result = PathValidator.IsWithinRoot(FileInRoot, Root);
+
+        await Assert.That(result).IsTrue();
+    }
+
+    // ── Traversal Attack Tests ──────────────────────────────────
+
+    [Test]
+    [Arguments("/../../../etc/passwd")]
+    [Arguments("/../../windows/system32/config/sam")]
+    [Arguments("/../")]
+    [Arguments("/./../../outside")]
+    [Arguments("/src/../../outside")]
+    public async Task ValidatePathTraversalAttemptsThrows(string maliciousSegment)
+    {
+        var maliciousPath = Root + maliciousSegment;
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => Task.FromResult(PathValidator.ValidatePath(maliciousPath, Root)));
+    }
+
+    [Test]
+    public async Task ValidateRelativePathTraversalViaRelativeThrows()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => Task.FromResult(PathValidator.ValidateRelativePath("../../etc/passwd", Root)));
+    }
+
+    [Test]
+    public async Task ValidatePathDotDotThatStaysWithinRootIsAccepted()
+    {
+        var pathWithDotDot = Path.Combine(Root, "src", "..", "lib", "Foo.cs");
+
+        var result = PathValidator.ValidatePath(pathWithDotDot, Root);
+
+        var expected = Path.Combine(Root, "lib", "Foo.cs");
+        await Assert.That(result).IsEqualTo(Path.GetFullPath(expected));
+    }
+
+    // ── Input Validation Tests ──────────────────────────────────
+
+    [Test]
+    public async Task ValidatePathNullInputThrowsArgumentException()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => Task.FromResult(PathValidator.ValidatePath(null!, Root)));
+    }
+
+    [Test]
+    public async Task ValidatePathEmptyInputThrowsArgumentException()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => Task.FromResult(PathValidator.ValidatePath("", Root)));
+    }
+
+    [Test]
+    public async Task ValidatePathWhitespaceInputThrowsArgumentException()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => Task.FromResult(PathValidator.ValidatePath("   ", Root)));
+    }
+
+    [Test]
+    public async Task ValidatePathNullProjectRootThrowsArgumentException()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => Task.FromResult(PathValidator.ValidatePath(FileInRoot, null!)));
+    }
+
+    // ── Null Byte Tests ─────────────────────────────────────────
+
+    [Test]
+    public async Task ValidatePathNullByteThrowsArgumentException()
+    {
+        var pathWithNull = Root + "/src/evil\0.cs";
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => Task.FromResult(PathValidator.ValidatePath(pathWithNull, Root)));
+    }
+
+    // ── Platform-Specific Tests ─────────────────────────────────
+
+    [Test]
+    public async Task ValidatePathMixedSeparatorsNormalizedAndAccepted()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var mixedPath = @"C:\project/src\Foo.cs";
+        var result = PathValidator.ValidatePath(mixedPath, @"C:\project");
+
+        await Assert.That(result).IsEqualTo(@"C:\project\src\Foo.cs");
+    }
+
+    [Test]
+    public async Task ValidatePathUncPathRejected()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => Task.FromResult(PathValidator.ValidatePath(@"\\server\share\file.cs", @"C:\project")));
+    }
+
+    [Test]
+    public async Task ValidatePathCaseSensitivityOnWindowsAccepted()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var result = PathValidator.ValidatePath(@"C:\PROJECT\SRC\Foo.cs", @"C:\project");
+
+        await Assert.That(result).IsEqualTo(@"C:\PROJECT\SRC\Foo.cs");
+    }
+
+    // ── Edge Case Tests ─────────────────────────────────────────
+
+    [Test]
+    public async Task ValidatePathTrailingSlashOnRootDoesNotAffectValidation()
+    {
+        var rootWithSlash = Root + Path.DirectorySeparatorChar;
+
+        var result = PathValidator.ValidatePath(FileInRoot, rootWithSlash);
+
+        await Assert.That(result).IsEqualTo(FileInRoot);
+    }
+
+    [Test]
+    public async Task ValidatePathDoubleSlashesNormalizedAndAccepted()
+    {
+        string pathWithDoubleSlash;
+        if (OperatingSystem.IsWindows())
+        {
+            pathWithDoubleSlash = @"C:\project\\src\\Foo.cs";
+        }
+        else
+        {
+            pathWithDoubleSlash = "/project//src//Foo.cs";
+        }
+
+        var result = PathValidator.ValidatePath(pathWithDoubleSlash, Root);
+
+        await Assert.That(result).IsEqualTo(FileInRoot);
+    }
+
+    [Test]
+    public async Task ValidatePathPrefixButNotChildRejected()
+    {
+        string sibling;
+        if (OperatingSystem.IsWindows())
+        {
+            sibling = @"C:\project-other\file.cs";
+        }
+        else
+        {
+            sibling = "/project-other/file.cs";
+        }
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => Task.FromResult(PathValidator.ValidatePath(sibling, Root)));
+    }
+
+    [Test]
+    public async Task IsWithinRootInvalidPathReturnsFalseWithoutThrowing()
+    {
+        var result = PathValidator.IsWithinRoot("", Root);
+
+        await Assert.That(result).IsFalse();
+    }
+
+    [Test]
+    public async Task IsWithinRootTraversalPathReturnsFalse()
+    {
+        var malicious = Root + "/../../../etc/passwd";
+
+        var result = PathValidator.IsWithinRoot(malicious, Root);
+
+        await Assert.That(result).IsFalse();
+    }
+
+    [Test]
+    public async Task IsWithinRootNullInputReturnsFalse()
+    {
+        var result = PathValidator.IsWithinRoot(null!, Root);
+
+        await Assert.That(result).IsFalse();
+    }
+
+    [Test]
+    public async Task ValidatePathUrlEncodedDotsNotDecoded()
+    {
+        // %2e%2e should be treated as literal characters, not ".."
+        var literalPath = Path.Combine(Root, "src", "%2e%2e", "Foo.cs");
+
+        var result = PathValidator.ValidatePath(literalPath, Root);
+
+        await Assert.That(result).IsEqualTo(Path.GetFullPath(literalPath));
+    }
+}


### PR DESCRIPTION
## Summary
- Add `PathValidator` static class with `ValidatePath`, `ValidateRelativePath`, and `IsWithinRoot` methods for OWASP A01 path traversal prevention
- Canonicalizes paths via `Path.GetFullPath()` and enforces project root boundaries with trailing-separator normalization
- OS-aware case comparison, UNC path rejection, null byte detection, and symlink resolution
- 25 TUnit tests covering happy paths, traversal attacks, input validation, null bytes, platform-specific behavior, and edge cases

## Test plan
- [x] All 25 PathValidator tests pass
- [x] Full solution builds with zero warnings
- [x] Full test suite (146 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)