### PR TITLE
Add MCP server host and indexing tools

### DIFF
--- a/src/CodeCompress.Core/Indexing/IndexEngine.cs
+++ b/src/CodeCompress.Core/Indexing/IndexEngine.cs
@@ -434,8 +434,9 @@ public sealed partial class IndexEngine : IIndexEngine
         return deps;
     }
 
-    internal static string ComputeRepoId(string canonicalRoot)
+    public static string ComputeRepoId(string canonicalRoot)
     {
+        ArgumentNullException.ThrowIfNull(canonicalRoot);
         var bytes = Encoding.UTF8.GetBytes(canonicalRoot.ToUpperInvariant());
         var hash = SHA256.HashData(bytes);
         return Convert.ToHexStringLower(hash);

--- a/src/CodeCompress.Server/CodeCompress.Server.csproj
+++ b/src/CodeCompress.Server/CodeCompress.Server.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="CodeCompress.Server.Tests" />
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CodeCompress.Server/CodeCompress.Server.csproj
+++ b/src/CodeCompress.Server/CodeCompress.Server.csproj
@@ -5,6 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="CodeCompress.Server.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\CodeCompress.Core\CodeCompress.Core.csproj" />
   </ItemGroup>
 

--- a/src/CodeCompress.Server/Program.cs
+++ b/src/CodeCompress.Server/Program.cs
@@ -1,2 +1,20 @@
-// CodeCompress MCP Server — implementation in a later plan.
-return;
+using CodeCompress.Server;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.Logging.AddConsole(options =>
+{
+    // All log output must go to stderr — stdout is reserved for the MCP JSON-RPC transport
+    options.LogToStandardErrorThreshold = LogLevel.Trace;
+});
+
+builder.Services
+    .AddCodeCompressServer()
+    .AddMcpServer()
+    .WithStdioServerTransport()
+    .WithToolsFromAssembly();
+
+await builder.Build().RunAsync().ConfigureAwait(false);

--- a/src/CodeCompress.Server/Scoping/IProjectScope.cs
+++ b/src/CodeCompress.Server/Scoping/IProjectScope.cs
@@ -1,0 +1,11 @@
+using CodeCompress.Core.Indexing;
+using CodeCompress.Core.Storage;
+
+namespace CodeCompress.Server.Scoping;
+
+internal interface IProjectScope : IAsyncDisposable
+{
+    internal string RepoId { get; }
+    internal ISymbolStore Store { get; }
+    internal IIndexEngine Engine { get; }
+}

--- a/src/CodeCompress.Server/Scoping/IProjectScopeFactory.cs
+++ b/src/CodeCompress.Server/Scoping/IProjectScopeFactory.cs
@@ -1,0 +1,6 @@
+namespace CodeCompress.Server.Scoping;
+
+internal interface IProjectScopeFactory
+{
+    internal Task<IProjectScope> CreateAsync(string projectRoot, CancellationToken cancellationToken = default);
+}

--- a/src/CodeCompress.Server/Scoping/ProjectScope.cs
+++ b/src/CodeCompress.Server/Scoping/ProjectScope.cs
@@ -1,0 +1,36 @@
+using CodeCompress.Core.Indexing;
+using CodeCompress.Core.Storage;
+using Microsoft.Data.Sqlite;
+
+namespace CodeCompress.Server.Scoping;
+
+internal sealed class ProjectScope : IProjectScope
+{
+    private readonly SqliteConnection _connection;
+
+    public ProjectScope(
+        SqliteConnection connection,
+        ISymbolStore store,
+        IIndexEngine engine,
+        string repoId)
+    {
+        ArgumentNullException.ThrowIfNull(connection);
+        ArgumentNullException.ThrowIfNull(store);
+        ArgumentNullException.ThrowIfNull(engine);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repoId);
+
+        _connection = connection;
+        Store = store;
+        Engine = engine;
+        RepoId = repoId;
+    }
+
+    public string RepoId { get; }
+    public ISymbolStore Store { get; }
+    public IIndexEngine Engine { get; }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _connection.DisposeAsync().ConfigureAwait(false);
+    }
+}

