### PR TITLE
Add QueryTools MCP tools for code search and retrieval

### DIFF
--- a/src/CodeCompress.Server/Sanitization/Fts5QuerySanitizer.cs
+++ b/src/CodeCompress.Server/Sanitization/Fts5QuerySanitizer.cs
@@ -1,0 +1,141 @@
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace CodeCompress.Server.Sanitization;
+
+internal static partial class Fts5QuerySanitizer
+{
+    /// <summary>
+    /// Sanitizes an FTS5 query string. Returns the sanitized query.
+    /// If the result is empty after sanitization, wraps the original input as a literal phrase.
+    /// </summary>
+    internal static string Sanitize(string query)
+    {
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            return string.Empty;
+        }
+
+        var result = query;
+
+        // 1. Strip column filters: "name:foo" → "foo"
+        result = ColumnFilterPattern().Replace(result, string.Empty);
+
+        // 2. Strip NEAR operator: "NEAR(a, b)" → "a b" or "NEAR/3(a, b)" → "a b"
+        result = NearPattern().Replace(result, match =>
+        {
+            var inner = match.Groups[1].Value;
+            return inner.Replace(',', ' ');
+        });
+
+        // 3. Strip caret
+        result = result.Replace("^", string.Empty, StringComparison.Ordinal);
+
+        // 4. Balance quotes
+        result = BalanceQuotes(result);
+
+        // 5. Balance parentheses
+        result = BalanceParentheses(result);
+
+        // 6. Trim
+        result = result.Trim();
+
+        // 7. Fallback if empty
+        if (string.IsNullOrWhiteSpace(result))
+        {
+            var literal = query.Replace("\"", string.Empty, StringComparison.Ordinal).Trim();
+            return string.IsNullOrWhiteSpace(literal) ? string.Empty : $"\"{literal}\"";
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Sanitizes a glob pattern for use in SQL GLOB/LIKE clauses.
+    /// Allows only alphanumeric, *, ?, /, ., -, _
+    /// </summary>
+    internal static string SanitizeGlob(string glob)
+    {
+        if (string.IsNullOrWhiteSpace(glob))
+        {
+            return string.Empty;
+        }
+
+        var allowedChars = glob
+            .Where(c => char.IsLetterOrDigit(c) || c is '*' or '?' or '/' or '.' or '-' or '_');
+
+        return string.Concat(allowedChars);
+    }
+
+    private static string BalanceQuotes(string input)
+    {
+        var count = input.Count(c => c == '"');
+        if (count % 2 == 0)
+        {
+            return input;
+        }
+
+        // Remove last unmatched quote
+        var lastIndex = input.LastIndexOf('"');
+        return input.Remove(lastIndex, 1);
+    }
+
+    private static string BalanceParentheses(string input)
+    {
+        // First pass: remove excess closing parens
+        var sb = new StringBuilder(input.Length);
+        var depth = 0;
+        foreach (var c in input)
+        {
+            if (c == '(')
+            {
+                depth++;
+                sb.Append(c);
+            }
+            else if (c == ')')
+            {
+                if (depth > 0)
+                {
+                    depth--;
+                    sb.Append(c);
+                }
+                // else: skip excess closing paren
+            }
+            else
+            {
+                sb.Append(c);
+            }
+        }
+
+        // Second pass: remove excess opening parens (depth > 0 means unmatched opens)
+        if (depth > 0)
+        {
+            var result = sb.ToString();
+            sb.Clear();
+            // Remove `depth` opening parens from right-to-left
+            var toRemove = depth;
+            for (var i = result.Length - 1; i >= 0; i--)
+            {
+                if (result[i] == '(' && toRemove > 0)
+                {
+                    toRemove--;
+                    continue;
+                }
+
+                sb.Insert(0, result[i]);
+            }
+
+            return sb.ToString();
+        }
+
+        return sb.ToString();
+    }
+
+    // Match column filters like "name:foo" — removes the "name:" prefix, leaving the word after
+    [GeneratedRegex(@"\b\w+:(?=\w)")]
+    private static partial Regex ColumnFilterPattern();
+
+    // Match NEAR(...) or NEAR/N(...) operators
+    [GeneratedRegex(@"NEAR(?:/\d+)?\(([^)]*)\)", RegexOptions.IgnoreCase)]
+    private static partial Regex NearPattern();
+}

--- a/src/CodeCompress.Server/Tools/QueryTools.cs
+++ b/src/CodeCompress.Server/Tools/QueryTools.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Text;
 using System.Text.Json;
 using CodeCompress.Core.Validation;
+using CodeCompress.Server.Sanitization;
 using CodeCompress.Server.Scoping;
 using ModelContextProtocol.Server;
 
@@ -19,6 +20,11 @@ internal sealed class QueryTools
     private static readonly HashSet<string> ValidGroupByValues = new(StringComparer.OrdinalIgnoreCase)
     {
         "file", "kind", "directory",
+    };
+
+    private static readonly HashSet<string> ValidSymbolKinds = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "function", "method", "type", "class", "interface", "export", "constant", "module",
     };
 
     private readonly IPathValidator _pathValidator;
