### PR TITLE
Add LuauParser: core function/method/class extraction

### DIFF
--- a/src/CodeCompress.Core/Parsers/LuauParser.cs
+++ b/src/CodeCompress.Core/Parsers/LuauParser.cs
@@ -1,0 +1,335 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using CodeCompress.Core.Models;
+
+namespace CodeCompress.Core.Parsers;
+
+public sealed partial class LuauParser : ILanguageParser
+{
+    public string LanguageId => "luau";
+
+    public IReadOnlyList<string> FileExtensions { get; } = [".luau", ".lua"];
+
+    // ── Regex patterns (source-generated) ───────────────────────
+
+    [GeneratedRegex(@"^local\s+(\w+)\s*=\s*\{\s*\}\s*::\s*(\w+)\s*$")]
+    private static partial Regex ModuleClassPattern();
+
+    [GeneratedRegex(@"^function\s+(\w+)[:\.](\w+)\s*\(([^)]*)\)\s*(?::\s*(.+))?$")]
+    private static partial Regex MethodPattern();
+
+    [GeneratedRegex(@"^local\s+function\s+(\w+)\s*\(([^)]*)\)\s*(?::\s*(.+))?$")]
+    private static partial Regex LocalFunctionPattern();
+
+    [GeneratedRegex(@"^function\s+(\w+)\s*\(([^)]*)\)\s*(?::\s*(.+))?$")]
+    private static partial Regex TopLevelFunctionPattern();
+
+    [GeneratedRegex(@"^return\s+(\w+)\s*$")]
+    private static partial Regex ModuleReturnPattern();
+
+    // Nesting: count block structures that need an `end`
+    // Each of these is one block: function(...), if...then, for...do, while...do, standalone do
+    [GeneratedRegex(@"\bfunction\s*[\w.:]*\s*\(")]
+    private static partial Regex FunctionOpenerPattern();
+
+    [GeneratedRegex(@"\bif\b")]
+    private static partial Regex IfPattern();
+
+    [GeneratedRegex(@"\bfor\b")]
+    private static partial Regex ForPattern();
+
+    [GeneratedRegex(@"\bwhile\b")]
+    private static partial Regex WhilePattern();
+
+    // standalone `do` — not preceded by `for...` or `while...` on the same line
+    // We'll handle this by counting: do keywords minus for/while keywords
+    [GeneratedRegex(@"\bdo\b")]
+    private static partial Regex DoPattern();
+
+    [GeneratedRegex(@"\bend\b")]
+    private static partial Regex EndKeywordPattern();
+
+    [GeneratedRegex(@"\buntil\b")]
+    private static partial Regex UntilKeywordPattern();
+
+    [GeneratedRegex(@"\brepeat\b")]
+    private static partial Regex RepeatPattern();
+
+    // `elseif` also contains `if` but does NOT open a new block
+    [GeneratedRegex(@"\belseif\b")]
+    private static partial Regex ElseIfPattern();
+
+    public ParseResult Parse(string filePath, ReadOnlySpan<byte> content)
+    {
+        if (content.IsEmpty)
+        {
+            return new ParseResult([], []);
+        }
+
+        var text = Encoding.UTF8.GetString(content);
+        var lines = text.Split('\n');
+        var symbols = new List<SymbolInfo>();
+        var pendingSymbols = new List<PendingSymbol>();
+        var lineByteOffsets = ComputeLineByteOffsets(content);
+
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var line = lines[i].TrimEnd('\r');
+            var trimmed = line.Trim();
+            var lineNumber = i + 1;
+
+            // Skip empty lines and comments
+            if (string.IsNullOrWhiteSpace(trimmed) || trimmed.StartsWith("--", StringComparison.Ordinal))
+            {
+                UpdateNesting(trimmed, lineNumber, lineByteOffsets[i], pendingSymbols, symbols);
+                continue;
+            }
+
+            // Try match patterns in priority order
+            // Module class, return, and top-level constructs only match at the top level
+            var atTopLevel = pendingSymbols.Count == 0;
+
+            _ = (atTopLevel && TryMatchModuleClass(trimmed, lineNumber, lineByteOffsets[i], symbols))
+                || TryMatchMethod(trimmed, lineNumber, lineByteOffsets[i], pendingSymbols)
+                || TryMatchLocalFunction(trimmed, lineNumber, lineByteOffsets[i], pendingSymbols)
+                || TryMatchTopLevelFunction(trimmed, lineNumber, lineByteOffsets[i], pendingSymbols)
+                || (atTopLevel && TryMatchModuleReturn(trimmed, lineNumber, lineByteOffsets[i], symbols));
+
+            // Always update nesting for lines that affect block depth
+            UpdateNesting(trimmed, lineNumber, lineByteOffsets[i], pendingSymbols, symbols);
+        }
+
+        // Post-process: determine exported class name for visibility
+        var exportedName = symbols
+            .FirstOrDefault(s => s.Kind == SymbolKind.Export)?.Name;
+
+        for (var i = 0; i < symbols.Count; i++)
+        {
+            if (symbols[i].Kind == SymbolKind.Method
+                && symbols[i].ParentSymbol is not null
+                && string.Equals(symbols[i].ParentSymbol, exportedName, StringComparison.Ordinal))
+            {
+                symbols[i] = symbols[i] with { Visibility = Visibility.Public };
+            }
+        }
+
+        return new ParseResult(symbols, []);
+    }
+
+    private static int[] ComputeLineByteOffsets(ReadOnlySpan<byte> content)
+    {
+        var offsets = new List<int> { 0 };
+        for (var i = 0; i < content.Length; i++)
+        {
+            if (content[i] == (byte)'\n')
+            {
+                offsets.Add(i + 1);
+            }
+        }
+
+        return [.. offsets];
+    }
+
+    private static bool TryMatchModuleClass(
+        string trimmed, int lineNumber, int byteOffset, List<SymbolInfo> symbols)
+    {
+        var match = ModuleClassPattern().Match(trimmed);
+        if (!match.Success)
+        {
+            return false;
+        }
+
+        symbols.Add(new SymbolInfo(
+            Name: match.Groups[1].Value,
+            Kind: SymbolKind.Class,
+            Signature: trimmed,
+            ParentSymbol: null,
+            ByteOffset: byteOffset,
+            ByteLength: Encoding.UTF8.GetByteCount(trimmed),
+            LineStart: lineNumber,
+            LineEnd: lineNumber,
+            Visibility: Visibility.Public,
+            DocComment: null));
+
+        return true;
+    }
+
+    private static bool TryMatchMethod(
+        string trimmed, int lineNumber, int byteOffset, List<PendingSymbol> pending)
+    {
+        var match = MethodPattern().Match(trimmed);
+        if (!match.Success)
+        {
+            return false;
+        }
+
+        pending.Add(new PendingSymbol(
+            Name: match.Groups[2].Value,
+            Kind: SymbolKind.Method,
+            Signature: trimmed,
+            ParentSymbol: match.Groups[1].Value,
+            ByteOffset: byteOffset,
+            LineStart: lineNumber,
+            Visibility: Visibility.Public,
+            NestingDepth: 0)); // Will be incremented by UpdateNesting
+
+        return true;
+    }
+
+    private static bool TryMatchLocalFunction(
+        string trimmed, int lineNumber, int byteOffset, List<PendingSymbol> pending)
+    {
+        var match = LocalFunctionPattern().Match(trimmed);
+        if (!match.Success)
+        {
+            return false;
+        }
+
+        pending.Add(new PendingSymbol(
+            Name: match.Groups[1].Value,
+            Kind: SymbolKind.Function,
+            Signature: trimmed,
+            ParentSymbol: null,
+            ByteOffset: byteOffset,
+            LineStart: lineNumber,
+            Visibility: Visibility.Private,
+            NestingDepth: 0));
+
+        return true;
+    }
+
+    private static bool TryMatchTopLevelFunction(
+        string trimmed, int lineNumber, int byteOffset, List<PendingSymbol> pending)
+    {
+        var match = TopLevelFunctionPattern().Match(trimmed);
+        if (!match.Success)
+        {
+            return false;
+        }
+
+        pending.Add(new PendingSymbol(
+            Name: match.Groups[1].Value,
+            Kind: SymbolKind.Function,
+            Signature: trimmed,
+            ParentSymbol: null,
+            ByteOffset: byteOffset,
+            LineStart: lineNumber,
+            Visibility: Visibility.Public,
+            NestingDepth: 0));
+
+        return true;
+    }
+
+    private static bool TryMatchModuleReturn(
+        string trimmed, int lineNumber, int byteOffset, List<SymbolInfo> symbols)
+    {
+        var match = ModuleReturnPattern().Match(trimmed);
+        if (!match.Success)
+        {
+            return false;
+        }
+
+        symbols.Add(new SymbolInfo(
+            Name: match.Groups[1].Value,
+            Kind: SymbolKind.Export,
+            Signature: trimmed,
+            ParentSymbol: null,
+            ByteOffset: byteOffset,
+            ByteLength: Encoding.UTF8.GetByteCount(trimmed),
+            LineStart: lineNumber,
+            LineEnd: lineNumber,
+            Visibility: Visibility.Public,
+            DocComment: null));
+
+        return true;
+    }
+
+    private static void UpdateNesting(
+        string trimmed, int lineNumber, int byteOffset,
+        List<PendingSymbol> pending, List<SymbolInfo> symbols)
+    {
+        if (pending.Count == 0)
+        {
+            return;
+        }
+
+        var opens = CountBlockOpens(trimmed);
+        var closes = EndKeywordPattern().Count(trimmed) + UntilKeywordPattern().Count(trimmed);
+
+        var delta = opens - closes;
+
+        for (var i = pending.Count - 1; i >= 0; i--)
+        {
+            var p = pending[i];
+            p.NestingDepth += delta;
+
+            if (p.NestingDepth <= 0)
+            {
+                CompletePendingSymbol(p, lineNumber, byteOffset, trimmed, symbols);
+                pending.RemoveAt(i);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Counts the number of block-opening statements on a line.
+    /// In Luau: function, if, for, while each open one block needing `end`.
+    /// `do` after `for`/`while` is part of the same statement (not extra).
+    /// Standalone `do` opens its own block.
+    /// `repeat` opens a block closed by `until`.
+    /// `elseif` contains `if` but does NOT open a new block.
+    /// </summary>
+    private static int CountBlockOpens(string line)
+    {
+        var functions = FunctionOpenerPattern().Count(line);
+        var ifs = IfPattern().Count(line) - ElseIfPattern().Count(line);
+        var fors = ForPattern().Count(line);
+        var whiles = WhilePattern().Count(line);
+        var dos = DoPattern().Count(line);
+        var repeats = RepeatPattern().Count(line);
+
+        // `do` keywords that are part of `for...do` or `while...do` are not standalone
+        var standaloneDos = Math.Max(0, dos - fors - whiles);
+
+        return functions + ifs + fors + whiles + standaloneDos + repeats;
+    }
+
+    private static void CompletePendingSymbol(
+        PendingSymbol pending, int endLineNumber, int endByteOffset,
+        string endLine, List<SymbolInfo> symbols)
+    {
+        var byteLength = endByteOffset + Encoding.UTF8.GetByteCount(endLine) - pending.ByteOffset;
+
+        symbols.Add(new SymbolInfo(
+            Name: pending.Name,
+            Kind: pending.Kind,
+            Signature: pending.Signature,
+            ParentSymbol: pending.ParentSymbol,
+            ByteOffset: pending.ByteOffset,
+            ByteLength: byteLength,
+            LineStart: pending.LineStart,
+            LineEnd: endLineNumber,
+            Visibility: pending.Visibility,
+            DocComment: null));
+    }
+
+    private sealed class PendingSymbol(
+        string Name,
+        SymbolKind Kind,
+        string Signature,
+        string? ParentSymbol,
+        int ByteOffset,
+        int LineStart,
+        Visibility Visibility,
+        int NestingDepth)
+    {
+        public string Name { get; } = Name;
+        public SymbolKind Kind { get; } = Kind;
+        public string Signature { get; } = Signature;
+        public string? ParentSymbol { get; } = ParentSymbol;
+        public int ByteOffset { get; } = ByteOffset;
+        public int LineStart { get; } = LineStart;
+        public Visibility Visibility { get; } = Visibility;
+        public int NestingDepth { get; set; } = NestingDepth;
+    }
+}

--- a/tests/CodeCompress.Core.Tests/Parsers/LuauParserTests.cs
+++ b/tests/CodeCompress.Core.Tests/Parsers/LuauParserTests.cs
@@ -1,0 +1,350 @@
+using System.Text;
+using CodeCompress.Core.Models;
+using CodeCompress.Core.Parsers;
+
+namespace CodeCompress.Core.Tests.Parsers;
+
+internal sealed class LuauParserTests
+{
+    private readonly LuauParser _parser = new();
+
+    private ParseResult Parse(string source)
+    {
+        var bytes = Encoding.UTF8.GetBytes(source);
+        return _parser.Parse("test.luau", bytes);
+    }
+
+    // ── Interface contract ──────────────────────────────────────
+
+    [Test]
+    public async Task LanguageIdIsLuau()
+    {
+        await Assert.That(_parser.LanguageId).IsEqualTo("luau");
+    }
+
+    [Test]
+    public async Task FileExtensionsContainsLuauAndLua()
+    {
+        await Assert.That(_parser.FileExtensions).Contains(".luau");
+        await Assert.That(_parser.FileExtensions).Contains(".lua");
+    }
+
+    // ── Empty / comments-only ───────────────────────────────────
+
+    [Test]
+    public async Task ParseEmptyFileReturnsEmptyResult()
+    {
+        var result = Parse("");
+
+        await Assert.That(result.Symbols).Count().IsEqualTo(0);
+        await Assert.That(result.Dependencies).Count().IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ParseOnlyCommentsReturnsEmptyResult()
+    {
+        var source = """
+            -- this is a comment
+            -- another comment
+            --[[ block comment ]]
+            """;
+
+        var result = Parse(source);
+
+        await Assert.That(result.Symbols).Count().IsEqualTo(0);
+    }
+
+    // ── Single function ─────────────────────────────────────────
+
+    [Test]
+    public async Task ParseSingleFunctionReturnsCorrectSymbolInfo()
+    {
+        var source = """
+            function greet(name: string): string
+                return "Hello, " .. name
+            end
+            """;
+
+        var result = Parse(source);
+
+        await Assert.That(result.Symbols).Count().IsEqualTo(1);
+
+        var sym = result.Symbols[0];
+        await Assert.That(sym.Name).IsEqualTo("greet");
+        await Assert.That(sym.Kind).IsEqualTo(SymbolKind.Function);
+        await Assert.That(sym.Visibility).IsEqualTo(Visibility.Public);
+        await Assert.That(sym.ParentSymbol).IsNull();
+        await Assert.That(sym.Signature).IsEqualTo("function greet(name: string): string");
+    }
+
+    // ── Method on class ─────────────────────────────────────────
+
+    [Test]
+    public async Task ParseMethodOnClassReturnsCorrectParentAndVisibility()
+    {
+        var source = """
+            local MyClass = {} :: MyClass
+
+            function MyClass:doStuff(x: number): boolean
+                return x > 0
+            end
+
+            return MyClass
+            """;
+
+        var result = Parse(source);
+
+        var method = result.Symbols.First(s => s.Kind == SymbolKind.Method);
+        await Assert.That(method.Name).IsEqualTo("doStuff");
+        await Assert.That(method.ParentSymbol).IsEqualTo("MyClass");
+        await Assert.That(method.Visibility).IsEqualTo(Visibility.Public);
+        await Assert.That(method.Signature).IsEqualTo("function MyClass:doStuff(x: number): boolean");
+    }
+
+    // ── Local function ──────────────────────────────────────────
+
+    [Test]
+    public async Task ParseLocalFunctionReturnsPrivateVisibility()
+    {
+        var source = """
+            local function helper(a: number, b: number): number
+                return a + b
+            end
+            """;
+
+        var result = Parse(source);
+
+        await Assert.That(result.Symbols).Count().IsEqualTo(1);
+
+        var sym = result.Symbols[0];
+        await Assert.That(sym.Name).IsEqualTo("helper");
+        await Assert.That(sym.Kind).IsEqualTo(SymbolKind.Function);
+        await Assert.That(sym.Visibility).IsEqualTo(Visibility.Private);
+    }
+
+    // ── Module class declaration ────────────────────────────────
+
+    [Test]
+    public async Task ParseModuleClassDeclarationReturnsClassSymbol()
+    {
+        var source = """
+            local PlayerService = {} :: PlayerService
+            """;
+
+        var result = Parse(source);
+
+        await Assert.That(result.Symbols).Count().IsEqualTo(1);
+
+        var sym = result.Symbols[0];
+        await Assert.That(sym.Name).IsEqualTo("PlayerService");
+        await Assert.That(sym.Kind).IsEqualTo(SymbolKind.Class);
+        await Assert.That(sym.Visibility).IsEqualTo(Visibility.Public);
+        await Assert.That(sym.Signature).IsEqualTo("local PlayerService = {} :: PlayerService");
+    }
+
+    // ── Module return ───────────────────────────────────────────
+
+    [Test]
+    public async Task ParseModuleReturnReturnsExportSymbol()
+    {
+        var source = """
+            local Foo = {} :: Foo
+
+            return Foo
+            """;
+
+        var result = Parse(source);
+
+        var export = result.Symbols.First(s => s.Kind == SymbolKind.Export);
+        await Assert.That(export.Name).IsEqualTo("Foo");
+        await Assert.That(export.Visibility).IsEqualTo(Visibility.Public);
+        await Assert.That(export.Signature).IsEqualTo("return Foo");
+    }
+
+    // ── Multiple symbols in order ───────────────────────────────
+
+    [Test]
+    public async Task ParseMultipleSymbolsReturnsAllInOrder()
+    {
+        var source = """
+            local MyModule = {} :: MyModule
+
+            local function privateHelper()
+            end
+
+            function MyModule:publicMethod()
+            end
+
+            function topLevel()
+            end
+
+            return MyModule
+            """;
+
+        var result = Parse(source);
+
+        await Assert.That(result.Symbols).Count().IsEqualTo(5);
+
+        await Assert.That(result.Symbols[0].Kind).IsEqualTo(SymbolKind.Class);
+        await Assert.That(result.Symbols[0].Name).IsEqualTo("MyModule");
+
+        await Assert.That(result.Symbols[1].Kind).IsEqualTo(SymbolKind.Function);
+        await Assert.That(result.Symbols[1].Name).IsEqualTo("privateHelper");
+        await Assert.That(result.Symbols[1].Visibility).IsEqualTo(Visibility.Private);
+
+        await Assert.That(result.Symbols[2].Kind).IsEqualTo(SymbolKind.Method);
+        await Assert.That(result.Symbols[2].Name).IsEqualTo("publicMethod");
+
+        await Assert.That(result.Symbols[3].Kind).IsEqualTo(SymbolKind.Function);
+        await Assert.That(result.Symbols[3].Name).IsEqualTo("topLevel");
+        await Assert.That(result.Symbols[3].Visibility).IsEqualTo(Visibility.Public);
+
+        await Assert.That(result.Symbols[4].Kind).IsEqualTo(SymbolKind.Export);
+        await Assert.That(result.Symbols[4].Name).IsEqualTo("MyModule");
+    }
+
+    // ── Line numbers ────────────────────────────────────────────
+
+    [Test]
+    public async Task ParseLineNumbersAreOneBased()
+    {
+        var source = "function foo()\n    local x = 1\nend\n";
+
+        var result = Parse(source);
+
+        var sym = result.Symbols[0];
+        await Assert.That(sym.LineStart).IsEqualTo(1);
+        await Assert.That(sym.LineEnd).IsEqualTo(3);
+    }
+
+    // ── Byte offsets ────────────────────────────────────────────
+
+    [Test]
+    public async Task ParseByteOffsetsAreAccurate()
+    {
+        var source = "function foo()\n    local x = 1\nend\n";
+        var bytes = Encoding.UTF8.GetBytes(source);
+
+        var result = _parser.Parse("test.luau", bytes);
+
+        var sym = result.Symbols[0];
+        await Assert.That(sym.ByteOffset).IsEqualTo(0);
+        // ByteLength covers from "function" to the end of "end"
+        var expectedLength = source.IndexOf("end", StringComparison.Ordinal) + 3 - 0;
+        await Assert.That(sym.ByteLength).IsEqualTo(expectedLength);
+    }
+
+    // ── Nested blocks ───────────────────────────────────────────
+
+    [Test]
+    public async Task ParseNestedBlocksDoNotConfuseEndMatching()
+    {
+        var source = """
+            function complex()
+                if true then
+                    for i = 1, 10 do
+                        print(i)
+                    end
+                end
+                while true do
+                    break
+                end
+            end
+            """;
+
+        var result = Parse(source);
+
+        await Assert.That(result.Symbols).Count().IsEqualTo(1);
+
+        var sym = result.Symbols[0];
+        await Assert.That(sym.Name).IsEqualTo("complex");
+        await Assert.That(sym.LineStart).IsEqualTo(1);
+        await Assert.That(sym.LineEnd).IsEqualTo(10);
+    }
+
+    // ── Signature capture ───────────────────────────────────────
+
+    [Test]
+    public async Task ParseFunctionWithReturnTypeCapturesFullSignature()
+    {
+        var source = """
+            function calculate(): string
+                return "result"
+            end
+            """;
+
+        var result = Parse(source);
+
+        await Assert.That(result.Symbols[0].Signature).IsEqualTo("function calculate(): string");
+    }
+
+    [Test]
+    public async Task ParseMethodWithParametersCapturesFullSignature()
+    {
+        var source = """
+            function Cls:bar(x: number, y: string): boolean
+                return true
+            end
+            """;
+
+        var result = Parse(source);
+
+        await Assert.That(result.Symbols[0].Signature).IsEqualTo("function Cls:bar(x: number, y: string): boolean");
+    }
+
+    // ── Nested function inside function ─────────────────────────
+
+    [Test]
+    public async Task ParseRepeatUntilBlockDoesNotConfuseEndMatching()
+    {
+        var source = """
+            function withRepeat()
+                repeat
+                    local x = 1
+                until x > 5
+            end
+            """;
+
+        var result = Parse(source);
+
+        await Assert.That(result.Symbols).Count().IsEqualTo(1);
+        await Assert.That(result.Symbols[0].LineEnd).IsEqualTo(5);
+    }
+
+    [Test]
+    public async Task ParseDoBlockDoesNotConfuseEndMatching()
+    {
+        var source = """
+            function withDo()
+                do
+                    local x = 1
+                end
+            end
+            """;
+
+        var result = Parse(source);
+
+        await Assert.That(result.Symbols).Count().IsEqualTo(1);
+        await Assert.That(result.Symbols[0].LineEnd).IsEqualTo(5);
+    }
+
+    // ── Dot function (module.func) ──────────────────────────────
+
+    [Test]
+    public async Task ParseDotFunctionExtractsAsMethod()
+    {
+        var source = """
+            function MyModule.staticFunc(a: number)
+                return a
+            end
+            """;
+
+        var result = Parse(source);
+
+        await Assert.That(result.Symbols).Count().IsEqualTo(1);
+        var sym = result.Symbols[0];
+        await Assert.That(sym.Name).IsEqualTo("staticFunc");
+        await Assert.That(sym.Kind).IsEqualTo(SymbolKind.Method);
+        await Assert.That(sym.ParentSymbol).IsEqualTo("MyModule");
+    }
+}


### PR DESCRIPTION
## Summary
- Add `LuauParser` implementing `ILanguageParser` — regex-based parser for Luau (Roblox Lua variant)
- Extracts module classes (`local X = {} :: X`), methods (`function X:Y()`), top-level/local functions, and module return exports
- Accurate `ByteOffset`, `ByteLength`, `LineStart`, `LineEnd` with proper end-keyword nesting (handles `if`/`for`/`while`/`do`/`repeat` blocks)
- 18 TUnit tests covering all symbol types, nested blocks, signature capture, and edge cases

## Test plan
- [x] All 18 LuauParser tests pass
- [x] Full solution builds with zero warnings
- [x] Full test suite (164 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)