--- a/src/CodeCompress.Server/Scoping/ProjectScopeFactory.cs
+++ b/src/CodeCompress.Server/Scoping/ProjectScopeFactory.cs
@@ -1,0 +1,59 @@
+using CodeCompress.Core.Indexing;
+using CodeCompress.Core.Parsers;
+using CodeCompress.Core.Storage;
+using CodeCompress.Core.Validation;
+using Microsoft.Extensions.Logging;
+
+namespace CodeCompress.Server.Scoping;
+
+internal sealed class ProjectScopeFactory : IProjectScopeFactory
+{
+    private readonly IConnectionFactory _connectionFactory;
+    private readonly IFileHasher _fileHasher;
+    private readonly IChangeTracker _changeTracker;
+    private readonly IEnumerable<ILanguageParser> _parsers;
+    private readonly IPathValidator _pathValidator;
+    private readonly ILoggerFactory _loggerFactory;
+
+    public ProjectScopeFactory(
+        IConnectionFactory connectionFactory,
+        IFileHasher fileHasher,
+        IChangeTracker changeTracker,
+        IEnumerable<ILanguageParser> parsers,
+        IPathValidator pathValidator,
+        ILoggerFactory loggerFactory)
+    {
+        ArgumentNullException.ThrowIfNull(connectionFactory);
+        ArgumentNullException.ThrowIfNull(fileHasher);
+        ArgumentNullException.ThrowIfNull(changeTracker);
+        ArgumentNullException.ThrowIfNull(parsers);
+        ArgumentNullException.ThrowIfNull(pathValidator);
+        ArgumentNullException.ThrowIfNull(loggerFactory);
+
+        _connectionFactory = connectionFactory;
+        _fileHasher = fileHasher;
+        _changeTracker = changeTracker;
+        _parsers = parsers;
+        _pathValidator = pathValidator;
+        _loggerFactory = loggerFactory;
+    }
+
+    public async Task<IProjectScope> CreateAsync(string projectRoot, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectRoot);
+
+        var connection = await _connectionFactory.CreateConnectionAsync(projectRoot).ConfigureAwait(false);
+        var store = new SqliteSymbolStore(connection);
+        var canonicalRoot = _pathValidator.ValidatePath(projectRoot, projectRoot);
+        var repoId = IndexEngine.ComputeRepoId(canonicalRoot);
+        var engine = new IndexEngine(
+            _fileHasher,
+            _changeTracker,
+            _parsers,
+            store,
+            _pathValidator,
+            _loggerFactory.CreateLogger<IndexEngine>());
+
+        return new ProjectScope(connection, store, engine, repoId);
+    }
+}

--- a/src/CodeCompress.Server/ServiceCollectionExtensions.cs
+++ b/src/CodeCompress.Server/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using CodeCompress.Core;
 using CodeCompress.Core.Storage;
+using CodeCompress.Server.Scoping;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace CodeCompress.Server;
@@ -16,6 +17,9 @@ internal static class ServiceCollectionExtensions
         // ISymbolStore and IIndexEngine are resolved per-project at tool invocation time,
         // not at startup, because they require an active SqliteConnection.
         services.AddSingleton<IConnectionFactory, SqliteConnectionFactory>();
+
+        // Scoping — creates per-project scope with connection, store, and engine
+        services.AddSingleton<IProjectScopeFactory, ProjectScopeFactory>();
 
         return services;
     }

--- a/src/CodeCompress.Server/ServiceCollectionExtensions.cs
+++ b/src/CodeCompress.Server/ServiceCollectionExtensions.cs
@@ -1,0 +1,22 @@
+using CodeCompress.Core;
+using CodeCompress.Core.Storage;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CodeCompress.Server;
+
+internal static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddCodeCompressServer(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddCodeCompressCore();
+
+        // Storage — SqliteConnectionFactory creates per-project connections.
+        // ISymbolStore and IIndexEngine are resolved per-project at tool invocation time,
+        // not at startup, because they require an active SqliteConnection.
+        services.AddSingleton<IConnectionFactory, SqliteConnectionFactory>();
+
+        return services;
+    }
+}