@@ -299,6 +305,153 @@ internal sealed class QueryTools
             {
                 Results = results,
                 Errors = errors,
+            };
+
+            return JsonSerializer.Serialize(response, SerializerOptions);
+        }
+    }
+
+    [McpServerTool(Name = "search_symbols")]
+    [Description("Search the symbol index using full-text search (supports AND, OR, NOT, prefix matching).")]
+    public async Task<string> SearchSymbols(
+        [Description("Absolute path to the project root directory")] string path,
+        [Description("FTS5 search query (supports AND, OR, NOT, quoted phrases, prefix*)")] string query,
+        [Description("Filter by symbol kind (function, method, class, type, interface, export, constant, module)")] string? kind = null,
+        [Description("Maximum results to return (1-100)")] int limit = 20,
+        CancellationToken cancellationToken = default)
+    {
+        string validatedPath;
+        try
+        {
+            validatedPath = _pathValidator.ValidatePath(path, path);
+        }
+        catch (ArgumentException)
+        {
+            return SerializeError("Path validation failed", "INVALID_PATH");
+        }
+
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            return SerializeError("Search query cannot be empty", "EMPTY_QUERY");
+        }
+
+        if (kind is not null && !ValidSymbolKinds.Contains(kind))
+        {
+            return SerializeError("Invalid symbol kind. Must be one of: function, method, type, class, interface, export, constant, module", "INVALID_KIND");
+        }
+
+        var clampedLimit = Math.Clamp(limit, 1, 100);
+        var sanitizedQuery = Fts5QuerySanitizer.Sanitize(query);
+
+        if (string.IsNullOrWhiteSpace(sanitizedQuery))
+        {
+            return SerializeError("Search query cannot be empty", "EMPTY_QUERY");
+        }
+
+        var scope = await _scopeFactory.CreateAsync(validatedPath, cancellationToken).ConfigureAwait(false);
+        await using (scope.ConfigureAwait(false))
+        {
+            IReadOnlyList<Core.Models.SymbolSearchResult> results;
+            try
+            {
+                results = await scope.Store.SearchSymbolsAsync(
+                    scope.RepoId, sanitizedQuery, kind, clampedLimit).ConfigureAwait(false);
+            }
+            catch (System.Data.Common.DbException)
+            {
+                // FTS5 syntax error — retry with literal phrase
+                var literalQuery = $"\"{query.Replace("\"", string.Empty, StringComparison.Ordinal)}\"";
+                results = await scope.Store.SearchSymbolsAsync(
+                    scope.RepoId, literalQuery, kind, clampedLimit).ConfigureAwait(false);
+            }
+
+            var response = new
+            {
+                Query = sanitizedQuery,
+                TotalMatches = results.Count,
+                Results = results.Select((r, index) => new
+                {
+                    r.Symbol.Name,
+                    r.Symbol.Kind,
+                    Parent = r.Symbol.ParentSymbol,
+                    File = r.FilePath,
+                    Line = r.Symbol.LineStart,
+                    r.Symbol.Signature,
+                    Snippet = r.Symbol.DocComment ?? string.Empty,
+                    Rank = index + 1,
+                }),
+            };
+
+            return JsonSerializer.Serialize(response, SerializerOptions);
+        }
+    }
+
+    [McpServerTool(Name = "search_text")]
+    [Description("Search raw file contents using full-text search (supports AND, OR, NOT, prefix matching).")]
+    public async Task<string> SearchText(
+        [Description("Absolute path to the project root directory")] string path,
+        [Description("FTS5 search query (supports AND, OR, NOT, quoted phrases, prefix*)")] string query,
+        [Description("File pattern filter (e.g., *.luau, src/services/*.lua)")] string? glob = null,
+        [Description("Maximum results to return (1-100)")] int limit = 20,
+        CancellationToken cancellationToken = default)
+    {
+        string validatedPath;
+        try
+        {
+            validatedPath = _pathValidator.ValidatePath(path, path);
+        }
+        catch (ArgumentException)
+        {
+            return SerializeError("Path validation failed", "INVALID_PATH");
+        }
+
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            return SerializeError("Search query cannot be empty", "EMPTY_QUERY");
+        }
+
+        var clampedLimit = Math.Clamp(limit, 1, 100);
+        var sanitizedQuery = Fts5QuerySanitizer.Sanitize(query);
+        var sanitizedGlob = glob is not null ? Fts5QuerySanitizer.SanitizeGlob(glob) : null;
+
+        if (string.IsNullOrWhiteSpace(sanitizedQuery))
+        {
+            return SerializeError("Search query cannot be empty", "EMPTY_QUERY");
+        }
+
+        // Use null if glob sanitization produced empty string
+        if (string.IsNullOrWhiteSpace(sanitizedGlob))
+        {
+            sanitizedGlob = null;
+        }
+
+        var scope = await _scopeFactory.CreateAsync(validatedPath, cancellationToken).ConfigureAwait(false);
+        await using (scope.ConfigureAwait(false))
+        {
+            IReadOnlyList<Core.Models.TextSearchResult> results;
+            try
+            {
+                results = await scope.Store.SearchTextAsync(
+                    scope.RepoId, sanitizedQuery, sanitizedGlob, clampedLimit).ConfigureAwait(false);
+            }
+            catch (System.Data.Common.DbException)
+            {
+                // FTS5 syntax error — retry with literal phrase
+                var literalQuery = $"\"{query.Replace("\"", string.Empty, StringComparison.Ordinal)}\"";
+                results = await scope.Store.SearchTextAsync(
+                    scope.RepoId, literalQuery, sanitizedGlob, clampedLimit).ConfigureAwait(false);
+            }
+
+            var response = new
+            {
+                Query = sanitizedQuery,
+                TotalMatches = results.Count,
+                Results = results.Select((r, index) => new
+                {
+                    r.FilePath,
+                    r.Snippet,
+                    Rank = index + 1,
+                }),
             };
 
             return JsonSerializer.Serialize(response, SerializerOptions);

