### PR TITLE
Add dependency_graph MCP tool

### DIFF
--- a/src/CodeCompress.Core/Storage/SqliteSymbolStore.cs
+++ b/src/CodeCompress.Core/Storage/SqliteSymbolStore.cs
@@ -1030,7 +1030,7 @@ public sealed class SqliteSymbolStore : ISymbolStore
         ArgumentNullException.ThrowIfNull(repoId);
         ArgumentNullException.ThrowIfNull(direction);
 
-        var clampedDepth = Math.Min(Math.Max(depth, 1), 10);
+        var clampedDepth = Math.Min(Math.Max(depth, 1), 50);
 
         // Load all files for this repo into a lookup
         var allFiles = await GetFilesByRepoAsync(repoId).ConfigureAwait(false);

--- a/src/CodeCompress.Server/Tools/DependencyTools.cs
+++ b/src/CodeCompress.Server/Tools/DependencyTools.cs
@@ -1,0 +1,175 @@
+using System.ComponentModel;
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using CodeCompress.Core.Models;
+using CodeCompress.Core.Validation;
+using CodeCompress.Server.Scoping;
+using ModelContextProtocol.Server;
+
+namespace CodeCompress.Server.Tools;
+
+[McpServerToolType]
+internal sealed class DependencyTools
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+    };
+
+    private static readonly HashSet<string> ValidDirections = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "dependencies", "dependents", "both",
+    };
+
+    private readonly IPathValidator _pathValidator;
+    private readonly IProjectScopeFactory _scopeFactory;
+
+    public DependencyTools(IPathValidator pathValidator, IProjectScopeFactory scopeFactory)
+    {
+        ArgumentNullException.ThrowIfNull(pathValidator);
+        ArgumentNullException.ThrowIfNull(scopeFactory);
+
+        _pathValidator = pathValidator;
+        _scopeFactory = scopeFactory;
+    }
+
+    [McpServerTool(Name = "dependency_graph")]
+    [Description("Get the import/require dependency graph for a project or a specific file.")]
+    public async Task<string> DependencyGraph(
+        [Description("Absolute path to the project root directory")] string path,
+        [Description("Start traversal from a specific file (relative path). Omit for full project graph.")] string? rootFile = null,
+        [Description("Direction: dependencies (outgoing), dependents (incoming), or both")] string direction = "both",
+        [Description("Maximum traversal depth (1-50). Omit for unlimited.")] int? depth = null,
+        CancellationToken cancellationToken = default)
+    {
+        string validatedPath;
+        try
+        {
+            validatedPath = _pathValidator.ValidatePath(path, path);
+        }
+        catch (ArgumentException)
+        {
+            return SerializeError("Path validation failed", "INVALID_PATH");
+        }
+
+        if (!ValidDirections.Contains(direction))
+        {
+            return SerializeError(
+                "Invalid direction. Must be one of: dependencies, dependents, both",
+                "INVALID_DIRECTION");
+        }
+
+        if (rootFile is not null)
+        {
+            try
+            {
+                _pathValidator.ValidateRelativePath(rootFile, validatedPath);
+            }
+            catch (ArgumentException)
+            {
+                return SerializeError("Path validation failed", "INVALID_PATH");
+            }
+        }
+
+        var clampedDepth = depth.HasValue ? Math.Clamp(depth.Value, 1, 50) : 50;
+
+        var scope = await _scopeFactory.CreateAsync(validatedPath, cancellationToken).ConfigureAwait(false);
+        await using (scope.ConfigureAwait(false))
+        {
+            var graph = await scope.Store.GetDependencyGraphAsync(
+                scope.RepoId, rootFile, direction, clampedDepth).ConfigureAwait(false);
+
+            // Non-existent root file returns empty graph
+            if (rootFile is not null && graph.Nodes.Count == 0)
+            {
+                return SerializeError("File not found in index", "FILE_NOT_FOUND");
+            }
+
+            return FormatGraph(graph, rootFile, direction, clampedDepth);
+        }
+    }
+
+    private static string FormatGraph(DependencyGraph graph, string? rootFile, string direction, int depth)
+    {
+        var sb = new StringBuilder();
+
+        // Header
+        if (rootFile is not null)
+        {
+            sb.AppendLine(CultureInfo.InvariantCulture,
+                $"Dependency graph for \"{rootFile}\" (depth: {depth}, direction: {direction}):");
+        }
+        else
+        {
+            sb.AppendLine(CultureInfo.InvariantCulture,
+                $"Dependency graph (full project, direction: {direction}):");
+        }
+
+        sb.AppendLine();
+
+        // Build edge lookups: From->To = "requires", To->From = "required by"
+        var outgoing = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+        var incoming = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+
+        foreach (var edge in graph.Edges)
+        {
+            if (!outgoing.TryGetValue(edge.From, out var outList))
+            {
+                outList = [];
+                outgoing[edge.From] = outList;
+            }
+
+            outList.Add(edge.To);
+
+            if (!incoming.TryGetValue(edge.To, out var inList))
+            {
+                inList = [];
+                incoming[edge.To] = inList;
+            }
+
+            inList.Add(edge.From);
+        }
+
+        var showOutgoing = string.Equals(direction, "dependencies", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(direction, "both", StringComparison.OrdinalIgnoreCase);
+        var showIncoming = string.Equals(direction, "dependents", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(direction, "both", StringComparison.OrdinalIgnoreCase);
+
+        // Render each node
+        foreach (var node in graph.Nodes)
+        {
+            sb.AppendLine(node);
+
+            if (showOutgoing)
+            {
+                var deps = outgoing.TryGetValue(node, out var outList)
+                    ? string.Join(", ", outList.Order(StringComparer.Ordinal))
+                    : "(none)";
+                sb.AppendLine(CultureInfo.InvariantCulture, $"  requires -> {deps}");
+            }
+
+            if (showIncoming)
+            {
+                var deps = incoming.TryGetValue(node, out var inList)
+                    ? string.Join(", ", inList.Order(StringComparer.Ordinal))
+                    : "(none)";
+                sb.AppendLine(CultureInfo.InvariantCulture, $"  required by -> {deps}");
+            }
+
+            sb.AppendLine();
+        }
+
+        // Full project summary
+        if (rootFile is null)
+        {
+            sb.AppendLine(CultureInfo.InvariantCulture,
+                $"Total: {graph.Nodes.Count} files, {graph.Edges.Count} dependency edges");
+        }
+
+        return sb.ToString();
+    }
+
+    private static string SerializeError(string error, string code) =>
+        JsonSerializer.Serialize(new { Error = error, Code = code }, SerializerOptions);
+}

--- a/tests/CodeCompress.Server.Tests/Tools/DependencyToolsTests.cs
+++ b/tests/CodeCompress.Server.Tests/Tools/DependencyToolsTests.cs
@@ -1,0 +1,292 @@
+using System.Text.Json;
+using CodeCompress.Core.Indexing;
+using CodeCompress.Core.Models;
+using CodeCompress.Core.Storage;
+using CodeCompress.Core.Validation;
+using CodeCompress.Server.Scoping;
+using CodeCompress.Server.Tools;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace CodeCompress.Server.Tests.Tools;
+
+internal sealed class DependencyToolsTests
+{
+    private IPathValidator _pathValidator = null!;
+    private IProjectScopeFactory _scopeFactory = null!;
+    private IProjectScope _scope = null!;
+    private IIndexEngine _engine = null!;
+    private ISymbolStore _store = null!;
+    private DependencyTools _tools = null!;
+
+    [Before(Test)]
+    public void SetUp()
+    {
+        _pathValidator = Substitute.For<IPathValidator>();
+        _scopeFactory = Substitute.For<IProjectScopeFactory>();
+        _scope = Substitute.For<IProjectScope>();
+        _engine = Substitute.For<IIndexEngine>();
+        _store = Substitute.For<ISymbolStore>();
+
+        _scope.Engine.Returns(_engine);
+        _scope.Store.Returns(_store);
+        _scope.RepoId.Returns("test-repo-id");
+        _scopeFactory.CreateAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(_scope);
+        _pathValidator.ValidatePath(Arg.Any<string>(), Arg.Any<string>()).Returns(callInfo => callInfo.ArgAt<string>(0));
+        _pathValidator.ValidateRelativePath(Arg.Any<string>(), Arg.Any<string>()).Returns(callInfo => Path.Combine(callInfo.ArgAt<string>(1), callInfo.ArgAt<string>(0)));
+
+        _tools = new DependencyTools(_pathValidator, _scopeFactory);
+    }
+
+    // ── 1. SingleFileDependenciesReturnsOutgoingEdges ───────────────
+
+    [Test]
+    public async Task SingleFileDependenciesReturnsOutgoingEdges()
+    {
+        var graph = new DependencyGraph(
+            ["CombatService.luau", "GameTypes.luau", "WeaponConfig.luau"],
+            [
+                new DependencyEdge("CombatService.luau", "GameTypes.luau", null),
+                new DependencyEdge("CombatService.luau", "WeaponConfig.luau", null),
+            ]);
+
+        _store.GetDependencyGraphAsync("test-repo-id", "CombatService.luau", "dependencies", Arg.Any<int>())
+            .Returns(graph);
+
+        var result = await _tools.DependencyGraph("/valid/path", rootFile: "CombatService.luau", direction: "dependencies").ConfigureAwait(false);
+
+        await Assert.That(result).Contains("requires -> GameTypes.luau, WeaponConfig.luau");
+    }
+
+    // ── 2. SingleFileDependentsReturnsIncomingEdges ─────────────────
+
+    [Test]
+    public async Task SingleFileDependentsReturnsIncomingEdges()
+    {
+        var graph = new DependencyGraph(
+            ["GameTypes.luau", "CombatService.luau", "AIService.luau"],
+            [
+                new DependencyEdge("CombatService.luau", "GameTypes.luau", null),
+                new DependencyEdge("AIService.luau", "GameTypes.luau", null),
+            ]);
+
+        _store.GetDependencyGraphAsync("test-repo-id", "GameTypes.luau", "dependents", Arg.Any<int>())
+            .Returns(graph);
+
+        var result = await _tools.DependencyGraph("/valid/path", rootFile: "GameTypes.luau", direction: "dependents").ConfigureAwait(false);
+
+        await Assert.That(result).Contains("required by ->");
+        await Assert.That(result).Contains("CombatService.luau");
+        await Assert.That(result).Contains("AIService.luau");
+    }
+
+    // ── 3. SingleFileBothReturnsBothDirections ─────────────────────
+
+    [Test]
+    public async Task SingleFileBothReturnsBothDirections()
+    {
+        var graph = new DependencyGraph(
+            ["CombatService.luau", "GameTypes.luau", "AgentService.luau"],
+            [
+                new DependencyEdge("CombatService.luau", "GameTypes.luau", null),
+                new DependencyEdge("AgentService.luau", "CombatService.luau", null),
+            ]);
+
+        _store.GetDependencyGraphAsync("test-repo-id", "CombatService.luau", "both", Arg.Any<int>())
+            .Returns(graph);
+
+        var result = await _tools.DependencyGraph("/valid/path", rootFile: "CombatService.luau", direction: "both").ConfigureAwait(false);
+
+        await Assert.That(result).Contains("requires ->");
+        await Assert.That(result).Contains("required by ->");
+    }
+
+    // ── 4. DepthLimitingStopsAtSpecifiedDepth ──────────────────────
+
+    [Test]
+    public async Task DepthLimitingStopsAtSpecifiedDepth()
+    {
+        var graph = new DependencyGraph(
+            ["A.luau", "B.luau"],
+            [new DependencyEdge("A.luau", "B.luau", null)]);
+
+        _store.GetDependencyGraphAsync("test-repo-id", "A.luau", "both", 1)
+            .Returns(graph);
+
+        var result = await _tools.DependencyGraph("/valid/path", rootFile: "A.luau", direction: "both", depth: 1).ConfigureAwait(false);
+
+        await _store.Received(1).GetDependencyGraphAsync("test-repo-id", "A.luau", "both", 1).ConfigureAwait(false);
+        await Assert.That(result).Contains("(depth: 1");
+    }
+
+    // ── 5. FullProjectGraphNoRootFileReturnsAllEdges ───────────────
+
+    [Test]
+    public async Task FullProjectGraphNoRootFileReturnsAllEdges()
+    {
+        var graph = new DependencyGraph(
+            ["File1.luau", "File2.luau", "File3.luau"],
+            [
+                new DependencyEdge("File1.luau", "File2.luau", null),
+                new DependencyEdge("File2.luau", "File3.luau", null),
+            ]);
+
+        _store.GetDependencyGraphAsync("test-repo-id", null, "both", Arg.Any<int>())
+            .Returns(graph);
+
+        var result = await _tools.DependencyGraph("/valid/path", rootFile: null, direction: "both").ConfigureAwait(false);
+
+        await Assert.That(result).Contains("full project");
+        await Assert.That(result).Contains("Total:");
+        await Assert.That(result).Contains("3 files");
+        await Assert.That(result).Contains("2 dependency edges");
+    }
+
+    // ── 6. FileWithNoDependenciesReturnsEmptyEdges ─────────────────
+
+    [Test]
+    public async Task FileWithNoDependenciesReturnsEmptyEdges()
+    {
+        var graph = new DependencyGraph(
+            ["Isolated.luau"],
+            []);
+
+        _store.GetDependencyGraphAsync("test-repo-id", "Isolated.luau", "both", Arg.Any<int>())
+            .Returns(graph);
+
+        var result = await _tools.DependencyGraph("/valid/path", rootFile: "Isolated.luau", direction: "both").ConfigureAwait(false);
+
+        await Assert.That(result).Contains("(none)");
+    }
+
+    // ── 7. NonExistentFileReturnsError ─────────────────────────────
+
+    [Test]
+    public async Task NonExistentFileReturnsError()
+    {
+        var graph = new DependencyGraph([], []);
+
+        _store.GetDependencyGraphAsync("test-repo-id", "missing.luau", "both", Arg.Any<int>())
+            .Returns(graph);
+
+        var result = await _tools.DependencyGraph("/valid/path", rootFile: "missing.luau", direction: "both").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        var root = doc.RootElement;
+        await Assert.That(root.GetProperty("code").GetString()).IsEqualTo("FILE_NOT_FOUND");
+    }
+
+    // ── 8. CircularDependenciesNoInfiniteLoop ──────────────────────
+
+    [Test]
+    public async Task CircularDependenciesNoInfiniteLoop()
+    {
+        var graph = new DependencyGraph(
+            ["A.luau", "B.luau"],
+            [
+                new DependencyEdge("A.luau", "B.luau", null),
+                new DependencyEdge("B.luau", "A.luau", null),
+            ]);
+
+        _store.GetDependencyGraphAsync("test-repo-id", "A.luau", "both", Arg.Any<int>())
+            .Returns(graph);
+
+        var result = await _tools.DependencyGraph("/valid/path", rootFile: "A.luau", direction: "both").ConfigureAwait(false);
+
+        await Assert.That(result).Contains("A.luau");
+        await Assert.That(result).Contains("B.luau");
+    }
+
+    // ── 9. InvalidDirectionReturnsError ────────────────────────────
+
+    [Test]
+    public async Task InvalidDirectionReturnsError()
+    {
+        var result = await _tools.DependencyGraph("/valid/path", rootFile: "file.luau", direction: "invalid").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        var root = doc.RootElement;
+        await Assert.That(root.GetProperty("code").GetString()).IsEqualTo("INVALID_DIRECTION");
+    }
+
+    // ── 10. PathValidationRejectsTraversal ─────────────────────────
+
+    [Test]
+    public async Task PathValidationRejectsTraversal()
+    {
+        _pathValidator.ValidatePath(Arg.Any<string>(), Arg.Any<string>())
+            .Throws(new ArgumentException("Path traversal detected"));
+
+        var result = await _tools.DependencyGraph("/../../../etc/passwd").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        var root = doc.RootElement;
+        await Assert.That(root.GetProperty("error").GetString()).IsEqualTo("Path validation failed");
+        await Assert.That(root.GetProperty("code").GetString()).IsEqualTo("INVALID_PATH");
+    }
+
+    // ── 11. DepthClampingExcessiveDepthClamped ─────────────────────
+
+    [Test]
+    public async Task DepthClampingExcessiveDepthClamped()
+    {
+        var graph = new DependencyGraph(["A.luau"], []);
+
+        _store.GetDependencyGraphAsync("test-repo-id", "A.luau", "both", 50)
+            .Returns(graph);
+
+        await _tools.DependencyGraph("/valid/path", rootFile: "A.luau", direction: "both", depth: 999).ConfigureAwait(false);
+
+        await _store.Received(1).GetDependencyGraphAsync(
+            Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(), 50).ConfigureAwait(false);
+    }
+
+    // ── 12. MultipleRootsInGraphCorrectTraversal ───────────────────
+
+    [Test]
+    public async Task MultipleRootsInGraphCorrectTraversal()
+    {
+        var graph = new DependencyGraph(
+            ["Main.luau", "Lib.luau", "Utils.luau", "Config.luau"],
+            [
+                new DependencyEdge("Main.luau", "Lib.luau", null),
+                new DependencyEdge("Main.luau", "Utils.luau", null),
+                new DependencyEdge("Lib.luau", "Config.luau", null),
+                new DependencyEdge("Utils.luau", "Config.luau", null),
+            ]);
+
+        _store.GetDependencyGraphAsync("test-repo-id", "Main.luau", "both", Arg.Any<int>())
+            .Returns(graph);
+
+        var result = await _tools.DependencyGraph("/valid/path", rootFile: "Main.luau", direction: "both").ConfigureAwait(false);
+
+        await Assert.That(result).Contains("Main.luau");
+        await Assert.That(result).Contains("Lib.luau");
+        await Assert.That(result).Contains("Utils.luau");
+        await Assert.That(result).Contains("Config.luau");
+    }
+
+    // ── 13. TransitiveDependenciesFullChain ────────────────────────
+
+    [Test]
+    public async Task TransitiveDependenciesFullChain()
+    {
+        var graph = new DependencyGraph(
+            ["A.luau", "B.luau", "C.luau", "D.luau"],
+            [
+                new DependencyEdge("A.luau", "B.luau", null),
+                new DependencyEdge("B.luau", "C.luau", null),
+                new DependencyEdge("C.luau", "D.luau", null),
+            ]);
+
+        _store.GetDependencyGraphAsync("test-repo-id", "A.luau", "dependencies", Arg.Any<int>())
+            .Returns(graph);
+
+        var result = await _tools.DependencyGraph("/valid/path", rootFile: "A.luau", direction: "dependencies").ConfigureAwait(false);
+
+        await Assert.That(result).Contains("A.luau");
+        await Assert.That(result).Contains("B.luau");
+        await Assert.That(result).Contains("C.luau");
+        await Assert.That(result).Contains("D.luau");
+    }
+}


### PR DESCRIPTION
## Summary
- Add `DependencyTools` class with `dependency_graph` MCP tool for import/require relationship traversal
- Supports three direction modes: `dependencies` (outgoing), `dependents` (incoming), `both`
- Depth-limited BFS traversal (1-50 clamped) with full project graph when `root_file` is omitted
- Structured adjacency list output showing `requires ->` and `required by ->` edges per node
- Handles circular dependencies, non-existent files, invalid directions, and path traversal attacks
- Increase store depth cap from 10 to 50 to match tool requirements

## Test plan
- [x] 13 new unit tests covering all acceptance criteria
- [x] All 313 tests pass across full test suite
- [x] Zero build warnings
- [x] Path validation on all parameters
- [x] Direction validation with clear error messages
- [x] Depth clamping (1-50) verified via NSubstitute received calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)