--- a/src/CodeCompress.Server/Tools/IndexingTools.cs
+++ b/src/CodeCompress.Server/Tools/IndexingTools.cs
@@ -1,0 +1,189 @@
+using System.ComponentModel;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using CodeCompress.Core.Validation;
+using CodeCompress.Server.Scoping;
+using ModelContextProtocol.Server;
+
+namespace CodeCompress.Server.Tools;
+
+[McpServerToolType]
+internal sealed partial class IndexingTools
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+    };
+
+    private readonly IPathValidator _pathValidator;
+    private readonly IProjectScopeFactory _scopeFactory;
+
+    public IndexingTools(IPathValidator pathValidator, IProjectScopeFactory scopeFactory)
+    {
+        ArgumentNullException.ThrowIfNull(pathValidator);
+        ArgumentNullException.ThrowIfNull(scopeFactory);
+
+        _pathValidator = pathValidator;
+        _scopeFactory = scopeFactory;
+    }
+
+    [McpServerTool(Name = "index_project")]
+    [Description("Index a codebase to build a searchable symbol database.")]
+    public async Task<string> IndexProject(
+        [Description("Absolute path to the project root directory")] string path,
+        [Description("Filter to a specific language (e.g., 'luau')")] string? language = null,
+        [Description("Glob patterns for files to include")] string[]? includePatterns = null,
+        [Description("Glob patterns for files to exclude")] string[]? excludePatterns = null,
+        CancellationToken cancellationToken = default)
+    {
+        string validatedPath;
+        try
+        {
+            validatedPath = _pathValidator.ValidatePath(path, path);
+        }
+        catch (ArgumentException)
+        {
+            return SerializeError("Path validation failed", "INVALID_PATH");
+        }
+
+        try
+        {
+            var scope = await _scopeFactory.CreateAsync(validatedPath, cancellationToken).ConfigureAwait(false);
+            await using (scope.ConfigureAwait(false))
+            {
+                var result = await scope.Engine.IndexProjectAsync(
+                    validatedPath,
+                    language,
+                    includePatterns,
+                    excludePatterns,
+                    cancellationToken).ConfigureAwait(false);
+
+                return JsonSerializer.Serialize(
+                    new
+                    {
+                        result.RepoId,
+                        result.FilesIndexed,
+                        result.FilesSkipped,
+                        result.SymbolsFound,
+                        result.DurationMs,
+                    },
+                    SerializerOptions);
+            }
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return SerializeError("Directory not found", "DIRECTORY_NOT_FOUND");
+        }
+    }
+
+    [McpServerTool(Name = "snapshot_create")]
+    [Description("Create a named snapshot of the current index state for delta queries.")]
+    public async Task<string> SnapshotCreate(
+        [Description("Absolute path to the project root directory")] string path,
+        [Description("Human-readable snapshot label")] string label,
+        CancellationToken cancellationToken = default)
+    {
+        string validatedPath;
+        try
+        {
+            validatedPath = _pathValidator.ValidatePath(path, path);
+        }
+        catch (ArgumentException)
+        {
+            return SerializeError("Path validation failed", "INVALID_PATH");
+        }
+
+        var sanitizedLabel = SanitizeLabel(label);
+
+        var scope = await _scopeFactory.CreateAsync(validatedPath, cancellationToken).ConfigureAwait(false);
+        await using (scope.ConfigureAwait(false))
+        {
+            var repo = await scope.Store.GetRepositoryAsync(scope.RepoId).ConfigureAwait(false);
+            var fileCount = repo?.FileCount ?? 0;
+            var symbolCount = repo?.SymbolCount ?? 0;
+
+            var snapshot = new Core.Models.IndexSnapshot(
+                0,
+                scope.RepoId,
+                sanitizedLabel,
+                DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+                string.Empty);
+
+            var snapshotId = await scope.Store.CreateSnapshotAsync(snapshot).ConfigureAwait(false);
+
+            return JsonSerializer.Serialize(
+                new
+                {
+                    SnapshotId = snapshotId,
+                    Label = sanitizedLabel,
+                    FileCount = fileCount,
+                    SymbolCount = symbolCount,
+                },
+                SerializerOptions);
+        }
+    }
+
+    [McpServerTool(Name = "invalidate_cache")]
+    [Description("Invalidate the index cache, forcing a full re-index on the next index_project call.")]
+    public async Task<string> InvalidateCache(
+        [Description("Absolute path to the project root directory")] string path,
+        CancellationToken cancellationToken = default)
+    {
+        string validatedPath;
+        try
+        {
+            validatedPath = _pathValidator.ValidatePath(path, path);
+        }
+        catch (ArgumentException)
+        {
+            return SerializeError("Path validation failed", "INVALID_PATH");
+        }
+
+        var scope = await _scopeFactory.CreateAsync(validatedPath, cancellationToken).ConfigureAwait(false);
+        await using (scope.ConfigureAwait(false))
+        {
+            var files = await scope.Store.GetFilesByRepoAsync(scope.RepoId).ConfigureAwait(false);
+            var fileIds = files.Select(f => f.Id).ToList();
+
+            foreach (var fileId in fileIds)
+            {
+                await scope.Store.DeleteSymbolsByFileAsync(fileId).ConfigureAwait(false);
+                await scope.Store.DeleteDependenciesByFileAsync(fileId).ConfigureAwait(false);
+                await scope.Store.DeleteFileAsync(fileId).ConfigureAwait(false);
+            }
+
+            await scope.Store.DeleteRepositoryAsync(scope.RepoId).ConfigureAwait(false);
+
+            return JsonSerializer.Serialize(
+                new
+                {
+                    Success = true,
+                    Message = "Cache invalidated. Next index operation will perform a full reparse.",
+                },
+                SerializerOptions);
+        }
+    }
+
+    internal static string SanitizeLabel(string? label)
+    {
+        if (string.IsNullOrWhiteSpace(label))
+        {
+            return string.Empty;
+        }
+
+        var sanitized = SafeLabelPattern().Replace(label, string.Empty);
+
+        if (sanitized.Length > 128)
+        {
+            sanitized = sanitized[..128];
+        }
+
+        return sanitized.Trim();
+    }
+
+    private static string SerializeError(string error, string code) =>
+        JsonSerializer.Serialize(new { Error = error, Code = code }, SerializerOptions);
+
+    [GeneratedRegex(@"[^a-zA-Z0-9 _.\-]")]
+    private static partial Regex SafeLabelPattern();
+}