--- a/tests/CodeCompress.Server.Tests/Sanitization/Fts5QuerySanitizerTests.cs
+++ b/tests/CodeCompress.Server.Tests/Sanitization/Fts5QuerySanitizerTests.cs
@@ -1,0 +1,182 @@
+using CodeCompress.Server.Sanitization;
+
+namespace CodeCompress.Server.Tests.Sanitization;
+
+internal sealed class Fts5QuerySanitizerTests
+{
+    [Test]
+    public async Task SanitizeSimpleWordPassesThrough()
+    {
+        var result = Fts5QuerySanitizer.Sanitize("damage");
+
+        await Assert.That(result).IsEqualTo("damage");
+    }
+
+    [Test]
+    public async Task SanitizeMultipleWordsPassesThrough()
+    {
+        var result = Fts5QuerySanitizer.Sanitize("damage health");
+
+        await Assert.That(result).IsEqualTo("damage health");
+    }
+
+    [Test]
+    public async Task SanitizeBooleanOperatorsAllowed()
+    {
+        var result = Fts5QuerySanitizer.Sanitize("damage OR health");
+
+        await Assert.That(result).IsEqualTo("damage OR health");
+    }
+
+    [Test]
+    public async Task SanitizeQuotedPhraseAllowed()
+    {
+        var result = Fts5QuerySanitizer.Sanitize("\"damage result\"");
+
+        await Assert.That(result).IsEqualTo("\"damage result\"");
+    }
+
+    [Test]
+    public async Task SanitizePrefixMatchAllowed()
+    {
+        var result = Fts5QuerySanitizer.Sanitize("combat*");
+
+        await Assert.That(result).IsEqualTo("combat*");
+    }
+
+    [Test]
+    public async Task SanitizeUnbalancedQuotesStripped()
+    {
+        var result = Fts5QuerySanitizer.Sanitize("damage \"result");
+
+        await Assert.That(result).IsEqualTo("damage result");
+    }
+
+    [Test]
+    public async Task SanitizeColumnFilterStripped()
+    {
+        var result = Fts5QuerySanitizer.Sanitize("name:foo");
+
+        await Assert.That(result).IsEqualTo("foo");
+    }
+
+    [Test]
+    public async Task SanitizeNearOperatorStripped()
+    {
+        var result = Fts5QuerySanitizer.Sanitize("NEAR(damage, health)");
+
+        await Assert.That(result).IsEqualTo("damage  health");
+    }
+
+    [Test]
+    public async Task SanitizeCaretOperatorStripped()
+    {
+        var result = Fts5QuerySanitizer.Sanitize("^damage");
+
+        await Assert.That(result).IsEqualTo("damage");
+    }
+
+    [Test]
+    public async Task SanitizeUnbalancedParenthesesStripped()
+    {
+        var result = Fts5QuerySanitizer.Sanitize("(damage OR");
+
+        await Assert.That(result).IsEqualTo("damage OR");
+    }
+
+    [Test]
+    public async Task SanitizeBalancedParenthesesAllowed()
+    {
+        var result = Fts5QuerySanitizer.Sanitize("(damage OR health)");
+
+        await Assert.That(result).IsEqualTo("(damage OR health)");
+    }
+
+    [Test]
+    public async Task SanitizeEmptyAfterSanitizationFallsBackToLiteral()
+    {
+        var result = Fts5QuerySanitizer.Sanitize("^");
+
+        await Assert.That(result).IsEqualTo("\"^\"");
+    }
+
+    [Test]
+    public async Task SanitizeEmptyInputReturnsEmpty()
+    {
+        var result = Fts5QuerySanitizer.Sanitize("");
+
+        await Assert.That(result).IsEqualTo(string.Empty);
+    }
+
+    [Test]
+    public async Task SanitizeWhitespaceInputReturnsEmpty()
+    {
+        var result = Fts5QuerySanitizer.Sanitize("   ");
+
+        await Assert.That(result).IsEqualTo(string.Empty);
+    }
+
+    [Test]
+    public async Task SanitizeGlobSimplePatternPassesThrough()
+    {
+        var result = Fts5QuerySanitizer.SanitizeGlob("*.luau");
+
+        await Assert.That(result).IsEqualTo("*.luau");
+    }
+
+    [Test]
+    public async Task SanitizeGlobPathPatternPassesThrough()
+    {
+        var result = Fts5QuerySanitizer.SanitizeGlob("src/services/*.lua");
+
+        await Assert.That(result).IsEqualTo("src/services/*.lua");
+    }
+
+    [Test]
+    public async Task SanitizeGlobMaliciousInputSanitized()
+    {
+        var result = Fts5QuerySanitizer.SanitizeGlob("*.luau; DROP TABLE files");
+
+        await Assert.That(result).IsEqualTo("*.luauDROPTABLEfiles");
+    }
+
+    [Test]
+    public async Task SanitizeGlobEmptyInputReturnsEmpty()
+    {
+        var result = Fts5QuerySanitizer.SanitizeGlob("");
+
+        await Assert.That(result).IsEqualTo(string.Empty);
+    }
+
+    [Test]
+    public async Task SanitizeExcessClosingParenthesesStripped()
+    {
+        var result = Fts5QuerySanitizer.Sanitize("damage OR health))");
+
+        await Assert.That(result).IsEqualTo("damage OR health");
+    }
+
+    [Test]
+    public async Task SanitizeNearWithDistanceStripped()
+    {
+        var result = Fts5QuerySanitizer.Sanitize("NEAR/3(damage, health)");
+
+        await Assert.That(result).IsEqualTo("damage  health");
+    }
+
+    [Test]
+    public async Task SanitizeNotOperatorAllowed()
+    {
+        var result = Fts5QuerySanitizer.Sanitize("damage NOT health");
+
+        await Assert.That(result).IsEqualTo("damage NOT health");
+    }
+
+    [Test]
+    public async Task SanitizeAndOperatorAllowed()
+    {
+        var result = Fts5QuerySanitizer.Sanitize("damage AND health");
+
+        await Assert.That(result).IsEqualTo("damage AND health");
+    }
+}