--- a/tests/CodeCompress.Server.Tests/CodeCompress.Server.Tests.csproj
+++ b/tests/CodeCompress.Server.Tests/CodeCompress.Server.Tests.csproj
@@ -13,6 +13,8 @@
   <ItemGroup>
     <PackageReference Include="TUnit" />
     <PackageReference Include="NSubstitute" />
+    <PackageReference Include="ModelContextProtocol" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
   </ItemGroup>
 
 </Project>

--- a/tests/CodeCompress.Server.Tests/Placeholder.cs
+++ b/tests/CodeCompress.Server.Tests/Placeholder.cs
@@ -1,9 +1,0 @@
-namespace CodeCompress.Server.Tests;
-
-/// <summary>
-/// Placeholder to allow empty test project to compile. Remove when real tests are added.
-/// </summary>
-internal static class Placeholder
-{
-    internal const string ProjectName = "CodeCompress.Server.Tests";
-}

--- a/tests/CodeCompress.Server.Tests/ServerHostTests.cs
+++ b/tests/CodeCompress.Server.Tests/ServerHostTests.cs
@@ -1,0 +1,123 @@
+using CodeCompress.Core.Indexing;
+using CodeCompress.Core.Parsers;
+using CodeCompress.Core.Storage;
+using CodeCompress.Core.Validation;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+
+namespace CodeCompress.Server.Tests;
+
+internal sealed class ServerHostTests
+{
+    private IHost _host = null!;
+
+    [Before(Test)]
+    public void SetUp()
+    {
+        var builder = Host.CreateApplicationBuilder([]);
+        builder.Logging.AddConsole(options =>
+        {
+            options.LogToStandardErrorThreshold = LogLevel.Trace;
+        });
+        builder.Services
+            .AddCodeCompressServer()
+            .AddMcpServer()
+            .WithStdioServerTransport()
+            .WithToolsFromAssembly();
+
+        _host = builder.Build();
+    }
+
+    [After(Test)]
+    public void TearDown()
+    {
+        _host?.Dispose();
+    }
+
+    [Test]
+    public async Task HostBuildsWithoutErrors()
+    {
+        await Assert.That(_host).IsNotNull();
+    }
+
+    [Test]
+    public async Task PathValidatorResolves()
+    {
+        var pathValidator = _host.Services.GetService<IPathValidator>();
+
+        await Assert.That(pathValidator).IsNotNull();
+    }
+
+    [Test]
+    public async Task ConnectionFactoryResolves()
+    {
+        var factory = _host.Services.GetService<IConnectionFactory>();
+
+        await Assert.That(factory).IsNotNull();
+    }
+
+    [Test]
+    public async Task FileHasherResolves()
+    {
+        var hasher = _host.Services.GetService<IFileHasher>();
+
+        await Assert.That(hasher).IsNotNull();
+    }
+
+    [Test]
+    public async Task ChangeTrackerResolves()
+    {
+        var tracker = _host.Services.GetService<IChangeTracker>();
+
+        await Assert.That(tracker).IsNotNull();
+    }
+
+    [Test]
+    public async Task LanguageParsersResolveAsCollection()
+    {
+        var parsers = _host.Services.GetService<IEnumerable<ILanguageParser>>();
+
+        await Assert.That(parsers).IsNotNull();
+        await Assert.That(parsers!.ToList()).Count().IsGreaterThanOrEqualTo(1);
+    }
+
+    [Test]
+    public async Task LanguageParsersContainLuauParser()
+    {
+        var parsers = _host.Services.GetRequiredService<IEnumerable<ILanguageParser>>().ToList();
+
+        var hasLuau = parsers.Any(p => p.LanguageId == "luau");
+
+        await Assert.That(hasLuau).IsTrue();
+    }
+
+    [Test]
+    public async Task AllExpectedServiceDescriptorsAreRegistered()
+    {
+        var builder = Host.CreateApplicationBuilder([]);
+        builder.Services.AddCodeCompressServer();
+
+        var hasConnectionFactory = builder.Services.Any(d => d.ServiceType == typeof(IConnectionFactory));
+        var hasPathValidator = builder.Services.Any(d => d.ServiceType == typeof(IPathValidator));
+        var hasFileHasher = builder.Services.Any(d => d.ServiceType == typeof(IFileHasher));
+        var hasChangeTracker = builder.Services.Any(d => d.ServiceType == typeof(IChangeTracker));
+        var hasParser = builder.Services.Any(d => d.ServiceType == typeof(ILanguageParser));
+
+        await Assert.That(hasConnectionFactory).IsTrue();
+        await Assert.That(hasPathValidator).IsTrue();
+        await Assert.That(hasFileHasher).IsTrue();
+        await Assert.That(hasChangeTracker).IsTrue();
+        await Assert.That(hasParser).IsTrue();
+    }
+
+    [Test]
+    public async Task McpServerIsConfigured()
+    {
+        // Verify MCP server services are registered via AddMcpServer() + WithStdioServerTransport()
+        var mcpServer = _host.Services.GetService<McpServer>();
+
+        await Assert.That(mcpServer).IsNotNull();
+    }
+}