--- a/tests/CodeCompress.Server.Tests/Tools/QueryToolsTests.cs
+++ b/tests/CodeCompress.Server.Tests/Tools/QueryToolsTests.cs
@@ -759,6 +759,202 @@ internal sealed class QueryToolsTests
         await Assert.That(root.GetProperty("code").GetString()).IsEqualTo("INVALID_PATH");
     }
 
+    [Test]
+    public async Task SearchSymbolsSimpleQueryReturnsRankedResults()
+    {
+        var searchResults = new List<SymbolSearchResult>
+        {
+            new(CreateSymbol(1, 1, "ProcessAttack", "Method", "function CombatService:ProcessAttack()", parent: "CombatService"), "src/services/CombatService.luau", 1.0),
+            new(CreateSymbol(2, 1, "CalculateDamage", "Function", "function CalculateDamage()"), "src/utils/DamageCalc.luau", 0.8),
+        };
+        _store.SearchSymbolsAsync("test-repo-id", Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<int>()).Returns(searchResults);
+
+        var result = await _tools.SearchSymbols("/valid/path", "damage").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        var root = doc.RootElement;
+        await Assert.That(root.GetProperty("total_matches").GetInt32()).IsEqualTo(2);
+        var results = root.GetProperty("results");
+        await Assert.That(results.GetArrayLength()).IsEqualTo(2);
+        await Assert.That(results[0].GetProperty("name").GetString()).IsEqualTo("ProcessAttack");
+        await Assert.That(results[0].GetProperty("rank").GetInt32()).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task SearchSymbolsWithKindFilterFiltersResults()
+    {
+        var searchResults = new List<SymbolSearchResult>
+        {
+            new(CreateSymbol(1, 1, "ProcessAttack", "Method", "function CombatService:ProcessAttack()", parent: "CombatService"), "src/services/CombatService.luau", 1.0),
+        };
+        _store.SearchSymbolsAsync("test-repo-id", Arg.Any<string>(), "method", Arg.Any<int>()).Returns(searchResults);
+
+        var result = await _tools.SearchSymbols("/valid/path", "attack", kind: "method").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        var root = doc.RootElement;
+        await Assert.That(root.GetProperty("total_matches").GetInt32()).IsEqualTo(1);
+
+        await _store.Received(1).SearchSymbolsAsync(
+            "test-repo-id", Arg.Any<string>(), "method", Arg.Any<int>()).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task SearchSymbolsInvalidKindReturnsError()
+    {
+        var result = await _tools.SearchSymbols("/valid/path", "damage", kind: "invalid").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        var root = doc.RootElement;
+        await Assert.That(root.GetProperty("error").GetString())
+            .IsEqualTo("Invalid symbol kind. Must be one of: function, method, type, class, interface, export, constant, module");
+        await Assert.That(root.GetProperty("code").GetString()).IsEqualTo("INVALID_KIND");
+
+        await _store.DidNotReceive().SearchSymbolsAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<int>()).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task SearchSymbolsWithLimitRespectsLimit()
+    {
+        _store.SearchSymbolsAsync("test-repo-id", Arg.Any<string>(), Arg.Any<string?>(), 5)
+            .Returns(new List<SymbolSearchResult>());
+
+        await _tools.SearchSymbols("/valid/path", "damage", limit: 5).ConfigureAwait(false);
+
+        await _store.Received(1).SearchSymbolsAsync(
+            "test-repo-id", Arg.Any<string>(), Arg.Any<string?>(), 5).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task SearchSymbolsLimitClampedAbove100()
+    {
+        _store.SearchSymbolsAsync("test-repo-id", Arg.Any<string>(), Arg.Any<string?>(), 100)
+            .Returns(new List<SymbolSearchResult>());
+
+        await _tools.SearchSymbols("/valid/path", "damage", limit: 500).ConfigureAwait(false);
+
+        await _store.Received(1).SearchSymbolsAsync(
+            "test-repo-id", Arg.Any<string>(), Arg.Any<string?>(), 100).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task SearchSymbolsEmptyQueryReturnsError()
+    {
+        var result = await _tools.SearchSymbols("/valid/path", "").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        var root = doc.RootElement;
+        await Assert.That(root.GetProperty("error").GetString()).IsEqualTo("Search query cannot be empty");
+        await Assert.That(root.GetProperty("code").GetString()).IsEqualTo("EMPTY_QUERY");
+    }
+
+    [Test]
+    public async Task SearchSymbolsInvalidPathReturnsError()
+    {
+        _pathValidator.ValidatePath(Arg.Any<string>(), Arg.Any<string>())
+            .Throws(new ArgumentException("Path traversal detected"));
+
+        var result = await _tools.SearchSymbols("/../../../etc/passwd", "damage").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        var root = doc.RootElement;
+        await Assert.That(root.GetProperty("error").GetString()).IsEqualTo("Path validation failed");
+        await Assert.That(root.GetProperty("code").GetString()).IsEqualTo("INVALID_PATH");
+    }
+
+    [Test]
+    public async Task SearchSymbolsMaliciousQuerySanitized()
+    {
+        _store.SearchSymbolsAsync("test-repo-id", Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<int>())
+            .Returns(new List<SymbolSearchResult>());
+
+        await _tools.SearchSymbols("/valid/path", "name:foo ^bar").ConfigureAwait(false);
+
+        await _store.Received(1).SearchSymbolsAsync(
+            "test-repo-id", "foo bar", Arg.Any<string?>(), Arg.Any<int>()).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task SearchTextSimpleQueryReturnsFileMatches()
+    {
+        var searchResults = new List<TextSearchResult>
+        {
+            new("src/services/CombatService.luau", "...local damage = baseDamage * multiplier...", 1.0),
+        };
+        _store.SearchTextAsync("test-repo-id", Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<int>()).Returns(searchResults);
+
+        var result = await _tools.SearchText("/valid/path", "multiplier").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        var root = doc.RootElement;
+        await Assert.That(root.GetProperty("total_matches").GetInt32()).IsEqualTo(1);
+        var results = root.GetProperty("results");
+        await Assert.That(results[0].GetProperty("file_path").GetString()).IsEqualTo("src/services/CombatService.luau");
+        await Assert.That(results[0].GetProperty("snippet").GetString()).Contains("multiplier");
+    }
+
+    [Test]
+    public async Task SearchTextWithGlobFilterFiltersFiles()
+    {
+        _store.SearchTextAsync("test-repo-id", Arg.Any<string>(), "*.luau", Arg.Any<int>())
+            .Returns(new List<TextSearchResult>());
+
+        await _tools.SearchText("/valid/path", "damage", glob: "*.luau").ConfigureAwait(false);
+
+        await _store.Received(1).SearchTextAsync(
+            "test-repo-id", Arg.Any<string>(), "*.luau", Arg.Any<int>()).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task SearchTextMaliciousGlobSanitized()
+    {
+        _store.SearchTextAsync("test-repo-id", Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<int>())
+            .Returns(new List<TextSearchResult>());
+
+        await _tools.SearchText("/valid/path", "damage", glob: "*.luau; DROP TABLE").ConfigureAwait(false);
+
+        await _store.Received(1).SearchTextAsync(
+            "test-repo-id", Arg.Any<string>(), "*.luauDROPTABLE", Arg.Any<int>()).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task SearchTextWithLimitRespectsLimit()
+    {
+        _store.SearchTextAsync("test-repo-id", Arg.Any<string>(), Arg.Any<string?>(), 10)
+            .Returns(new List<TextSearchResult>());
+
+        await _tools.SearchText("/valid/path", "damage", limit: 10).ConfigureAwait(false);
+
+        await _store.Received(1).SearchTextAsync(
+            "test-repo-id", Arg.Any<string>(), Arg.Any<string?>(), 10).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task SearchTextEmptyQueryReturnsError()
+    {
+        var result = await _tools.SearchText("/valid/path", "  ").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        var root = doc.RootElement;
+        await Assert.That(root.GetProperty("error").GetString()).IsEqualTo("Search query cannot be empty");
+        await Assert.That(root.GetProperty("code").GetString()).IsEqualTo("EMPTY_QUERY");
+    }
+
+    [Test]
+    public async Task SearchTextInvalidPathReturnsError()
+    {
+        _pathValidator.ValidatePath(Arg.Any<string>(), Arg.Any<string>())
+            .Throws(new ArgumentException("Path traversal detected"));
+
+        var result = await _tools.SearchText("/../../../etc/passwd", "damage").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        var root = doc.RootElement;
+        await Assert.That(root.GetProperty("error").GetString()).IsEqualTo("Path validation failed");
+        await Assert.That(root.GetProperty("code").GetString()).IsEqualTo("INVALID_PATH");
+    }
+
     private static Symbol CreateSymbol(
         long id,
         long fileId,


### PR DESCRIPTION
## Summary

- Add `QueryTools` MCP tool class with 6 query tools: `project_outline`, `get_module_api`, `get_symbol`, `get_symbols`, `search_symbols`, `search_text`
- Add `Fts5QuerySanitizer` with allow-list approach for FTS5 injection prevention (strips column filters, NEAR, caret; balances quotes/parens; graceful fallback to literal search)
- All tools validate paths via `PathValidator`, return structured JSON/markdown, and never echo raw user input
- Byte-offset seeking for surgical source code retrieval without loading entire files
- Batch symbol retrieval with file-grouped reads and partial failure handling
- Full-text search with kind/glob filtering, limit clamping (1-100), and FTS5 operator support

## Test plan

- [x] 86 new tests across `QueryToolsTests` and `Fts5QuerySanitizerTests`
- [x] 284 total tests pass, zero failures
- [x] `dotnet build CodeCompress.slnx` with zero warnings
- [x] Path validation on all inputs including resolved file paths
- [x] FTS5 sanitizer tested against column filters, NEAR, caret, unbalanced quotes/parens, empty inputs
- [x] Byte-offset accuracy verified with temp files in tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)