--- a/tests/CodeCompress.Server.Tests/Tools/IndexingToolsTests.cs
+++ b/tests/CodeCompress.Server.Tests/Tools/IndexingToolsTests.cs
@@ -1,0 +1,267 @@
+using System.Text.Json;
+using CodeCompress.Core.Indexing;
+using CodeCompress.Core.Models;
+using CodeCompress.Core.Storage;
+using CodeCompress.Core.Validation;
+using CodeCompress.Server.Scoping;
+using CodeCompress.Server.Tools;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace CodeCompress.Server.Tests.Tools;
+
+internal sealed class IndexingToolsTests
+{
+    private IPathValidator _pathValidator = null!;
+    private IProjectScopeFactory _scopeFactory = null!;
+    private IProjectScope _scope = null!;
+    private IIndexEngine _engine = null!;
+    private ISymbolStore _store = null!;
+    private IndexingTools _tools = null!;
+
+    [Before(Test)]
+    public void SetUp()
+    {
+        _pathValidator = Substitute.For<IPathValidator>();
+        _scopeFactory = Substitute.For<IProjectScopeFactory>();
+        _scope = Substitute.For<IProjectScope>();
+        _engine = Substitute.For<IIndexEngine>();
+        _store = Substitute.For<ISymbolStore>();
+
+        _scope.Engine.Returns(_engine);
+        _scope.Store.Returns(_store);
+        _scope.RepoId.Returns("test-repo-id");
+        _scopeFactory.CreateAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(_scope);
+        _pathValidator.ValidatePath(Arg.Any<string>(), Arg.Any<string>()).Returns(callInfo => callInfo.ArgAt<string>(0));
+
+        _tools = new IndexingTools(_pathValidator, _scopeFactory);
+    }
+
+    [Test]
+    public async Task IndexProjectValidPathReturnsIndexingResults()
+    {
+        var indexResult = new IndexResult("repo1", 42, 3, 0, 187, 1250);
+        _engine.IndexProjectAsync(
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<string[]?>(),
+            Arg.Any<string[]?>(),
+            Arg.Any<CancellationToken>()).Returns(indexResult);
+
+        var result = await _tools.IndexProject("/valid/path").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        var root = doc.RootElement;
+        await Assert.That(root.GetProperty("repo_id").GetString()).IsEqualTo("repo1");
+        await Assert.That(root.GetProperty("files_indexed").GetInt32()).IsEqualTo(42);
+        await Assert.That(root.GetProperty("files_skipped").GetInt32()).IsEqualTo(3);
+        await Assert.That(root.GetProperty("symbols_found").GetInt32()).IsEqualTo(187);
+        await Assert.That(root.GetProperty("duration_ms").GetInt64()).IsEqualTo(1250);
+    }
+
+    [Test]
+    public async Task IndexProjectTraversalPathReturnsError()
+    {
+        _pathValidator.ValidatePath(Arg.Any<string>(), Arg.Any<string>())
+            .Throws(new ArgumentException("Path traversal detected"));
+
+        var result = await _tools.IndexProject("/../../../etc/passwd").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        var root = doc.RootElement;
+        await Assert.That(root.GetProperty("error").GetString()).IsEqualTo("Path validation failed");
+        await Assert.That(root.GetProperty("code").GetString()).IsEqualTo("INVALID_PATH");
+    }
+
+    [Test]
+    public async Task IndexProjectNonExistentPathReturnsError()
+    {
+        _engine.IndexProjectAsync(
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<string[]?>(),
+            Arg.Any<string[]?>(),
+            Arg.Any<CancellationToken>()).Throws(new DirectoryNotFoundException("Not found"));
+
+        var result = await _tools.IndexProject("/nonexistent/path").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        var root = doc.RootElement;
+        await Assert.That(root.GetProperty("error").GetString()).IsEqualTo("Directory not found");
+        await Assert.That(root.GetProperty("code").GetString()).IsEqualTo("DIRECTORY_NOT_FOUND");
+    }
+
+    [Test]
+    public async Task IndexProjectWithLanguageFilterPassesToEngine()
+    {
+        var indexResult = new IndexResult("repo1", 10, 0, 0, 50, 100);
+        _engine.IndexProjectAsync(
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<string[]?>(),
+            Arg.Any<string[]?>(),
+            Arg.Any<CancellationToken>()).Returns(indexResult);
+
+        await _tools.IndexProject("/valid/path", language: "luau").ConfigureAwait(false);
+
+        await _engine.Received(1).IndexProjectAsync(
+            Arg.Any<string>(),
+            "luau",
+            Arg.Any<string[]?>(),
+            Arg.Any<string[]?>(),
+            Arg.Any<CancellationToken>()).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task IndexProjectWithGlobPatternsPassesToEngine()
+    {
+        var include = new[] { "**/*.lua" };
+        var exclude = new[] { "**/test/**" };
+        var indexResult = new IndexResult("repo1", 5, 0, 0, 20, 50);
+        _engine.IndexProjectAsync(
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<string[]?>(),
+            Arg.Any<string[]?>(),
+            Arg.Any<CancellationToken>()).Returns(indexResult);
+
+        await _tools.IndexProject("/valid/path", includePatterns: include, excludePatterns: exclude).ConfigureAwait(false);
+
+        await _engine.Received(1).IndexProjectAsync(
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            include,
+            exclude,
+            Arg.Any<CancellationToken>()).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task SnapshotCreateValidInputsReturnsSnapshotInfo()
+    {
+        var repo = new Repository("test-repo-id", "/valid/path", "project", "luau", 1000, 42, 187);
+        _store.GetRepositoryAsync("test-repo-id").Returns(repo);
+        _store.CreateSnapshotAsync(Arg.Any<IndexSnapshot>()).Returns(1L);
+
+        var result = await _tools.SnapshotCreate("/valid/path", "pre-refactor").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        var root = doc.RootElement;
+        await Assert.That(root.GetProperty("snapshot_id").GetInt64()).IsEqualTo(1L);
+        await Assert.That(root.GetProperty("label").GetString()).IsEqualTo("pre-refactor");
+        await Assert.That(root.GetProperty("file_count").GetInt32()).IsEqualTo(42);
+        await Assert.That(root.GetProperty("symbol_count").GetInt32()).IsEqualTo(187);
+    }
+
+    [Test]
+    public async Task SnapshotCreateMaliciousLabelIsSanitized()
+    {
+        var repo = new Repository("test-repo-id", "/valid/path", "project", "luau", 1000, 10, 50);
+        _store.GetRepositoryAsync("test-repo-id").Returns(repo);
+        _store.CreateSnapshotAsync(Arg.Any<IndexSnapshot>()).Returns(1L);
+
+        var result = await _tools.SnapshotCreate("/valid/path", "pre-<script>alert('xss')</script>refactor").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        var label = doc.RootElement.GetProperty("label").GetString();
+        await Assert.That(label).IsEqualTo("pre-scriptalertxssscriptrefactor");
+    }
+
+    [Test]
+    public async Task SnapshotCreateLongLabelIsTruncated()
+    {
+        var repo = new Repository("test-repo-id", "/valid/path", "project", "luau", 1000, 10, 50);
+        _store.GetRepositoryAsync("test-repo-id").Returns(repo);
+        _store.CreateSnapshotAsync(Arg.Any<IndexSnapshot>()).Returns(1L);
+
+        var longLabel = new string('a', 200);
+        var result = await _tools.SnapshotCreate("/valid/path", longLabel).ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        var label = doc.RootElement.GetProperty("label").GetString();
+        await Assert.That(label!.Length).IsLessThanOrEqualTo(128);
+    }
+
+    [Test]
+    public async Task SnapshotCreateInvalidPathReturnsError()
+    {
+        _pathValidator.ValidatePath(Arg.Any<string>(), Arg.Any<string>())
+            .Throws(new ArgumentException("Path traversal detected"));
+
+        var result = await _tools.SnapshotCreate("/../invalid", "test-label").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        var root = doc.RootElement;
+        await Assert.That(root.GetProperty("error").GetString()).IsEqualTo("Path validation failed");
+        await Assert.That(root.GetProperty("code").GetString()).IsEqualTo("INVALID_PATH");
+    }
+
+    [Test]
+    public async Task InvalidateCacheValidPathReturnsSuccess()
+    {
+        var files = new List<FileRecord>
+        {
+            new(1, "test-repo-id", "file1.lua", "hash1", 100, 10, 1000, 2000),
+            new(2, "test-repo-id", "file2.lua", "hash2", 200, 20, 1000, 2000),
+        };
+        _store.GetFilesByRepoAsync("test-repo-id").Returns(files);
+
+        var result = await _tools.InvalidateCache("/valid/path").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        var root = doc.RootElement;
+        await Assert.That(root.GetProperty("success").GetBoolean()).IsTrue();
+        await Assert.That(root.GetProperty("message").GetString())
+            .IsEqualTo("Cache invalidated. Next index operation will perform a full reparse.");
+
+        await _store.Received(2).DeleteSymbolsByFileAsync(Arg.Any<long>()).ConfigureAwait(false);
+        await _store.Received(2).DeleteDependenciesByFileAsync(Arg.Any<long>()).ConfigureAwait(false);
+        await _store.Received(2).DeleteFileAsync(Arg.Any<long>()).ConfigureAwait(false);
+        await _store.Received(1).DeleteRepositoryAsync("test-repo-id").ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task InvalidateCacheInvalidPathReturnsError()
+    {
+        _pathValidator.ValidatePath(Arg.Any<string>(), Arg.Any<string>())
+            .Throws(new ArgumentException("Path traversal detected"));
+
+        var result = await _tools.InvalidateCache("/../invalid").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        var root = doc.RootElement;
+        await Assert.That(root.GetProperty("error").GetString()).IsEqualTo("Path validation failed");
+        await Assert.That(root.GetProperty("code").GetString()).IsEqualTo("INVALID_PATH");
+    }
+
+    [Test]
+    public async Task SanitizeLabelRemovesUnsafeCharacters()
+    {
+        var sanitized = IndexingTools.SanitizeLabel("hello<world>&\"test'");
+        await Assert.That(sanitized).IsEqualTo("helloworldtest");
+    }
+
+    [Test]
+    public async Task SanitizeLabelTruncatesTo128Characters()
+    {
+        var longLabel = new string('x', 200);
+        var sanitized = IndexingTools.SanitizeLabel(longLabel);
+        await Assert.That(sanitized.Length).IsEqualTo(128);
+    }
+
+    [Test]
+    public async Task IndexProjectDoesNotEchoRawPath()
+    {
+        var distinctivePath = "/very/unique/distinctive/test/path/12345";
+        var indexResult = new IndexResult("repo1", 10, 0, 0, 50, 100);
+        _engine.IndexProjectAsync(
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<string[]?>(),
+            Arg.Any<string[]?>(),
+            Arg.Any<CancellationToken>()).Returns(indexResult);
+
+        var result = await _tools.IndexProject(distinctivePath).ConfigureAwait(false);
+
+        await Assert.That(result).DoesNotContain(distinctivePath);
+    }
+}


### PR DESCRIPTION
## Summary
- Configure MCP server with GenericHost, stdio transport, and full DI registration of all core services
- Implement `IndexingTools` MCP tool class with `index_project`, `snapshot_create`, and `invalidate_cache` tools
- Introduce `IProjectScopeFactory` pattern for per-project SQLite connections, symbol stores, and index engines
- All tools enforce path validation, return structured JSON, sanitize labels, and never echo raw user input

## Test plan
- [x] 23 server tests passing (9 host + 14 tool tests)
- [x] 219 total tests passing across all projects
- [x] Zero build warnings
- [x] Path validation rejects traversal attempts with structured error responses
- [x] Label sanitization strips unsafe characters and truncates to 128 chars
- [x] No raw user input echoed in tool responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)