### PR TITLE
Add C# parser with full symbol extraction and integration tests

### DIFF
--- a/samples/csharp-sample-project/Enums/GameState.cs
+++ b/samples/csharp-sample-project/Enums/GameState.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace GameProject.Enums;
+
+/// <summary>
+/// Represents the current state of the game.
+/// </summary>
+public enum GameState
+{
+    NotStarted,
+    InProgress,
+    Paused,
+    Completed
+}
+
+/// <summary>
+/// Flags for player capabilities.
+/// </summary>
+[Flags]
+public enum PlayerCapabilities
+{
+    None = 0,
+    CanAttack = 1,
+    CanHeal = 2,
+    CanTrade = 4,
+    CanCraft = 8
+}

--- a/samples/csharp-sample-project/Handlers/GameHandler.cs
+++ b/samples/csharp-sample-project/Handlers/GameHandler.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Threading.Tasks;
+using GameProject.Models;
+using GameProject.Services;
+
+namespace GameProject.Handlers;
+
+/// <summary>
+/// Handles game-level operations and coordinates services.
+/// </summary>
+public class GameHandler
+{
+    private readonly ICombatService _combatService;
+    private readonly InventoryService _inventoryService;
+
+    public GameHandler(ICombatService combatService, InventoryService inventoryService)
+    {
+        _combatService = combatService;
+        _inventoryService = inventoryService;
+    }
+
+    public async Task<(bool Success, string Message)> HandleAttackAsync(Player attacker, Player defender)
+    {
+        var damage = await _combatService.ProcessAttackAsync(attacker, defender);
+        return (true, $"Attack dealt {damage} damage");
+    }
+
+    public Player? FindPlayerByName(string name)
+    {
+        return null;
+    }
+
+    /// <summary>
+    /// Gets the game status for a player.
+    /// </summary>
+    public string GetStatus(Player player) => player.IsAlive ? "Active" : "Defeated";
+}

--- a/samples/csharp-sample-project/Models/GameEvent.cs
+++ b/samples/csharp-sample-project/Models/GameEvent.cs
@@ -1,0 +1,51 @@
+using System;
+
+namespace GameProject.Models;
+
+/// <summary>
+/// Base class for all game events.
+/// </summary>
+public abstract class GameEvent
+{
+    public DateTime Timestamp { get; init; }
+
+    public abstract string EventType { get; }
+
+    public abstract void Execute();
+}
+
+/// <summary>
+/// Represents a typed game event.
+/// </summary>
+public class GameEvent<T> : GameEvent where T : class
+{
+    public T Payload { get; }
+
+    public override string EventType => typeof(T).Name;
+
+    public GameEvent(T payload)
+    {
+        Payload = payload;
+        Timestamp = DateTime.UtcNow;
+    }
+
+    public override void Execute()
+    {
+        // Process the event
+    }
+}
+
+/// <summary>
+/// Defines a handler for game events.
+/// </summary>
+public interface IGameEventHandler
+{
+    void Handle(GameEvent gameEvent);
+
+    bool CanHandle(string eventType);
+}
+
+public interface IGameEventHandler<T> where T : class
+{
+    void Handle(GameEvent<T> gameEvent);
+}

--- a/samples/csharp-sample-project/Models/Inventory.cs
+++ b/samples/csharp-sample-project/Models/Inventory.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+
+namespace GameProject.Models;
+
+/// <summary>
+/// Manages a player's inventory of items.
+/// </summary>
+public class Inventory
+{
+    private readonly List<string> _items = [];
+
+    /// <summary>
+    /// Gets the number of items in the inventory.
+    /// </summary>
+    public int Count => _items.Count;
+
+    public IReadOnlyList<string> Items => _items;
+
+    public void AddItem(string item)
+    {
+        _items.Add(item);
+    }
+
+    public bool RemoveItem(string item)
+    {
+        return _items.Remove(item);
+    }
+
+    public bool Contains(string item)
+    {
+        return _items.Contains(item);
+    }
+
+    /// <summary>
+    /// Represents the rarity of an item.
+    /// </summary>
+    public enum ItemRarity
+    {
+        Common,
+        Uncommon,
+        Rare,
+        Epic,
+        Legendary
+    }
+}

--- a/samples/csharp-sample-project/Models/Player.cs
+++ b/samples/csharp-sample-project/Models/Player.cs
@@ -1,0 +1,19 @@
+using System;
+using GameProject.Services;
+
+namespace GameProject.Models;
+
+/// <summary>
+/// Represents a player in the game.
+/// </summary>
+public record Player(string Name, int Level, int Health)
+{
+    /// <summary>
+    /// Gets or sets the player's score.
+    /// </summary>
+    public int Score { get; set; }
+
+    public bool IsAlive => Health > 0;
+
+    public string DisplayName => Name + " (Level " + Level + ")";
+}

--- a/samples/csharp-sample-project/Services/CombatService.cs
+++ b/samples/csharp-sample-project/Services/CombatService.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Threading.Tasks;
+using GameProject.Models;
+
+namespace GameProject.Services;
+
+/// <summary>
+/// Implementation of combat operations.
+/// </summary>
+public class CombatService : ICombatService
+{
+    private readonly Random _random;
+
+    public CombatService(Random random)
+    {
+        _random = random;
+    }
+
+    /// <summary>
+    /// Processes an attack between two players.
+    /// </summary>
+    public async Task<int> ProcessAttackAsync(Player attacker, Player defender)
+    {
+        var damage = CalculateDamage(attacker);
+        await Task.Delay(10);
+        return damage;
+    }
+
+    public int CalculateDamage(Player attacker)
+    {
+        return attacker.Level * _random.Next(1, 10);
+    }
+
+    public async Task HealAsync(Player target, int amount)
+    {
+        await Task.Delay(10);
+    }
+
+    private int CalculateCriticalHit(int baseDamage)
+    {
+        return baseDamage * 2;
+    }
+}

--- a/samples/csharp-sample-project/Services/ICombatService.cs
+++ b/samples/csharp-sample-project/Services/ICombatService.cs
@@ -1,0 +1,22 @@
+using System.Threading.Tasks;
+using GameProject.Models;
+
+namespace GameProject.Services;
+
+/// <summary>
+/// Provides combat-related operations.
+/// </summary>
+public interface ICombatService
+{
+    /// <summary>
+    /// Processes an attack between two players.
+    /// </summary>
+    Task<int> ProcessAttackAsync(Player attacker, Player defender);
+
+    /// <summary>
+    /// Calculates damage based on attacker stats.
+    /// </summary>
+    int CalculateDamage(Player attacker);
+
+    Task HealAsync(Player target, int amount);
+}

--- a/samples/csharp-sample-project/Services/InventoryService.cs
+++ b/samples/csharp-sample-project/Services/InventoryService.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using GameProject.Models;
+
+namespace GameProject.Services;
+
+/// <summary>
+/// Provides inventory management operations.
+/// </summary>
+public class InventoryService
+{
+    public bool TryAddItem(Inventory inventory, string item)
+    {
+        if (inventory.Count >= 100)
+        {
+            return false;
+        }
+
+        inventory.AddItem(item);
+        return true;
+    }
+
+    public List<string> GetSortedItems(Inventory inventory)
+    {
+        return inventory.Items.OrderBy(i => i, StringComparer.Ordinal).ToList();
+    }
+
+    public int GetItemCount(Inventory inventory) => inventory.Count;
+}
+
+/// <summary>
+/// Extension methods for inventory operations.
+/// </summary>
+public static class InventoryExtensions
+{
+    public static bool IsEmpty(this Inventory inventory) => inventory.Count == 0;
+
+    public static bool IsFull(this Inventory inventory) => inventory.Count >= 100;
+}

--- a/src/CodeCompress.Core/Parsers/CSharpParser.cs
+++ b/src/CodeCompress.Core/Parsers/CSharpParser.cs
@@ -1,0 +1,752 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using CodeCompress.Core.Models;
+
+namespace CodeCompress.Core.Parsers;
+
+public sealed partial class CSharpParser : ILanguageParser
+{
+    public string LanguageId => "csharp";
+
+    public IReadOnlyList<string> FileExtensions { get; } = [".cs"];
+
+    [GeneratedRegex(@"^\s*namespace\s+([\w.]+)\s*;")]
+    private static partial Regex FileScopedNamespacePattern();
+
+    [GeneratedRegex(@"^\s*namespace\s+([\w.]+)\s*$")]
+    private static partial Regex BlockScopedNamespacePattern();
+
+    [GeneratedRegex(@"^\s*((?:(?:public|internal|private|protected|static|abstract|sealed|partial|readonly|file|required|new)\s+)*)(?:(class|interface|struct)\s+|(record)\s+(?:(class|struct)\s+)?)([\w]+)\s*(<[^>]+>)?\s*(.*)$")]
+    private static partial Regex TypeDeclarationPattern();
+
+    [GeneratedRegex(@"^\s*((?:(?:public|internal|private|protected|static|abstract|sealed|partial|readonly|file|required|new)\s+)*)enum\s+(\w+)\s*(.*)$")]
+    private static partial Regex EnumDeclarationPattern();
+
+    [GeneratedRegex(@"^\s*///")]
+    private static partial Regex XmlDocCommentPattern();
+
+    public ParseResult Parse(string filePath, ReadOnlySpan<byte> content)
+    {
+        if (content.IsEmpty)
+        {
+            return new ParseResult([], []);
+        }
+
+        var text = Encoding.UTF8.GetString(content);
+        var lines = text.Split('\n');
+        var symbols = new List<SymbolInfo>();
+        var lineByteOffsets = ComputeLineByteOffsets(content);
+        var parentStack = new List<PendingType>();
+        var docCommentLines = new List<string>();
+        var inBlockComment = false;
+
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var line = lines[i].TrimEnd('\r');
+            var trimmed = line.Trim();
+            var lineNumber = i + 1;
+            var byteOffset = lineByteOffsets[i];
+
+            if (inBlockComment)
+            {
+                var endIdx = trimmed.IndexOf("*/", StringComparison.Ordinal);
+                if (endIdx >= 0)
+                {
+                    inBlockComment = false;
+                    var afterComment = trimmed[(endIdx + 2)..].Trim();
+                    if (!string.IsNullOrEmpty(afterComment))
+                    {
+                        UpdateBraceDepth(afterComment, lineNumber, byteOffset, parentStack, symbols);
+                    }
+                }
+
+                continue;
+            }
+
+            if (trimmed.StartsWith("/*", StringComparison.Ordinal))
+            {
+                if (!trimmed.Contains("*/", StringComparison.Ordinal))
+                {
+                    inBlockComment = true;
+                }
+
+                docCommentLines.Clear();
+                continue;
+            }
+
+            if (XmlDocCommentPattern().IsMatch(line))
+            {
+                docCommentLines.Add(trimmed);
+                continue;
+            }
+
+            if (trimmed.StartsWith("//", StringComparison.Ordinal))
+            {
+                docCommentLines.Clear();
+                continue;
+            }
+
+            if (string.IsNullOrWhiteSpace(trimmed))
+            {
+                UpdateBraceDepth(trimmed, lineNumber, byteOffset, parentStack, symbols);
+                continue;
+            }
+
+            var matched = TryMatchFileScopedNamespace(trimmed, lineNumber, byteOffset, docCommentLines, symbols)
+                          || TryMatchBlockScopedNamespace(trimmed, lineNumber, byteOffset, docCommentLines, parentStack)
+                          || TryMatchEnum(trimmed, lineNumber, byteOffset, docCommentLines, parentStack)
+                          || TryMatchTypeDeclaration(trimmed, lineNumber, byteOffset, docCommentLines, parentStack, symbols);
+
+            if (!matched && !XmlDocCommentPattern().IsMatch(trimmed))
+            {
+                docCommentLines.Clear();
+            }
+
+            if (matched)
+            {
+                docCommentLines.Clear();
+            }
+
+            UpdateBraceDepth(trimmed, lineNumber, byteOffset, parentStack, symbols);
+        }
+
+        return new ParseResult(symbols, []);
+    }
+
+    private static int[] ComputeLineByteOffsets(ReadOnlySpan<byte> content)
+    {
+        var offsets = new List<int> { 0 };
+        for (var i = 0; i < content.Length; i++)
+        {
+            if (content[i] == (byte)'\n')
+            {
+                offsets.Add(i + 1);
+            }
+        }
+
+        return [.. offsets];
+    }
+
+    private static bool TryMatchFileScopedNamespace(
+        string trimmed, int lineNumber, int byteOffset,
+        List<string> docCommentLines, List<SymbolInfo> symbols)
+    {
+        var match = FileScopedNamespacePattern().Match(trimmed);
+        if (!match.Success)
+        {
+            return false;
+        }
+
+        var docComment = BuildDocComment(docCommentLines);
+
+        symbols.Add(new SymbolInfo(
+            Name: match.Groups[1].Value,
+            Kind: SymbolKind.Module,
+            Signature: trimmed,
+            ParentSymbol: null,
+            ByteOffset: byteOffset,
+            ByteLength: Encoding.UTF8.GetByteCount(trimmed),
+            LineStart: lineNumber,
+            LineEnd: lineNumber,
+            Visibility: Visibility.Public,
+            DocComment: docComment));
+
+        return true;
+    }
+
+    private static bool TryMatchBlockScopedNamespace(
+        string trimmed, int lineNumber, int byteOffset,
+        List<string> docCommentLines, List<PendingType> parentStack)
+    {
+        var match = BlockScopedNamespacePattern().Match(trimmed);
+        if (!match.Success)
+        {
+            return false;
+        }
+
+        var docComment = BuildDocComment(docCommentLines);
+        var currentDepth = GetCurrentBraceDepth(parentStack);
+
+        parentStack.Add(new PendingType(
+            Name: match.Groups[1].Value,
+            Kind: SymbolKind.Module,
+            Signature: trimmed,
+            ParentName: null,
+            ByteOffset: byteOffset,
+            LineStart: lineNumber,
+            Visibility: Visibility.Public,
+            DocComment: docComment,
+            BraceDepthAtDeclaration: currentDepth,
+            IsNamespace: true));
+
+        return true;
+    }
+
+    private static bool TryMatchEnum(
+        string trimmed, int lineNumber, int byteOffset,
+        List<string> docCommentLines, List<PendingType> parentStack)
+    {
+        var match = EnumDeclarationPattern().Match(trimmed);
+        if (!match.Success)
+        {
+            return false;
+        }
+
+        var modifiers = match.Groups[1].Value.Trim();
+        var name = match.Groups[2].Value;
+        var rest = match.Groups[3].Value.Trim();
+
+        var signatureBuilder = new StringBuilder();
+        if (!string.IsNullOrEmpty(modifiers))
+        {
+            signatureBuilder.Append(modifiers).Append(' ');
+        }
+
+        signatureBuilder.Append("enum ").Append(name);
+
+        if (rest.Length > 0)
+        {
+            var baseAndBrace = rest.TrimEnd('{').Trim();
+            if (baseAndBrace.Length > 0)
+            {
+                signatureBuilder.Append(' ').Append(baseAndBrace);
+            }
+        }
+
+        var signature = signatureBuilder.ToString().TrimEnd();
+        var docComment = BuildDocComment(docCommentLines);
+        var parentName = GetCurrentParentName(parentStack);
+        var isNested = parentName is not null;
+        var visibility = DeriveVisibility(modifiers, isNested);
+        var currentDepth = GetCurrentBraceDepth(parentStack);
+
+        parentStack.Add(new PendingType(
+            Name: name,
+            Kind: SymbolKind.Type,
+            Signature: signature,
+            ParentName: parentName,
+            ByteOffset: byteOffset,
+            LineStart: lineNumber,
+            Visibility: visibility,
+            DocComment: docComment,
+            BraceDepthAtDeclaration: currentDepth,
+            IsNamespace: false));
+
+        return true;
+    }
+
+    private static bool TryMatchTypeDeclaration(
+        string trimmed, int lineNumber, int byteOffset,
+        List<string> docCommentLines, List<PendingType> parentStack,
+        List<SymbolInfo> symbols)
+    {
+        var match = TypeDeclarationPattern().Match(trimmed);
+        if (!match.Success)
+        {
+            return false;
+        }
+
+        var modifiers = match.Groups[1].Value.Trim();
+        var typeKeyword = match.Groups[2].Value;
+        var recordKeyword = match.Groups[3].Value;
+        var recordSubKeyword = match.Groups[4].Value;
+        var name = match.Groups[5].Value;
+        var genericParams = match.Groups[6].Value;
+        var rest = match.Groups[7].Value.Trim();
+
+        SymbolKind kind;
+        string keyword;
+        if (!string.IsNullOrEmpty(recordKeyword))
+        {
+            kind = SymbolKind.Class;
+            keyword = string.IsNullOrEmpty(recordSubKeyword)
+                ? "record"
+                : $"record {recordSubKeyword}";
+        }
+        else if (string.Equals(typeKeyword, "interface", StringComparison.Ordinal))
+        {
+            kind = SymbolKind.Interface;
+            keyword = "interface";
+        }
+        else
+        {
+            kind = SymbolKind.Class;
+            keyword = typeKeyword;
+        }
+
+        var signatureBuilder = new StringBuilder();
+        if (!string.IsNullOrEmpty(modifiers))
+        {
+            signatureBuilder.Append(modifiers).Append(' ');
+        }
+
+        signatureBuilder.Append(keyword).Append(' ').Append(name);
+
+        if (!string.IsNullOrEmpty(genericParams))
+        {
+            signatureBuilder.Append(genericParams);
+        }
+
+        if (!string.IsNullOrEmpty(rest))
+        {
+            var signatureRest = rest;
+            var semicolonIdx = FindSignatureEnd(signatureRest);
+            if (semicolonIdx >= 0)
+            {
+                signatureRest = signatureRest[..(semicolonIdx + 1)];
+            }
+            else
+            {
+                var braceIdx = FindOpenBraceInCode(signatureRest);
+                if (braceIdx >= 0)
+                {
+                    signatureRest = signatureRest[..braceIdx].Trim();
+                }
+            }
+
+            if (!string.IsNullOrEmpty(signatureRest))
+            {
+                // Don't add space before opening paren (record primary constructors)
+                if (signatureRest[0] == '(')
+                {
+                    signatureBuilder.Append(signatureRest);
+                }
+                else
+                {
+                    signatureBuilder.Append(' ').Append(signatureRest);
+                }
+            }
+        }
+
+        var signature = signatureBuilder.ToString().TrimEnd();
+        var docComment = BuildDocComment(docCommentLines);
+        var parentName = GetCurrentParentName(parentStack);
+        var isNested = parentName is not null;
+        var visibility = DeriveVisibility(modifiers, isNested);
+        var currentDepth = GetCurrentBraceDepth(parentStack);
+
+        var isSemicolonTerminated = trimmed.EndsWith(';');
+
+        if (isSemicolonTerminated)
+        {
+            symbols.Add(new SymbolInfo(
+                Name: name,
+                Kind: kind,
+                Signature: signature,
+                ParentSymbol: parentName,
+                ByteOffset: byteOffset,
+                ByteLength: Encoding.UTF8.GetByteCount(trimmed),
+                LineStart: lineNumber,
+                LineEnd: lineNumber,
+                Visibility: visibility,
+                DocComment: docComment));
+        }
+        else
+        {
+            parentStack.Add(new PendingType(
+                Name: name,
+                Kind: kind,
+                Signature: signature,
+                ParentName: parentName,
+                ByteOffset: byteOffset,
+                LineStart: lineNumber,
+                Visibility: visibility,
+                DocComment: docComment,
+                BraceDepthAtDeclaration: currentDepth,
+                IsNamespace: false));
+        }
+
+        return true;
+    }
+
+    private static void UpdateBraceDepth(
+        string line, int lineNumber, int byteOffset,
+        List<PendingType> parentStack, List<SymbolInfo> symbols)
+    {
+        var (opens, closes) = CountBracesDetailed(line);
+        if (opens == 0 && closes == 0)
+        {
+            return;
+        }
+
+        var effectiveDepth = GetCurrentBraceDepth(parentStack);
+
+        effectiveDepth += opens;
+
+        for (var c = 0; c < closes; c++)
+        {
+            effectiveDepth--;
+
+            for (var i = parentStack.Count - 1; i >= 0; i--)
+            {
+                if (parentStack[i].BraceDepthAtDeclaration == effectiveDepth)
+                {
+                    CompletePendingType(parentStack[i], lineNumber, byteOffset, line, symbols);
+                    parentStack.RemoveAt(i);
+                    break;
+                }
+            }
+        }
+
+        foreach (var pending in parentStack)
+        {
+            pending.CurrentBraceDepth = effectiveDepth;
+        }
+    }
+
+    private static (int Opens, int Closes) CountBracesDetailed(string line)
+    {
+        var opens = 0;
+        var closes = 0;
+        var state = CharScanState.Normal;
+        var pos = 0;
+
+        while (pos < line.Length)
+        {
+            var ch = line[pos];
+
+            switch (state)
+            {
+                case CharScanState.Normal:
+                    (state, pos) = ProcessNormalChar(line, pos, ch, ref opens, ref closes);
+                    break;
+
+                case CharScanState.InSingleLineComment:
+                    return (opens, closes);
+
+                case CharScanState.InBlockComment:
+                    if (ch == '*' && pos + 1 < line.Length && line[pos + 1] == '/')
+                    {
+                        state = CharScanState.Normal;
+                        pos += 2;
+                    }
+                    else
+                    {
+                        pos++;
+                    }
+
+                    break;
+
+                case CharScanState.InString:
+                    if (ch == '\\')
+                    {
+                        pos += 2;
+                    }
+                    else if (ch == '"')
+                    {
+                        state = CharScanState.Normal;
+                        pos++;
+                    }
+                    else
+                    {
+                        pos++;
+                    }
+
+                    break;
+
+                case CharScanState.InVerbatimString:
+                    if (ch == '"')
+                    {
+                        if (pos + 1 < line.Length && line[pos + 1] == '"')
+                        {
+                            pos += 2;
+                        }
+                        else
+                        {
+                            state = CharScanState.Normal;
+                            pos++;
+                        }
+                    }
+                    else
+                    {
+                        pos++;
+                    }
+
+                    break;
+
+                case CharScanState.InCharLiteral:
+                    if (ch == '\\')
+                    {
+                        pos += 2;
+                    }
+                    else if (ch == '\'')
+                    {
+                        state = CharScanState.Normal;
+                        pos++;
+                    }
+                    else
+                    {
+                        pos++;
+                    }
+
+                    break;
+
+                default:
+                    pos++;
+                    break;
+            }
+        }
+
+        return (opens, closes);
+    }
+
+    private static (CharScanState State, int NextPos) ProcessNormalChar(
+        string line, int pos, char ch, ref int opens, ref int closes)
+    {
+        if (ch == '/' && pos + 1 < line.Length)
+        {
+            if (line[pos + 1] == '/')
+            {
+                return (CharScanState.InSingleLineComment, pos + 2);
+            }
+
+            if (line[pos + 1] == '*')
+            {
+                return (CharScanState.InBlockComment, pos + 2);
+            }
+        }
+
+        if (ch == '@' && pos + 1 < line.Length && line[pos + 1] == '"')
+        {
+            return (CharScanState.InVerbatimString, pos + 2);
+        }
+
+        if (ch == '"')
+        {
+            return (CharScanState.InString, pos + 1);
+        }
+
+        if (ch == '\'')
+        {
+            return (CharScanState.InCharLiteral, pos + 1);
+        }
+
+        if (ch == '{')
+        {
+            opens++;
+        }
+        else if (ch == '}')
+        {
+            closes++;
+        }
+
+        return (CharScanState.Normal, pos + 1);
+    }
+
+    private static int FindOpenBraceInCode(string text)
+    {
+        var state = CharScanState.Normal;
+        var pos = 0;
+
+        while (pos < text.Length)
+        {
+            var ch = text[pos];
+
+            switch (state)
+            {
+                case CharScanState.InString:
+                    if (ch == '\\')
+                    {
+                        pos += 2;
+                    }
+                    else if (ch == '"')
+                    {
+                        state = CharScanState.Normal;
+                        pos++;
+                    }
+                    else
+                    {
+                        pos++;
+                    }
+
+                    break;
+
+                case CharScanState.InCharLiteral:
+                    if (ch == '\\')
+                    {
+                        pos += 2;
+                    }
+                    else if (ch == '\'')
+                    {
+                        state = CharScanState.Normal;
+                        pos++;
+                    }
+                    else
+                    {
+                        pos++;
+                    }
+
+                    break;
+
+                default:
+                    if (ch == '"')
+                    {
+                        state = CharScanState.InString;
+                        pos++;
+                    }
+                    else if (ch == '\'')
+                    {
+                        state = CharScanState.InCharLiteral;
+                        pos++;
+                    }
+                    else if (ch == '{')
+                    {
+                        return pos;
+                    }
+                    else
+                    {
+                        pos++;
+                    }
+
+                    break;
+            }
+        }
+
+        return -1;
+    }
+
+    private static int FindSignatureEnd(string text)
+    {
+        var parenDepth = 0;
+        for (var i = 0; i < text.Length; i++)
+        {
+            var ch = text[i];
+            if (ch == '(')
+            {
+                parenDepth++;
+            }
+            else if (ch == ')')
+            {
+                parenDepth--;
+            }
+            else if (ch == ';' && parenDepth == 0)
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    private static void CompletePendingType(
+        PendingType pending, int endLineNumber, int endByteOffset,
+        string endLine, List<SymbolInfo> symbols)
+    {
+        var byteLength = endByteOffset + Encoding.UTF8.GetByteCount(endLine) - pending.ByteOffset;
+
+        symbols.Add(new SymbolInfo(
+            Name: pending.Name,
+            Kind: pending.Kind,
+            Signature: pending.Signature,
+            ParentSymbol: pending.ParentName,
+            ByteOffset: pending.ByteOffset,
+            ByteLength: byteLength,
+            LineStart: pending.LineStart,
+            LineEnd: endLineNumber,
+            Visibility: pending.Visibility,
+            DocComment: pending.DocComment));
+    }
+
+    private static Visibility DeriveVisibility(string modifiers, bool isNested)
+    {
+        if (string.IsNullOrEmpty(modifiers))
+        {
+            return isNested ? Visibility.Private : Visibility.Public;
+        }
+
+        if (modifiers.Contains("private protected", StringComparison.Ordinal))
+        {
+            return Visibility.Private;
+        }
+
+        if (modifiers.Contains("protected internal", StringComparison.Ordinal))
+        {
+            return Visibility.Public;
+        }
+
+        if (modifiers.Contains("private", StringComparison.Ordinal))
+        {
+            return Visibility.Private;
+        }
+
+        if (modifiers.Contains("protected", StringComparison.Ordinal))
+        {
+            return Visibility.Private;
+        }
+
+        if (modifiers.Contains("file", StringComparison.Ordinal))
+        {
+            return Visibility.Private;
+        }
+
+        return Visibility.Public;
+    }
+
+    private static string? BuildDocComment(List<string> docCommentLines)
+    {
+        if (docCommentLines.Count == 0)
+        {
+            return null;
+        }
+
+        return string.Join("\n", docCommentLines);
+    }
+
+    private static string? GetCurrentParentName(List<PendingType> parentStack)
+    {
+        for (var i = parentStack.Count - 1; i >= 0; i--)
+        {
+            if (!parentStack[i].IsNamespace)
+            {
+                return parentStack[i].Name;
+            }
+        }
+
+        return null;
+    }
+
+    private static int GetCurrentBraceDepth(List<PendingType> parentStack)
+    {
+        if (parentStack.Count == 0)
+        {
+            return 0;
+        }
+
+        return parentStack[^1].CurrentBraceDepth;
+    }
+
+    private enum CharScanState
+    {
+        Normal,
+        InSingleLineComment,
+        InBlockComment,
+        InString,
+        InVerbatimString,
+        InCharLiteral
+    }
+
+    private sealed class PendingType(
+        string Name,
+        SymbolKind Kind,
+        string Signature,
+        string? ParentName,
+        int ByteOffset,
+        int LineStart,
+        Visibility Visibility,
+        string? DocComment,
+        int BraceDepthAtDeclaration,
+        bool IsNamespace)
+    {
+        public string Name { get; } = Name;
+        public SymbolKind Kind { get; } = Kind;
+        public string Signature { get; } = Signature;
+        public string? ParentName { get; } = ParentName;
+        public int ByteOffset { get; } = ByteOffset;
+        public int LineStart { get; } = LineStart;
+        public Visibility Visibility { get; } = Visibility;
+        public string? DocComment { get; } = DocComment;
+        public int BraceDepthAtDeclaration { get; } = BraceDepthAtDeclaration;
+        public bool IsNamespace { get; } = IsNamespace;
+        public int CurrentBraceDepth { get; set; } = BraceDepthAtDeclaration;
+    }
+}

--- a/src/CodeCompress.Core/Parsers/CSharpParser.cs
+++ b/src/CodeCompress.Core/Parsers/CSharpParser.cs
@@ -6,6 +6,13 @@ namespace CodeCompress.Core.Parsers;
 
 public sealed partial class CSharpParser : ILanguageParser
 {
+    private static readonly string[] KnownModifiers =
+    [
+        "public", "internal", "private", "protected", "static", "abstract",
+        "sealed", "partial", "readonly", "file", "required", "new",
+        "virtual", "override", "async", "extern", "unsafe", "volatile"
+    ];
+
     public string LanguageId => "csharp";
 
     public IReadOnlyList<string> FileExtensions { get; } = [".cs"];
@@ -25,6 +32,9 @@ public sealed partial class CSharpParser : ILanguageParser
     [GeneratedRegex(@"^\s*///")]
     private static partial Regex XmlDocCommentPattern();
 
+    [GeneratedRegex(@"^\s*(global\s+)?using\s+(static\s+)?(?:(\w[\w.]*)\s*=\s*)?(.+?)\s*;\s*$")]
+    private static partial Regex UsingStatementPattern();
+
     public ParseResult Parse(string filePath, ReadOnlySpan<byte> content)
     {
         if (content.IsEmpty)
@@ -35,6 +45,7 @@ public sealed partial class CSharpParser : ILanguageParser
         var text = Encoding.UTF8.GetString(content);
         var lines = text.Split('\n');
         var symbols = new List<SymbolInfo>();
+        var dependencies = new List<DependencyInfo>();
         var lineByteOffsets = ComputeLineByteOffsets(content);
         var parentStack = new List<PendingType>();
         var docCommentLines = new List<string>();
@@ -92,10 +103,20 @@ public sealed partial class CSharpParser : ILanguageParser
                 continue;
             }
 
-            var matched = TryMatchFileScopedNamespace(trimmed, lineNumber, byteOffset, docCommentLines, symbols)
+            // Skip attribute lines — preserve doc comments
+            if (IsAttributeLine(trimmed))
+            {
+                UpdateBraceDepth(trimmed, lineNumber, byteOffset, parentStack, symbols);
+                continue;
+            }
+
+            var matched = TryMatchUsingStatement(trimmed, parentStack, dependencies)
+                          || TryMatchFileScopedNamespace(trimmed, lineNumber, byteOffset, docCommentLines, symbols)
                           || TryMatchBlockScopedNamespace(trimmed, lineNumber, byteOffset, docCommentLines, parentStack)
                           || TryMatchEnum(trimmed, lineNumber, byteOffset, docCommentLines, parentStack)
-                          || TryMatchTypeDeclaration(trimmed, lineNumber, byteOffset, docCommentLines, parentStack, symbols);
+                          || TryMatchTypeDeclaration(trimmed, lineNumber, byteOffset, docCommentLines, parentStack, symbols)
+                          || TryMatchProperty(trimmed, lineNumber, byteOffset, docCommentLines, parentStack, symbols)
+                          || TryMatchMethod(trimmed, lineNumber, byteOffset, docCommentLines, parentStack, symbols);
 
             if (!matched && !XmlDocCommentPattern().IsMatch(trimmed))
             {
@@ -110,7 +131,618 @@ public sealed partial class CSharpParser : ILanguageParser
             UpdateBraceDepth(trimmed, lineNumber, byteOffset, parentStack, symbols);
         }
 
-        return new ParseResult(symbols, []);
+        return new ParseResult(symbols, dependencies);
+    }
+
+    private static bool IsAttributeLine(string trimmed)
+    {
+        return trimmed.StartsWith('[') && !trimmed.StartsWith("[]", StringComparison.Ordinal);
+    }
+
+    private static bool TryMatchUsingStatement(
+        string trimmed, List<PendingType> parentStack, List<DependencyInfo> dependencies)
+    {
+        // Only match at file level (not inside type bodies)
+        if (IsInsideTypeBody(parentStack))
+        {
+            return false;
+        }
+
+        var match = UsingStatementPattern().Match(trimmed);
+        if (!match.Success)
+        {
+            return false;
+        }
+
+        var path = match.Groups[4].Value.Trim();
+
+        // Skip `using var` (local variable declaration in top-level statements)
+        if (path.StartsWith("var ", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        // Skip `using (` (using statement with disposable)
+        if (path.StartsWith('('))
+        {
+            return false;
+        }
+
+        var alias = match.Groups[3].Success && match.Groups[3].Value.Length > 0
+            ? match.Groups[3].Value
+            : null;
+
+        dependencies.Add(new DependencyInfo(RequirePath: path, Alias: alias));
+
+        return true;
+    }
+
+    private static bool TryMatchProperty(
+        string trimmed, int lineNumber, int byteOffset,
+        List<string> docCommentLines, List<PendingType> parentStack, List<SymbolInfo> symbols)
+    {
+        if (!IsInsideTypeBody(parentStack))
+        {
+            return false;
+        }
+
+        // Check for accessor property: has `{ get`/`{ set`/`{ init` without `)` before `{`
+        var bracePos = FindOpenBraceInCode(trimmed);
+        if (bracePos >= 0)
+        {
+            var afterBrace = trimmed[(bracePos + 1)..].TrimStart();
+            var isAccessorProperty = afterBrace.StartsWith("get", StringComparison.Ordinal)
+                                     || afterBrace.StartsWith("set", StringComparison.Ordinal)
+                                     || afterBrace.StartsWith("init", StringComparison.Ordinal);
+
+            if (isAccessorProperty)
+            {
+                var beforeBrace = trimmed[..bracePos].TrimEnd();
+                // If `)` appears right before `{` (with spaces), it's a method body
+                if (beforeBrace.EndsWith(')'))
+                {
+                    return false;
+                }
+
+                return ExtractProperty(trimmed, trimmed, lineNumber, byteOffset, docCommentLines, parentStack, symbols);
+            }
+        }
+
+        // Check for expression-bodied property: has `=>` without `)` before `=>`
+        var arrowPos = trimmed.IndexOf("=>", StringComparison.Ordinal);
+        if (arrowPos > 0)
+        {
+            var beforeArrow = trimmed[..arrowPos].TrimEnd();
+            // If `)` or `]` right before `=>`, it's a method or indexer body
+            if (beforeArrow.EndsWith(')') || beforeArrow.EndsWith(']'))
+            {
+                return false;
+            }
+
+            return ExtractProperty(trimmed, trimmed, lineNumber, byteOffset, docCommentLines, parentStack, symbols);
+        }
+
+        return false;
+    }
+
+    private static bool ExtractProperty(
+        string trimmed, string signatureText, int lineNumber, int byteOffset,
+        List<string> docCommentLines, List<PendingType> parentStack, List<SymbolInfo> symbols)
+    {
+        // Parse: [modifiers] Type Name { ... } or [modifiers] Type Name => ...
+        // Find the property name: last word before `{` or `=>`
+        var signatureEnd = trimmed.IndexOf('{', StringComparison.Ordinal);
+        if (signatureEnd < 0)
+        {
+            signatureEnd = trimmed.IndexOf("=>", StringComparison.Ordinal);
+        }
+
+        if (signatureEnd < 0)
+        {
+            return false;
+        }
+
+        var prefix = trimmed[..signatureEnd].TrimEnd();
+        var parts = prefix.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length < 2)
+        {
+            return false;
+        }
+
+        var name = parts[^1];
+
+        // Extract modifiers
+        var modifiers = ExtractModifiers(parts);
+
+        var docComment = BuildDocComment(docCommentLines);
+        var parentName = GetCurrentParentName(parentStack);
+        var visibility = DeriveVisibility(modifiers, isNested: true);
+
+        symbols.Add(new SymbolInfo(
+            Name: name,
+            Kind: SymbolKind.Constant,
+            Signature: signatureText,
+            ParentSymbol: parentName,
+            ByteOffset: byteOffset,
+            ByteLength: Encoding.UTF8.GetByteCount(trimmed),
+            LineStart: lineNumber,
+            LineEnd: lineNumber,
+            Visibility: visibility,
+            DocComment: docComment));
+
+        return true;
+    }
+
+    private static bool TryMatchMethod(
+        string trimmed, int lineNumber, int byteOffset,
+        List<string> docCommentLines, List<PendingType> parentStack, List<SymbolInfo> symbols)
+    {
+        if (!IsInsideTypeBody(parentStack))
+        {
+            return false;
+        }
+
+        // Try indexer: `this[`
+        if (TryMatchIndexer(trimmed, lineNumber, byteOffset, docCommentLines, parentStack))
+        {
+            return true;
+        }
+
+        // Try finalizer: `~Name(`
+        if (TryMatchFinalizer(trimmed, lineNumber, byteOffset, docCommentLines, parentStack))
+        {
+            return true;
+        }
+
+        // Find first `(` at angle-bracket depth 0
+        var parenPos = FindMethodParenOpen(trimmed);
+        if (parenPos < 0)
+        {
+            return false;
+        }
+
+        // Find matching `)`
+        var closeParenPos = FindMatchingCloseParen(trimmed, parenPos);
+        if (closeParenPos < 0)
+        {
+            return false;
+        }
+
+        var prefix = trimmed[..parenPos].TrimEnd();
+        var paramsText = trimmed[parenPos..(closeParenPos + 1)];
+        var afterParams = trimmed[(closeParenPos + 1)..].TrimStart();
+
+        // Build signature: prefix + params + optional where constraints
+        var signatureBuilder = new StringBuilder();
+        signatureBuilder.Append(prefix).Append(paramsText);
+
+        if (afterParams.StartsWith("where ", StringComparison.Ordinal))
+        {
+            var constraintEnd = afterParams.IndexOfAny(['{', '=']);
+            var constraint = constraintEnd >= 0
+                ? afterParams[..constraintEnd].TrimEnd()
+                : afterParams.TrimEnd(';', ' ');
+            signatureBuilder.Append(' ').Append(constraint);
+        }
+
+        var signature = signatureBuilder.ToString().TrimEnd();
+
+        // Extract name and modifiers from prefix
+        var (name, modifiers) = ExtractMethodNameAndModifiers(prefix);
+
+        if (string.IsNullOrEmpty(name))
+        {
+            return false;
+        }
+
+        var docComment = BuildDocComment(docCommentLines);
+        var parentName = GetCurrentParentName(parentStack);
+        var visibility = DeriveVisibility(modifiers, isNested: true);
+
+        // Determine if single-line (expression-bodied or semicolon)
+        var isSingleLine = trimmed.EndsWith(';')
+                           || (afterParams.Contains("=>", StringComparison.Ordinal) && trimmed.EndsWith(';'));
+
+        if (isSingleLine)
+        {
+            symbols.Add(new SymbolInfo(
+                Name: name,
+                Kind: SymbolKind.Method,
+                Signature: signature,
+                ParentSymbol: parentName,
+                ByteOffset: byteOffset,
+                ByteLength: Encoding.UTF8.GetByteCount(trimmed),
+                LineStart: lineNumber,
+                LineEnd: lineNumber,
+                Visibility: visibility,
+                DocComment: docComment));
+        }
+        else
+        {
+            var currentDepth = GetCurrentBraceDepth(parentStack);
+            parentStack.Add(new PendingType(
+                Name: name,
+                Kind: SymbolKind.Method,
+                Signature: signature,
+                ParentName: parentName,
+                ByteOffset: byteOffset,
+                LineStart: lineNumber,
+                Visibility: visibility,
+                DocComment: docComment,
+                BraceDepthAtDeclaration: currentDepth,
+                IsNamespace: false,
+                IsContainer: false));
+        }
+
+        return true;
+    }
+
+    private static bool TryMatchIndexer(
+        string trimmed, int lineNumber, int byteOffset,
+        List<string> docCommentLines, List<PendingType> parentStack)
+    {
+        var thisIdx = trimmed.IndexOf("this[", StringComparison.Ordinal);
+        if (thisIdx < 0)
+        {
+            return false;
+        }
+
+        // Ensure `this[` is a member declaration, not inside code
+        var beforeThis = trimmed[..thisIdx].TrimEnd();
+        var parts = beforeThis.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length == 0)
+        {
+            return false;
+        }
+
+        // Build signature up to `]`
+        var closeBracket = trimmed.IndexOf(']', thisIdx);
+        if (closeBracket < 0)
+        {
+            return false;
+        }
+
+        var signature = trimmed[..(closeBracket + 1)];
+        var modifiers = ExtractModifiers(parts);
+
+        var docComment = BuildDocComment(docCommentLines);
+        var parentName = GetCurrentParentName(parentStack);
+        var visibility = DeriveVisibility(modifiers, isNested: true);
+
+        var currentDepth = GetCurrentBraceDepth(parentStack);
+        parentStack.Add(new PendingType(
+            Name: "this[]",
+            Kind: SymbolKind.Method,
+            Signature: signature,
+            ParentName: parentName,
+            ByteOffset: byteOffset,
+            LineStart: lineNumber,
+            Visibility: visibility,
+            DocComment: docComment,
+            BraceDepthAtDeclaration: currentDepth,
+            IsNamespace: false,
+            IsContainer: false));
+
+        return true;
+    }
+
+    private static bool TryMatchFinalizer(
+        string trimmed, int lineNumber, int byteOffset,
+        List<string> docCommentLines, List<PendingType> parentStack)
+    {
+        if (!trimmed.StartsWith('~'))
+        {
+            return false;
+        }
+
+        var parenPos = trimmed.IndexOf('(', StringComparison.Ordinal);
+        if (parenPos < 0)
+        {
+            return false;
+        }
+
+        var name = trimmed[..parenPos].Trim();
+        var closeParenPos = trimmed.IndexOf(')', parenPos);
+        if (closeParenPos < 0)
+        {
+            return false;
+        }
+
+        var signature = trimmed[..(closeParenPos + 1)];
+
+        var docComment = BuildDocComment(docCommentLines);
+        var parentName = GetCurrentParentName(parentStack);
+
+        var currentDepth = GetCurrentBraceDepth(parentStack);
+        parentStack.Add(new PendingType(
+            Name: name,
+            Kind: SymbolKind.Method,
+            Signature: signature,
+            ParentName: parentName,
+            ByteOffset: byteOffset,
+            LineStart: lineNumber,
+            Visibility: Visibility.Private,
+            DocComment: docComment,
+            BraceDepthAtDeclaration: currentDepth,
+            IsNamespace: false,
+            IsContainer: false));
+
+        return true;
+    }
+
+    private static (string Name, string Modifiers) ExtractMethodNameAndModifiers(
+        string prefix)
+    {
+        var parts = prefix.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length == 0)
+        {
+            return (string.Empty, string.Empty);
+        }
+
+        var modifiers = ExtractModifiers(parts);
+
+        // Find the non-modifier tokens
+        var nonModifierStart = 0;
+        foreach (var part in parts)
+        {
+            if (IsModifier(part))
+            {
+                nonModifierStart++;
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        var remaining = parts[nonModifierStart..];
+
+        if (remaining.Length == 0)
+        {
+            return (string.Empty, modifiers);
+        }
+
+        // Check for operator: `ReturnType operator +`
+        var operatorIdx = Array.IndexOf(remaining, "operator");
+        if (operatorIdx >= 0 && operatorIdx + 1 < remaining.Length)
+        {
+            var operatorSymbol = remaining[operatorIdx + 1];
+            return ($"operator {operatorSymbol}", modifiers);
+        }
+
+        // Last token is the name (may have generic params)
+        var lastToken = remaining[^1];
+
+        // Strip generic params from name for display
+        var genericIdx = lastToken.IndexOf('<', StringComparison.Ordinal);
+        var name = genericIdx >= 0 ? lastToken[..genericIdx] : lastToken;
+
+        // If name contains '.', it's explicit interface implementation
+        // Name stays as-is (e.g., "IDisposable.Dispose")
+
+        return (name, modifiers);
+    }
+
+    private static string ExtractModifiers(string[] parts)
+    {
+        var modifierList = new List<string>();
+        foreach (var part in parts)
+        {
+            if (IsModifier(part))
+            {
+                modifierList.Add(part);
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        return string.Join(" ", modifierList);
+    }
+
+    private static bool IsModifier(string word)
+    {
+        return Array.Exists(KnownModifiers, m => string.Equals(m, word, StringComparison.Ordinal));
+    }
+
+    private static int FindMethodParenOpen(string line)
+    {
+        // Find the `(` that represents the method parameter list, not tuple type parens.
+        // Strategy: find `(` that follows a word char, `>` (generic), or `]` (indexer)
+        // and is at angle-bracket depth 0 and paren depth 0.
+        var angleBracketDepth = 0;
+        var parenDepth = 0;
+        var pos = 0;
+        var state = CharScanState.Normal;
+
+        while (pos < line.Length)
+        {
+            var ch = line[pos];
+
+            if (state != CharScanState.Normal)
+            {
+                pos = AdvanceNonNormalState(line, pos, ch, ref state);
+                continue;
+            }
+
+            switch (ch)
+            {
+                case '/' when pos + 1 < line.Length && line[pos + 1] == '/':
+                    return -1;
+                case '"':
+                    state = CharScanState.InString;
+                    pos++;
+                    break;
+                case '@' when pos + 1 < line.Length && line[pos + 1] == '"':
+                    state = CharScanState.InVerbatimString;
+                    pos += 2;
+                    break;
+                case '\'':
+                    state = CharScanState.InCharLiteral;
+                    pos++;
+                    break;
+                case '<':
+                    angleBracketDepth++;
+                    pos++;
+                    break;
+                case '>':
+                    if (angleBracketDepth > 0)
+                    {
+                        angleBracketDepth--;
+                    }
+
+                    pos++;
+                    break;
+                case '(' when angleBracketDepth == 0 && parenDepth == 0:
+                    // Check if this is a method parameter `(` vs a tuple type `(`
+                    // Method params follow: word char, `>`, `~`, or operator symbol
+                    // Tuple type `(` follows a space after a modifier keyword
+                    if (pos > 0 && IsMethodParenPreceder(line[pos - 1]))
+                    {
+                        return pos;
+                    }
+
+                    // Check if preceded by operator symbol (with possible space)
+                    var beforeParen = line[..pos].TrimEnd();
+                    if (beforeParen.Length > 0 && IsOperatorChar(beforeParen[^1]))
+                    {
+                        return pos;
+                    }
+
+                    // This is likely a tuple type paren — skip the balanced group
+                    parenDepth++;
+                    pos++;
+                    break;
+                case '(' when parenDepth > 0:
+                    parenDepth++;
+                    pos++;
+                    break;
+                case ')' when parenDepth > 0:
+                    parenDepth--;
+                    pos++;
+                    break;
+                default:
+                    pos++;
+                    break;
+            }
+        }
+
+        return -1;
+    }
+
+    private static bool IsMethodParenPreceder(char ch)
+    {
+        return char.IsLetterOrDigit(ch) || ch == '>' || ch == '~' || ch == ']';
+    }
+
+    private static bool IsOperatorChar(char ch)
+    {
+        return ch is '+' or '-' or '*' or '/' or '%' or '&' or '|' or '^'
+            or '!' or '<' or '>' or '=' or '~';
+    }
+
+    private static int AdvanceNonNormalState(string line, int pos, char ch, ref CharScanState state)
+    {
+        switch (state)
+        {
+            case CharScanState.InString:
+                if (ch == '\\')
+                {
+                    return pos + 2;
+                }
+
+                if (ch == '"')
+                {
+                    state = CharScanState.Normal;
+                }
+
+                return pos + 1;
+
+            case CharScanState.InVerbatimString:
+                if (ch == '"')
+                {
+                    if (pos + 1 < line.Length && line[pos + 1] == '"')
+                    {
+                        return pos + 2;
+                    }
+
+                    state = CharScanState.Normal;
+                }
+
+                return pos + 1;
+
+            case CharScanState.InCharLiteral:
+                if (ch == '\\')
+                {
+                    return pos + 2;
+                }
+
+                if (ch == '\'')
+                {
+                    state = CharScanState.Normal;
+                }
+
+                return pos + 1;
+
+            default:
+                return pos + 1;
+        }
+    }
+
+    private static int FindMatchingCloseParen(string text, int openPos)
+    {
+        var depth = 0;
+        for (var i = openPos; i < text.Length; i++)
+        {
+            var ch = text[i];
+            if (ch == '(')
+            {
+                depth++;
+            }
+            else if (ch == ')')
+            {
+                depth--;
+                if (depth == 0)
+                {
+                    return i;
+                }
+            }
+        }
+
+        return -1;
+    }
+
+    private static bool IsInsideTypeBody(List<PendingType> parentStack)
+    {
+        // Check if we're directly inside a type body (not nested inside a method body)
+        // The current depth should be exactly one more than the type's declaration depth
+        var currentDepth = GetCurrentBraceDepth(parentStack);
+
+        for (var i = parentStack.Count - 1; i >= 0; i--)
+        {
+            var entry = parentStack[i];
+
+            // If we encounter a non-container (method/property), we're inside its body
+            if (!entry.IsContainer && !entry.IsNamespace)
+            {
+                return false;
+            }
+
+            if (entry.IsContainer)
+            {
+                // Don't match methods/properties inside enums
+                if (entry.Kind == SymbolKind.Type)
+                {
+                    return false;
+                }
+
+                // We're directly inside this type if depth is exactly type's depth + 1
+                return currentDepth == entry.BraceDepthAtDeclaration + 1;
+            }
+        }
+
+        return false;
     }
 
     private static int[] ComputeLineByteOffsets(ReadOnlySpan<byte> content)
@@ -177,7 +809,8 @@ public sealed partial class CSharpParser : ILanguageParser
             Visibility: Visibility.Public,
             DocComment: docComment,
             BraceDepthAtDeclaration: currentDepth,
-            IsNamespace: true));
+            IsNamespace: true,
+            IsContainer: false));
 
         return true;
     }
@@ -230,7 +863,8 @@ public sealed partial class CSharpParser : ILanguageParser
             Visibility: visibility,
             DocComment: docComment,
             BraceDepthAtDeclaration: currentDepth,
-            IsNamespace: false));
+            IsNamespace: false,
+            IsContainer: true));
 
         return true;
     }
@@ -306,7 +940,6 @@ public sealed partial class CSharpParser : ILanguageParser
 
             if (!string.IsNullOrEmpty(signatureRest))
             {
-                // Don't add space before opening paren (record primary constructors)
                 if (signatureRest[0] == '(')
                 {
                     signatureBuilder.Append(signatureRest);
@@ -353,7 +986,8 @@ public sealed partial class CSharpParser : ILanguageParser
                 Visibility: visibility,
                 DocComment: docComment,
                 BraceDepthAtDeclaration: currentDepth,
-                IsNamespace: false));
+                IsNamespace: false,
+                IsContainer: true));
         }
 
         return true;
@@ -428,57 +1062,9 @@ public sealed partial class CSharpParser : ILanguageParser
                     break;
 
                 case CharScanState.InString:
-                    if (ch == '\\')
-                    {
-                        pos += 2;
-                    }
-                    else if (ch == '"')
-                    {
-                        state = CharScanState.Normal;
-                        pos++;
-                    }
-                    else
-                    {
-                        pos++;
-                    }
-
-                    break;
-
                 case CharScanState.InVerbatimString:
-                    if (ch == '"')
-                    {
-                        if (pos + 1 < line.Length && line[pos + 1] == '"')
-                        {
-                            pos += 2;
-                        }
-                        else
-                        {
-                            state = CharScanState.Normal;
-                            pos++;
-                        }
-                    }
-                    else
-                    {
-                        pos++;
-                    }
-
-                    break;
-
                 case CharScanState.InCharLiteral:
-                    if (ch == '\\')
-                    {
-                        pos += 2;
-                    }
-                    else if (ch == '\'')
-                    {
-                        state = CharScanState.Normal;
-                        pos++;
-                    }
-                    else
-                    {
-                        pos++;
-                    }
-
+                    pos = AdvanceNonNormalState(line, pos, ch, ref state);
                     break;
 
                 default:
@@ -545,37 +1131,8 @@ public sealed partial class CSharpParser : ILanguageParser
             switch (state)
             {
                 case CharScanState.InString:
-                    if (ch == '\\')
-                    {
-                        pos += 2;
-                    }
-                    else if (ch == '"')
-                    {
-                        state = CharScanState.Normal;
-                        pos++;
-                    }
-                    else
-                    {
-                        pos++;
-                    }
-
-                    break;
-
                 case CharScanState.InCharLiteral:
-                    if (ch == '\\')
-                    {
-                        pos += 2;
-                    }
-                    else if (ch == '\'')
-                    {
-                        state = CharScanState.Normal;
-                        pos++;
-                    }
-                    else
-                    {
-                        pos++;
-                    }
-
+                    pos = AdvanceNonNormalState(text, pos, ch, ref state);
                     break;
 
                 default:
@@ -696,7 +1253,7 @@ public sealed partial class CSharpParser : ILanguageParser
     {
         for (var i = parentStack.Count - 1; i >= 0; i--)
         {
-            if (!parentStack[i].IsNamespace)
+            if (parentStack[i].IsContainer)
             {
                 return parentStack[i].Name;
             }
@@ -735,7 +1292,8 @@ public sealed partial class CSharpParser : ILanguageParser
         Visibility Visibility,
         string? DocComment,
         int BraceDepthAtDeclaration,
-        bool IsNamespace)
+        bool IsNamespace,
+        bool IsContainer)
     {
         public string Name { get; } = Name;
         public SymbolKind Kind { get; } = Kind;
@@ -747,6 +1305,7 @@ public sealed partial class CSharpParser : ILanguageParser
         public string? DocComment { get; } = DocComment;
         public int BraceDepthAtDeclaration { get; } = BraceDepthAtDeclaration;
         public bool IsNamespace { get; } = IsNamespace;
+        public bool IsContainer { get; } = IsContainer;
         public int CurrentBraceDepth { get; set; } = BraceDepthAtDeclaration;
     }
 }

--- a/src/CodeCompress.Core/ServiceCollectionExtensions.cs
+++ b/src/CodeCompress.Core/ServiceCollectionExtensions.cs
@@ -16,6 +16,7 @@ public static class ServiceCollectionExtensions
 
         // Parsers
         services.AddSingleton<ILanguageParser, LuauParser>();
+        services.AddSingleton<ILanguageParser, CSharpParser>();
 
         // Indexing
         services.AddSingleton<IFileHasher, FileHasher>();

--- a/tests/CodeCompress.Core.Tests/Parsers/CSharpParserTests.cs
+++ b/tests/CodeCompress.Core.Tests/Parsers/CSharpParserTests.cs
@@ -1,0 +1,683 @@
+using System.Text;
+using CodeCompress.Core.Models;
+using CodeCompress.Core.Parsers;
+
+namespace CodeCompress.Core.Tests.Parsers;
+
+internal sealed class CSharpParserTests
+{
+    private readonly CSharpParser _parser = new();
+
+    private ParseResult Parse(string source)
+    {
+        var bytes = Encoding.UTF8.GetBytes(source);
+        return _parser.Parse("test.cs", bytes);
+    }
+
+    // ── Interface contract ──────────────────────────────────────
+
+    [Test]
+    public async Task LanguageIdIsCSharp()
+    {
+        await Assert.That(_parser.LanguageId).IsEqualTo("csharp");
+    }
+
+    [Test]
+    public async Task FileExtensionsContainsCs()
+    {
+        await Assert.That(_parser.FileExtensions).Contains(".cs");
+    }
+
+    // ── Empty / comments-only ───────────────────────────────────
+
+    [Test]
+    public async Task EmptyFileReturnsEmptyResult()
+    {
+        var result = Parse("");
+
+        await Assert.That(result.Symbols).Count().IsEqualTo(0);
+        await Assert.That(result.Dependencies).Count().IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task CommentOnlyFileReturnsEmptyResult()
+    {
+        var source = """
+            // this is a comment
+            /* block comment */
+            /// xml comment
+            """;
+
+        var result = Parse(source);
+
+        await Assert.That(result.Symbols).Count().IsEqualTo(0);
+    }
+
+    // ── Namespace ────────────────────────────────────────────────
+
+    [Test]
+    public async Task FileScopedNamespaceExtracted()
+    {
+        var source = """
+            namespace Foo.Bar;
+
+            public class Baz { }
+            """;
+
+        var result = Parse(source);
+
+        var ns = result.Symbols.First(s => s.Kind == SymbolKind.Module);
+        await Assert.That(ns.Name).IsEqualTo("Foo.Bar");
+        await Assert.That(ns.Kind).IsEqualTo(SymbolKind.Module);
+        await Assert.That(ns.Signature).IsEqualTo("namespace Foo.Bar;");
+    }
+
+    [Test]
+    public async Task BlockScopedNamespaceExtracted()
+    {
+        var source = """
+            namespace Foo.Bar
+            {
+                public class Baz { }
+            }
+            """;
+
+        var result = Parse(source);
+
+        var ns = result.Symbols.First(s => s.Kind == SymbolKind.Module);
+        await Assert.That(ns.Name).IsEqualTo("Foo.Bar");
+        await Assert.That(ns.Kind).IsEqualTo(SymbolKind.Module);
+        await Assert.That(ns.LineStart).IsEqualTo(1);
+        await Assert.That(ns.LineEnd).IsEqualTo(4);
+    }
+
+    [Test]
+    public async Task MultipleNamespacesBlockScoped()
+    {
+        var source = """
+            namespace First
+            {
+                public class A { }
+            }
+
+            namespace Second
+            {
+                public class B { }
+            }
+            """;
+
+        var result = Parse(source);
+
+        var namespaces = result.Symbols.Where(s => s.Kind == SymbolKind.Module).ToList();
+        await Assert.That(namespaces).Count().IsEqualTo(2);
+        await Assert.That(namespaces[0].Name).IsEqualTo("First");
+        await Assert.That(namespaces[1].Name).IsEqualTo("Second");
+    }
+
+    // ── Class ────────────────────────────────────────────────────
+
+    [Test]
+    public async Task PublicClassWithBaseAndInterfaces()
+    {
+        var source = """
+            namespace Test;
+
+            public class Foo : Bar, IBaz
+            {
+                public int X { get; set; }
+            }
+            """;
+
+        var result = Parse(source);
+
+        var cls = result.Symbols.First(s => s.Kind == SymbolKind.Class);
+        await Assert.That(cls.Name).IsEqualTo("Foo");
+        await Assert.That(cls.Kind).IsEqualTo(SymbolKind.Class);
+        await Assert.That(cls.Visibility).IsEqualTo(Visibility.Public);
+        await Assert.That(cls.Signature).IsEqualTo("public class Foo : Bar, IBaz");
+    }
+
+    [Test]
+    public async Task InternalClassVisibilityPublic()
+    {
+        var source = """
+            internal class Foo
+            {
+            }
+            """;
+
+        var result = Parse(source);
+
+        var cls = result.Symbols.First(s => s.Kind == SymbolKind.Class);
+        await Assert.That(cls.Visibility).IsEqualTo(Visibility.Public);
+    }
+
+    [Test]
+    public async Task AbstractClassExtracted()
+    {
+        var source = """
+            public abstract class Foo
+            {
+            }
+            """;
+
+        var result = Parse(source);
+
+        var cls = result.Symbols.First(s => s.Kind == SymbolKind.Class);
+        await Assert.That(cls.Signature).IsEqualTo("public abstract class Foo");
+    }
+
+    [Test]
+    public async Task SealedClassExtracted()
+    {
+        var source = """
+            public sealed class Foo
+            {
+            }
+            """;
+
+        var result = Parse(source);
+
+        var cls = result.Symbols.First(s => s.Kind == SymbolKind.Class);
+        await Assert.That(cls.Signature).IsEqualTo("public sealed class Foo");
+    }
+
+    [Test]
+    public async Task StaticClassExtracted()
+    {
+        var source = """
+            public static class Foo
+            {
+            }
+            """;
+
+        var result = Parse(source);
+
+        var cls = result.Symbols.First(s => s.Kind == SymbolKind.Class);
+        await Assert.That(cls.Signature).IsEqualTo("public static class Foo");
+    }
+
+    [Test]
+    public async Task PartialClassExtracted()
+    {
+        var source = """
+            public partial class Foo
+            {
+            }
+            """;
+
+        var result = Parse(source);
+
+        var cls = result.Symbols.First(s => s.Kind == SymbolKind.Class);
+        await Assert.That(cls.Signature).IsEqualTo("public partial class Foo");
+    }
+
+    // ── Interface ────────────────────────────────────────────────
+
+    [Test]
+    public async Task InterfaceWithIPrefix()
+    {
+        var source = """
+            public interface IFoo
+            {
+                void DoStuff();
+            }
+            """;
+
+        var result = Parse(source);
+
+        var iface = result.Symbols.First(s => s.Kind == SymbolKind.Interface);
+        await Assert.That(iface.Name).IsEqualTo("IFoo");
+        await Assert.That(iface.Kind).IsEqualTo(SymbolKind.Interface);
+        await Assert.That(iface.Visibility).IsEqualTo(Visibility.Public);
+    }
+
+    [Test]
+    public async Task GenericInterfaceExtracted()
+    {
+        var source = """
+            public interface IRepo<T>
+            {
+            }
+            """;
+
+        var result = Parse(source);
+
+        var iface = result.Symbols.First(s => s.Kind == SymbolKind.Interface);
+        await Assert.That(iface.Name).IsEqualTo("IRepo");
+        await Assert.That(iface.Signature).IsEqualTo("public interface IRepo<T>");
+    }
+
+    // ── Record ───────────────────────────────────────────────────
+
+    [Test]
+    public async Task RecordWithPrimaryConstructor()
+    {
+        var source = """
+            public record Foo(int X, string Y);
+            """;
+
+        var result = Parse(source);
+
+        var rec = result.Symbols.First(s => s.Name == "Foo");
+        await Assert.That(rec.Kind).IsEqualTo(SymbolKind.Class);
+        await Assert.That(rec.Signature).IsEqualTo("public record Foo(int X, string Y);");
+    }
+
+    [Test]
+    public async Task RecordStructExtracted()
+    {
+        var source = """
+            public record struct Point(int X, int Y);
+            """;
+
+        var result = Parse(source);
+
+        var rec = result.Symbols.First(s => s.Name == "Point");
+        await Assert.That(rec.Kind).IsEqualTo(SymbolKind.Class);
+        await Assert.That(rec.Signature).IsEqualTo("public record struct Point(int X, int Y);");
+    }
+
+    // ── Enum ─────────────────────────────────────────────────────
+
+    [Test]
+    public async Task EnumExtracted()
+    {
+        var source = """
+            public enum Color
+            {
+                Red,
+                Green,
+                Blue
+            }
+            """;
+
+        var result = Parse(source);
+
+        var en = result.Symbols.First(s => s.Name == "Color");
+        await Assert.That(en.Kind).IsEqualTo(SymbolKind.Type);
+        await Assert.That(en.Visibility).IsEqualTo(Visibility.Public);
+    }
+
+    [Test]
+    public async Task EnumWithUnderlyingType()
+    {
+        var source = """
+            public enum Flags : byte
+            {
+                None = 0,
+                A = 1
+            }
+            """;
+
+        var result = Parse(source);
+
+        var en = result.Symbols.First(s => s.Name == "Flags");
+        await Assert.That(en.Signature).IsEqualTo("public enum Flags : byte");
+    }
+
+    // ── Struct ───────────────────────────────────────────────────
+
+    [Test]
+    public async Task StructExtracted()
+    {
+        var source = """
+            public struct Vector3
+            {
+                public float X;
+                public float Y;
+                public float Z;
+            }
+            """;
+
+        var result = Parse(source);
+
+        var st = result.Symbols.First(s => s.Name == "Vector3");
+        await Assert.That(st.Kind).IsEqualTo(SymbolKind.Class);
+        await Assert.That(st.Visibility).IsEqualTo(Visibility.Public);
+    }
+
+    // ── Generics ─────────────────────────────────────────────────
+
+    [Test]
+    public async Task GenericClassWithConstraints()
+    {
+        var source = """
+            public class Repo<T> where T : IEntity
+            {
+            }
+            """;
+
+        var result = Parse(source);
+
+        var cls = result.Symbols.First(s => s.Kind == SymbolKind.Class);
+        await Assert.That(cls.Name).IsEqualTo("Repo");
+        await Assert.That(cls.Signature).IsEqualTo("public class Repo<T> where T : IEntity");
+    }
+
+    // ── Nested types ─────────────────────────────────────────────
+
+    [Test]
+    public async Task NestedClassParentSet()
+    {
+        var source = """
+            public class Outer
+            {
+                public class Inner
+                {
+                }
+            }
+            """;
+
+        var result = Parse(source);
+
+        var inner = result.Symbols.First(s => s.Name == "Inner");
+        await Assert.That(inner.ParentSymbol).IsEqualTo("Outer");
+    }
+
+    [Test]
+    public async Task NestedEnumParentSet()
+    {
+        var source = """
+            public class Container
+            {
+                public enum Status
+                {
+                    Active,
+                    Inactive
+                }
+            }
+            """;
+
+        var result = Parse(source);
+
+        var en = result.Symbols.First(s => s.Name == "Status");
+        await Assert.That(en.ParentSymbol).IsEqualTo("Container");
+    }
+
+    [Test]
+    public async Task PrivateNestedClassVisibilityPrivate()
+    {
+        var source = """
+            public class Outer
+            {
+                class Inner
+                {
+                }
+            }
+            """;
+
+        var result = Parse(source);
+
+        var inner = result.Symbols.First(s => s.Name == "Inner");
+        await Assert.That(inner.Visibility).IsEqualTo(Visibility.Private);
+    }
+
+    // ── XML Doc Comments ─────────────────────────────────────────
+
+    [Test]
+    public async Task XmlDocCommentCaptured()
+    {
+        var source = """
+            /// <summary>My class.</summary>
+            public class Foo
+            {
+            }
+            """;
+
+        var result = Parse(source);
+
+        var cls = result.Symbols.First(s => s.Name == "Foo");
+        await Assert.That(cls.DocComment).IsEqualTo("/// <summary>My class.</summary>");
+    }
+
+    [Test]
+    public async Task MultiLineXmlDocCaptured()
+    {
+        var source = """
+            /// <summary>
+            /// My class does things.
+            /// </summary>
+            public class Foo
+            {
+            }
+            """;
+
+        var result = Parse(source);
+
+        var cls = result.Symbols.First(s => s.Name == "Foo");
+        await Assert.That(cls.DocComment).IsEqualTo(
+            """
+            /// <summary>
+            /// My class does things.
+            /// </summary>
+            """);
+    }
+
+    // ── Visibility derivation ────────────────────────────────────
+
+    [Test]
+    public async Task NoModifierTopLevelVisibilityPublic()
+    {
+        // C# default for top-level types is internal, mapped to Public
+        var source = """
+            class Foo
+            {
+            }
+            """;
+
+        var result = Parse(source);
+
+        var cls = result.Symbols.First(s => s.Name == "Foo");
+        await Assert.That(cls.Visibility).IsEqualTo(Visibility.Public);
+    }
+
+    [Test]
+    public async Task ProtectedInternalVisibilityPublic()
+    {
+        var source = """
+            public class Outer
+            {
+                protected internal class Inner
+                {
+                }
+            }
+            """;
+
+        var result = Parse(source);
+
+        var inner = result.Symbols.First(s => s.Name == "Inner");
+        await Assert.That(inner.Visibility).IsEqualTo(Visibility.Public);
+    }
+
+    [Test]
+    public async Task PrivateProtectedVisibilityPrivate()
+    {
+        var source = """
+            public class Outer
+            {
+                private protected class Inner
+                {
+                }
+            }
+            """;
+
+        var result = Parse(source);
+
+        var inner = result.Symbols.First(s => s.Name == "Inner");
+        await Assert.That(inner.Visibility).IsEqualTo(Visibility.Private);
+    }
+
+    [Test]
+    public async Task ProtectedVisibilityPrivate()
+    {
+        var source = """
+            public class Outer
+            {
+                protected class Inner
+                {
+                }
+            }
+            """;
+
+        var result = Parse(source);
+
+        var inner = result.Symbols.First(s => s.Name == "Inner");
+        await Assert.That(inner.Visibility).IsEqualTo(Visibility.Private);
+    }
+
+    // ── Brace tracking edge cases ────────────────────────────────
+
+    [Test]
+    public async Task BracesInStringLiteralsIgnored()
+    {
+        var source = """
+            public class Foo
+            {
+                public string Bar = "{ }";
+            }
+            """;
+
+        var result = Parse(source);
+
+        var cls = result.Symbols.First(s => s.Name == "Foo");
+        await Assert.That(cls.LineStart).IsEqualTo(1);
+        await Assert.That(cls.LineEnd).IsEqualTo(4);
+    }
+
+    [Test]
+    public async Task BracesInVerbatimStringIgnored()
+    {
+        var source = """
+            public class Foo
+            {
+                public string Bar = @"test { } more";
+            }
+            """;
+
+        var result = Parse(source);
+
+        var cls = result.Symbols.First(s => s.Name == "Foo");
+        await Assert.That(cls.LineEnd).IsEqualTo(4);
+    }
+
+    [Test]
+    public async Task BracesInSingleLineCommentIgnored()
+    {
+        var source = """
+            public class Foo
+            {
+                // this has { braces }
+                public int X;
+            }
+            """;
+
+        var result = Parse(source);
+
+        var cls = result.Symbols.First(s => s.Name == "Foo");
+        await Assert.That(cls.LineEnd).IsEqualTo(5);
+    }
+
+    [Test]
+    public async Task BracesInBlockCommentIgnored()
+    {
+        var source = """
+            public class Foo
+            {
+                /* { } */
+                public int X;
+            }
+            """;
+
+        var result = Parse(source);
+
+        var cls = result.Symbols.First(s => s.Name == "Foo");
+        await Assert.That(cls.LineEnd).IsEqualTo(5);
+    }
+
+    [Test]
+    public async Task BracesInCharLiteralIgnored()
+    {
+        var source = """
+            public class Foo
+            {
+                public char Open = '{';
+                public char Close = '}';
+            }
+            """;
+
+        var result = Parse(source);
+
+        var cls = result.Symbols.First(s => s.Name == "Foo");
+        await Assert.That(cls.LineEnd).IsEqualTo(5);
+    }
+
+    // ── Line numbers and byte offsets ────────────────────────────
+
+    [Test]
+    public async Task LineNumbersAreOneBased()
+    {
+        var source = """
+            namespace Test;
+
+            public class Foo
+            {
+            }
+            """;
+
+        var result = Parse(source);
+
+        var cls = result.Symbols.First(s => s.Kind == SymbolKind.Class);
+        await Assert.That(cls.LineStart).IsEqualTo(3);
+        await Assert.That(cls.LineEnd).IsEqualTo(5);
+    }
+
+    [Test]
+    public async Task ByteOffsetIsCorrect()
+    {
+        var source = "namespace Test;\n\npublic class Foo\n{\n}\n";
+
+        var result = Parse(source);
+
+        var cls = result.Symbols.First(s => s.Kind == SymbolKind.Class);
+        var expectedOffset = Encoding.UTF8.GetByteCount("namespace Test;\n\n");
+        await Assert.That(cls.ByteOffset).IsEqualTo(expectedOffset);
+    }
+
+    // ── Record with body ─────────────────────────────────────────
+
+    [Test]
+    public async Task RecordWithBodyExtracted()
+    {
+        var source = """
+            public record Foo(int X)
+            {
+                public int Y { get; init; }
+            }
+            """;
+
+        var result = Parse(source);
+
+        var rec = result.Symbols.First(s => s.Name == "Foo");
+        await Assert.That(rec.Kind).IsEqualTo(SymbolKind.Class);
+        await Assert.That(rec.LineEnd).IsEqualTo(4);
+    }
+
+    // ── File-scoped type (C# 14 file modifier) ──────────────────
+
+    [Test]
+    public async Task FileModifierClassExtracted()
+    {
+        var source = """
+            file class Secret
+            {
+            }
+            """;
+
+        var result = Parse(source);
+
+        var cls = result.Symbols.First(s => s.Name == "Secret");
+        await Assert.That(cls.Kind).IsEqualTo(SymbolKind.Class);
+        await Assert.That(cls.Visibility).IsEqualTo(Visibility.Private);
+    }
+}

--- a/tests/CodeCompress.Core.Tests/Parsers/CSharpParserTests.cs
+++ b/tests/CodeCompress.Core.Tests/Parsers/CSharpParserTests.cs
@@ -680,4 +680,550 @@ internal sealed class CSharpParserTests
         await Assert.That(cls.Kind).IsEqualTo(SymbolKind.Class);
         await Assert.That(cls.Visibility).IsEqualTo(Visibility.Private);
     }
+
+    // ── Methods ──────────────────────────────────────────────────
+
+    [Test]
+    public async Task PublicMethodExtracted()
+    {
+        var source = """
+            public class MyClass
+            {
+                public void DoSomething()
+                {
+                }
+            }
+            """;
+
+        var result = Parse(source);
+
+        var method = result.Symbols.First(s => s.Kind == SymbolKind.Method);
+        await Assert.That(method.Name).IsEqualTo("DoSomething");
+        await Assert.That(method.Kind).IsEqualTo(SymbolKind.Method);
+        await Assert.That(method.Visibility).IsEqualTo(Visibility.Public);
+        await Assert.That(method.ParentSymbol).IsEqualTo("MyClass");
+        await Assert.That(method.Signature).IsEqualTo("public void DoSomething()");
+    }
+
+    [Test]
+    public async Task PrivateMethodVisibilityPrivate()
+    {
+        var source = """
+            public class MyClass
+            {
+                private int Calculate()
+                {
+                    return 42;
+                }
+            }
+            """;
+
+        var result = Parse(source);
+
+        var method = result.Symbols.First(s => s.Kind == SymbolKind.Method);
+        await Assert.That(method.Visibility).IsEqualTo(Visibility.Private);
+    }
+
+    [Test]
+    public async Task ProtectedMethodExtracted()
+    {
+        var source = """
+            public class MyClass
+            {
+                protected virtual void OnEvent()
+                {
+                }
+            }
+            """;
+
+        var result = Parse(source);
+
+        var method = result.Symbols.First(s => s.Kind == SymbolKind.Method);
+        await Assert.That(method.Signature).IsEqualTo("protected virtual void OnEvent()");
+    }
+
+    [Test]
+    public async Task AsyncMethodTaskReturn()
+    {
+        var source = """
+            public class MyClass
+            {
+                public async Task<int> GetAsync()
+                {
+                    return 42;
+                }
+            }
+            """;
+
+        var result = Parse(source);
+
+        var method = result.Symbols.First(s => s.Kind == SymbolKind.Method);
+        await Assert.That(method.Signature).IsEqualTo("public async Task<int> GetAsync()");
+    }
+
+    [Test]
+    public async Task GenericMethodWithConstraints()
+    {
+        var source = """
+            public class MyClass
+            {
+                public T Find<T>(int id) where T : class
+                {
+                    return default;
+                }
+            }
+            """;
+
+        var result = Parse(source);
+
+        var method = result.Symbols.First(s => s.Kind == SymbolKind.Method);
+        await Assert.That(method.Name).IsEqualTo("Find");
+        await Assert.That(method.Signature).IsEqualTo("public T Find<T>(int id) where T : class");
+    }
+
+    [Test]
+    public async Task ConstructorExtracted()
+    {
+        var source = """
+            public class MyClass
+            {
+                public MyClass(int x, string y)
+                {
+                }
+            }
+            """;
+
+        var result = Parse(source);
+
+        var ctor = result.Symbols.First(s => s.Kind == SymbolKind.Method);
+        await Assert.That(ctor.Name).IsEqualTo("MyClass");
+        await Assert.That(ctor.ParentSymbol).IsEqualTo("MyClass");
+    }
+
+    [Test]
+    public async Task StaticConstructorExtracted()
+    {
+        var source = """
+            public class MyClass
+            {
+                static MyClass()
+                {
+                }
+            }
+            """;
+
+        var result = Parse(source);
+
+        var ctor = result.Symbols.First(s => s.Kind == SymbolKind.Method);
+        await Assert.That(ctor.Name).IsEqualTo("MyClass");
+        await Assert.That(ctor.Signature).IsEqualTo("static MyClass()");
+    }
+
+    [Test]
+    public async Task FinalizerExtracted()
+    {
+        var source = """
+            public class MyClass
+            {
+                ~MyClass()
+                {
+                }
+            }
+            """;
+
+        var result = Parse(source);
+
+        var finalizer = result.Symbols.First(s => s.Kind == SymbolKind.Method);
+        await Assert.That(finalizer.Name).IsEqualTo("~MyClass");
+    }
+
+    [Test]
+    public async Task OperatorOverloadExtracted()
+    {
+        var source = """
+            public class MyClass
+            {
+                public static MyClass operator +(MyClass a, MyClass b)
+                {
+                    return a;
+                }
+            }
+            """;
+
+        var result = Parse(source);
+
+        var op = result.Symbols.First(s => s.Kind == SymbolKind.Method);
+        await Assert.That(op.Name).IsEqualTo("operator +");
+        await Assert.That(op.Signature).IsEqualTo("public static MyClass operator +(MyClass a, MyClass b)");
+    }
+
+    [Test]
+    public async Task IndexerExtracted()
+    {
+        var source = """
+            public class MyClass
+            {
+                public int this[int i]
+                {
+                    get { return 0; }
+                }
+            }
+            """;
+
+        var result = Parse(source);
+
+        var indexer = result.Symbols.First(s => s.Kind == SymbolKind.Method);
+        await Assert.That(indexer.Name).IsEqualTo("this[]");
+        await Assert.That(indexer.Signature).IsEqualTo("public int this[int i]");
+    }
+
+    [Test]
+    public async Task ExpressionBodiedMethodExtracted()
+    {
+        var source = """
+            public class MyClass
+            {
+                public int Sum() => X + Y;
+            }
+            """;
+
+        var result = Parse(source);
+
+        var method = result.Symbols.First(s => s.Kind == SymbolKind.Method);
+        await Assert.That(method.Name).IsEqualTo("Sum");
+        await Assert.That(method.Signature).IsEqualTo("public int Sum()");
+    }
+
+    [Test]
+    public async Task ExtensionMethodThisParameter()
+    {
+        var source = """
+            public static class Extensions
+            {
+                public static int Count(this IEnumerable<int> source)
+                {
+                    return 0;
+                }
+            }
+            """;
+
+        var result = Parse(source);
+
+        var method = result.Symbols.First(s => s.Kind == SymbolKind.Method);
+        await Assert.That(method.Name).IsEqualTo("Count");
+        await Assert.That(method.Signature).IsEqualTo("public static int Count(this IEnumerable<int> source)");
+    }
+
+    [Test]
+    public async Task VoidMethodExtracted()
+    {
+        var source = """
+            public class MyClass
+            {
+                public void Execute()
+                {
+                }
+            }
+            """;
+
+        var result = Parse(source);
+
+        var method = result.Symbols.First(s => s.Kind == SymbolKind.Method);
+        await Assert.That(method.Name).IsEqualTo("Execute");
+    }
+
+    // ── Properties ───────────────────────────────────────────────
+
+    [Test]
+    public async Task AutoPropertyExtracted()
+    {
+        var source = """
+            public class MyClass
+            {
+                public string Name { get; set; }
+            }
+            """;
+
+        var result = Parse(source);
+
+        var prop = result.Symbols.First(s => s.Kind == SymbolKind.Constant);
+        await Assert.That(prop.Name).IsEqualTo("Name");
+        await Assert.That(prop.Kind).IsEqualTo(SymbolKind.Constant);
+        await Assert.That(prop.Signature).IsEqualTo("public string Name { get; set; }");
+        await Assert.That(prop.ParentSymbol).IsEqualTo("MyClass");
+    }
+
+    [Test]
+    public async Task InitOnlyPropertyExtracted()
+    {
+        var source = """
+            public class MyClass
+            {
+                public string Name { get; init; }
+            }
+            """;
+
+        var result = Parse(source);
+
+        var prop = result.Symbols.First(s => s.Kind == SymbolKind.Constant);
+        await Assert.That(prop.Signature).IsEqualTo("public string Name { get; init; }");
+    }
+
+    [Test]
+    public async Task ExpressionBodiedPropertyExtracted()
+    {
+        var source = """
+            public class MyClass
+            {
+                public int Total => Items.Count;
+            }
+            """;
+
+        var result = Parse(source);
+
+        var prop = result.Symbols.First(s => s.Kind == SymbolKind.Constant);
+        await Assert.That(prop.Name).IsEqualTo("Total");
+        await Assert.That(prop.Signature).IsEqualTo("public int Total => Items.Count;");
+    }
+
+    [Test]
+    public async Task RequiredPropertyExtracted()
+    {
+        var source = """
+            public class MyClass
+            {
+                public required string Name { get; set; }
+            }
+            """;
+
+        var result = Parse(source);
+
+        var prop = result.Symbols.First(s => s.Kind == SymbolKind.Constant);
+        await Assert.That(prop.Signature).IsEqualTo("public required string Name { get; set; }");
+    }
+
+    // ── Using statements ─────────────────────────────────────────
+
+    [Test]
+    public async Task UsingStatementAsDependency()
+    {
+        var source = """
+            using System.Collections.Generic;
+
+            public class Foo { }
+            """;
+
+        var result = Parse(source);
+
+        await Assert.That(result.Dependencies).Count().IsEqualTo(1);
+        await Assert.That(result.Dependencies[0].RequirePath).IsEqualTo("System.Collections.Generic");
+        await Assert.That(result.Dependencies[0].Alias).IsNull();
+    }
+
+    [Test]
+    public async Task GlobalUsingAsDependency()
+    {
+        var source = """
+            global using System.Linq;
+
+            public class Foo { }
+            """;
+
+        var result = Parse(source);
+
+        await Assert.That(result.Dependencies).Count().IsEqualTo(1);
+        await Assert.That(result.Dependencies[0].RequirePath).IsEqualTo("System.Linq");
+    }
+
+    [Test]
+    public async Task UsingAliasAsDependency()
+    {
+        var source = """
+            using Dict = System.Collections.Generic.Dictionary<string, int>;
+
+            public class Foo { }
+            """;
+
+        var result = Parse(source);
+
+        await Assert.That(result.Dependencies).Count().IsEqualTo(1);
+        await Assert.That(result.Dependencies[0].RequirePath).IsEqualTo("System.Collections.Generic.Dictionary<string, int>");
+        await Assert.That(result.Dependencies[0].Alias).IsEqualTo("Dict");
+    }
+
+    [Test]
+    public async Task UsingStaticAsDependency()
+    {
+        var source = """
+            using static System.Math;
+
+            public class Foo { }
+            """;
+
+        var result = Parse(source);
+
+        await Assert.That(result.Dependencies).Count().IsEqualTo(1);
+        await Assert.That(result.Dependencies[0].RequirePath).IsEqualTo("System.Math");
+    }
+
+    // ── Edge cases ───────────────────────────────────────────────
+
+    [Test]
+    public async Task MethodWithAttributesAttributeSkipped()
+    {
+        var source = """
+            public class MyController
+            {
+                [HttpGet]
+                public IActionResult Get()
+                {
+                    return Ok();
+                }
+            }
+            """;
+
+        var result = Parse(source);
+
+        var method = result.Symbols.First(s => s.Kind == SymbolKind.Method);
+        await Assert.That(method.Signature).IsEqualTo("public IActionResult Get()");
+    }
+
+    [Test]
+    public async Task NullableReturnTypeCaptured()
+    {
+        var source = """
+            public class MyClass
+            {
+                public string? GetName()
+                {
+                    return null;
+                }
+            }
+            """;
+
+        var result = Parse(source);
+
+        var method = result.Symbols.First(s => s.Kind == SymbolKind.Method);
+        await Assert.That(method.Signature).IsEqualTo("public string? GetName()");
+    }
+
+    [Test]
+    public async Task TupleReturnTypeCaptured()
+    {
+        var source = """
+            public class MyClass
+            {
+                public (int X, string Y) GetPair()
+                {
+                    return (1, "a");
+                }
+            }
+            """;
+
+        var result = Parse(source);
+
+        var method = result.Symbols.First(s => s.Kind == SymbolKind.Method);
+        await Assert.That(method.Signature).IsEqualTo("public (int X, string Y) GetPair()");
+    }
+
+    [Test]
+    public async Task ExplicitInterfaceImplCaptured()
+    {
+        var source = """
+            public class MyClass : IDisposable
+            {
+                void IDisposable.Dispose()
+                {
+                }
+            }
+            """;
+
+        var result = Parse(source);
+
+        var method = result.Symbols.First(s => s.Kind == SymbolKind.Method);
+        await Assert.That(method.Name).IsEqualTo("IDisposable.Dispose");
+    }
+
+    [Test]
+    public async Task DefaultVisibilityForMethodIsPrivate()
+    {
+        var source = """
+            public class MyClass
+            {
+                void InternalMethod()
+                {
+                }
+            }
+            """;
+
+        var result = Parse(source);
+
+        var method = result.Symbols.First(s => s.Kind == SymbolKind.Method);
+        await Assert.That(method.Visibility).IsEqualTo(Visibility.Private);
+    }
+
+    [Test]
+    public async Task ComplexRealWorldFileAllSymbolsExtracted()
+    {
+        var source = """
+            using System;
+            using System.Collections.Generic;
+
+            namespace MyApp.Services;
+
+            /// <summary>
+            /// Service for managing users.
+            /// </summary>
+            public class UserService : IUserService
+            {
+                private readonly ILogger _logger;
+
+                public UserService(ILogger logger)
+                {
+                    _logger = logger;
+                }
+
+                public string Name { get; set; }
+
+                public int Count => _users.Count;
+
+                public async Task<User?> GetByIdAsync(int id)
+                {
+                    return null;
+                }
+
+                private void Validate(User user)
+                {
+                    if (user == null) throw new ArgumentNullException(nameof(user));
+                }
+
+                public enum Status
+                {
+                    Active,
+                    Inactive
+                }
+            }
+            """;
+
+        var result = Parse(source);
+
+        // Should find: namespace, class, constructor, 2 properties, 2 methods, nested enum
+        var ns = result.Symbols.Where(s => s.Kind == SymbolKind.Module).ToList();
+        await Assert.That(ns).Count().IsEqualTo(1);
+
+        var classes = result.Symbols.Where(s => s.Kind == SymbolKind.Class).ToList();
+        await Assert.That(classes).Count().IsEqualTo(1);
+
+        var methods = result.Symbols.Where(s => s.Kind == SymbolKind.Method).ToList();
+        await Assert.That(methods.Count).IsGreaterThanOrEqualTo(3);
+
+        var properties = result.Symbols.Where(s => s.Kind == SymbolKind.Constant).ToList();
+        await Assert.That(properties.Count).IsGreaterThanOrEqualTo(2);
+
+        var enums = result.Symbols.Where(s => s.Kind == SymbolKind.Type).ToList();
+        await Assert.That(enums).Count().IsEqualTo(1);
+
+        // Dependencies from using statements
+        await Assert.That(result.Dependencies.Count).IsGreaterThanOrEqualTo(2);
+    }
 }

--- a/tests/CodeCompress.Integration.Tests/CSharpEndToEndTests.cs
+++ b/tests/CodeCompress.Integration.Tests/CSharpEndToEndTests.cs
@@ -1,0 +1,311 @@
+using CodeCompress.Core.Indexing;
+using CodeCompress.Core.Models;
+using CodeCompress.Core.Parsers;
+using CodeCompress.Core.Storage;
+using CodeCompress.Core.Validation;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CodeCompress.Integration.Tests;
+
+internal sealed class CSharpEndToEndTests : IDisposable
+{
+    private SqliteConnection _connection = null!;
+    private SqliteSymbolStore _store = null!;
+    private IndexEngine _engine = null!;
+    private string _sampleProjectPath = null!;
+    private string _repoId = null!;
+
+    public void Dispose()
+    {
+        _connection?.Dispose();
+    }
+
+    [Before(Test)]
+    public async Task SetUp()
+    {
+        _connection = new SqliteConnection("Data Source=:memory:");
+        await _connection.OpenAsync().ConfigureAwait(false);
+
+        await Migrations.ApplyAsync(_connection).ConfigureAwait(false);
+
+        _store = new SqliteSymbolStore(_connection);
+
+        var parsers = new ILanguageParser[] { new CSharpParser() };
+        var fileHasher = new FileHasher();
+        var changeTracker = new ChangeTracker();
+        var pathValidator = new PathValidatorService();
+
+        _engine = new IndexEngine(
+            fileHasher,
+            changeTracker,
+            parsers,
+            _store,
+            pathValidator,
+            NullLogger<IndexEngine>.Instance);
+
+        _sampleProjectPath = FindCSharpSampleProjectPath();
+        _repoId = IndexEngine.ComputeRepoId(Path.GetFullPath(_sampleProjectPath));
+    }
+
+    [After(Test)]
+    public async Task TearDown()
+    {
+        await _connection.DisposeAsync().ConfigureAwait(false);
+    }
+
+    // ── Indexing Tests ───────────────────────────────────────────────────
+
+    [Test]
+    public async Task IndexProjectCSharpSampleCorrectFilesAndSymbolCounts()
+    {
+        var result = await _engine.IndexProjectAsync(_sampleProjectPath, "csharp").ConfigureAwait(false);
+
+        await Assert.That(result.RepoId).IsEqualTo(_repoId);
+        await Assert.That(result.FilesIndexed).IsEqualTo(8);
+        await Assert.That(result.SymbolsFound).IsEqualTo(57);
+    }
+
+    // ── Query Tests ──────────────────────────────────────────────────────
+
+    [Test]
+    public async Task ProjectOutlineCSharpSymbolsGroupedCorrectly()
+    {
+        await IndexSampleProjectAsync().ConfigureAwait(false);
+
+        var outline = await _store.GetProjectOutlineAsync(
+            _repoId, includePrivate: true, groupBy: "file", maxDepth: 0).ConfigureAwait(false);
+
+        await Assert.That(outline.Groups).Count().IsGreaterThanOrEqualTo(1);
+
+        var totalSymbols = CountOutlineSymbols(outline.Groups);
+        await Assert.That(totalSymbols).IsEqualTo(57);
+
+        // Verify some specific symbol kinds appear
+        var allSymbolKinds = CollectSymbolKinds(outline.Groups);
+        await Assert.That(allSymbolKinds).Contains("Class");
+        await Assert.That(allSymbolKinds).Contains("Method");
+        await Assert.That(allSymbolKinds).Contains("Interface");
+        await Assert.That(allSymbolKinds).Contains("Module");
+        await Assert.That(allSymbolKinds).Contains("Constant");
+        await Assert.That(allSymbolKinds).Contains("Type");
+    }
+
+    [Test]
+    public async Task GetSymbolCSharpMethodReturnsSourceCode()
+    {
+        await IndexSampleProjectAsync().ConfigureAwait(false);
+
+        var symbol = await _store.GetSymbolByNameAsync(
+            _repoId, "CombatService:ProcessAttackAsync").ConfigureAwait(false);
+
+        await Assert.That(symbol).IsNotNull();
+        await Assert.That(symbol!.Name).IsEqualTo("ProcessAttackAsync");
+        await Assert.That(symbol.Kind).IsEqualTo("Method");
+        await Assert.That(symbol.ParentSymbol).IsEqualTo("CombatService");
+        await Assert.That(symbol.Visibility).IsEqualTo("Public");
+        await Assert.That(symbol.ByteOffset).IsGreaterThan(0);
+        await Assert.That(symbol.ByteLength).IsGreaterThan(0);
+
+        // Verify source code can be read from the actual file
+        var files = await _store.GetFilesByRepoAsync(_repoId).ConfigureAwait(false);
+        var file = files.First(f => f.RelativePath.Contains("CombatService", StringComparison.Ordinal)
+                                    && !f.RelativePath.Contains("ICombat", StringComparison.Ordinal));
+        var fullPath = Path.Combine(_sampleProjectPath, file.RelativePath);
+        var bytes = await File.ReadAllBytesAsync(fullPath).ConfigureAwait(false);
+        var sourceCode = System.Text.Encoding.UTF8.GetString(bytes, symbol.ByteOffset, symbol.ByteLength);
+
+        await Assert.That(sourceCode).Contains("ProcessAttackAsync");
+    }
+
+    [Test]
+    public async Task GetSymbolCSharpRecordReturnsDeclaration()
+    {
+        await IndexSampleProjectAsync().ConfigureAwait(false);
+
+        // The record is stored as a Class kind
+        var symbols = await _store.GetSymbolsByNamesAsync(_repoId, ["Player"]).ConfigureAwait(false);
+        var record = symbols.FirstOrDefault(s => s.Kind == "Class" && s.Name == "Player");
+
+        await Assert.That(record).IsNotNull();
+        await Assert.That(record!.Signature).Contains("record");
+        await Assert.That(record.Signature).Contains("Player");
+    }
+
+    [Test]
+    public async Task SearchSymbolsCSharpNamesReturnsRankedResults()
+    {
+        await IndexSampleProjectAsync().ConfigureAwait(false);
+
+        var results = await _store.SearchSymbolsAsync(
+            _repoId, "ProcessAttackAsync", kind: null, limit: 10).ConfigureAwait(false);
+
+        await Assert.That(results).Count().IsGreaterThanOrEqualTo(1);
+
+        var names = results.Select(r => r.Symbol.Name).ToList();
+        await Assert.That(names).Contains("ProcessAttackAsync");
+    }
+
+    [Test]
+    public async Task GetModuleApiCSharpServiceReturnsPublicApi()
+    {
+        await IndexSampleProjectAsync().ConfigureAwait(false);
+
+        var combatServiceRelPath = GetStoredRelativePath("CombatService.cs", excludePattern: "ICombat");
+        var moduleApi = await _store.GetModuleApiAsync(_repoId, combatServiceRelPath).ConfigureAwait(false);
+
+        await Assert.That(moduleApi.File.RelativePath).IsEqualTo(combatServiceRelPath);
+
+        // Public methods in CombatService
+        var methodNames = moduleApi.Symbols
+            .Where(s => s.Kind == "Method")
+            .Select(s => s.Name)
+            .OrderBy(n => n, StringComparer.Ordinal)
+            .ToList();
+
+        await Assert.That(methodNames).Contains("ProcessAttackAsync");
+        await Assert.That(methodNames).Contains("CalculateDamage");
+        await Assert.That(methodNames).Contains("HealAsync");
+        await Assert.That(methodNames).Contains("CombatService"); // constructor
+    }
+
+    [Test]
+    public async Task DependencyGraphUsingStatementsCaptured()
+    {
+        await IndexSampleProjectAsync().ConfigureAwait(false);
+
+        var graph = await _store.GetDependencyGraphAsync(
+            _repoId, rootFile: null, direction: "dependencies", depth: 50).ConfigureAwait(false);
+
+        // Nodes include files and their dependency targets (using statement namespaces)
+        await Assert.That(graph.Nodes).Count().IsGreaterThanOrEqualTo(8);
+
+        // Using statements create dependency edges
+        await Assert.That(graph.Edges).Count().IsGreaterThan(0);
+    }
+
+    [Test]
+    public async Task NamespaceExtractionAllFilesHaveNamespace()
+    {
+        await IndexSampleProjectAsync().ConfigureAwait(false);
+
+        var outline = await _store.GetProjectOutlineAsync(
+            _repoId, includePrivate: true, groupBy: "file", maxDepth: 0).ConfigureAwait(false);
+
+        // Each file group should have a Module symbol (namespace)
+        foreach (var group in outline.Groups)
+        {
+            var symbols = group.Symbols;
+            var hasModule = symbols.Any(s => s.Kind == "Module");
+            await Assert.That(hasModule)
+                .IsTrue()
+                .Because($"File group '{group.Name}' should have a Module (namespace) symbol");
+        }
+    }
+
+    [Test]
+    public async Task NestedTypesParentChainCorrect()
+    {
+        await IndexSampleProjectAsync().ConfigureAwait(false);
+
+        // ItemRarity is a nested enum inside Inventory
+        var symbols = await _store.GetSymbolsByNamesAsync(_repoId, ["ItemRarity"]).ConfigureAwait(false);
+
+        await Assert.That(symbols).Count().IsGreaterThanOrEqualTo(1);
+        var itemRarity = symbols.First(s => s.Name == "ItemRarity");
+        await Assert.That(itemRarity.ParentSymbol).IsEqualTo("Inventory");
+        await Assert.That(itemRarity.Kind).IsEqualTo("Type");
+    }
+
+    [Test]
+    public async Task XmlDocCommentsCapturedOnSymbols()
+    {
+        await IndexSampleProjectAsync().ConfigureAwait(false);
+
+        // CombatService class should have a doc comment
+        var symbols = await _store.GetSymbolsByNamesAsync(_repoId, ["CombatService"]).ConfigureAwait(false);
+        var combatClass = symbols.First(s => s.Kind == "Class" && s.Name == "CombatService");
+
+        await Assert.That(combatClass.DocComment).IsNotNull();
+        await Assert.That(combatClass.DocComment!).Contains("Implementation of combat operations");
+
+        // ProcessAttackAsync should have a doc comment
+        var processAttack = await _store.GetSymbolByNameAsync(
+            _repoId, "CombatService:ProcessAttackAsync").ConfigureAwait(false);
+
+        await Assert.That(processAttack).IsNotNull();
+        await Assert.That(processAttack!.DocComment).IsNotNull();
+        await Assert.That(processAttack.DocComment!).Contains("Processes an attack");
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    private async Task IndexSampleProjectAsync()
+    {
+        await _engine.IndexProjectAsync(_sampleProjectPath, "csharp").ConfigureAwait(false);
+    }
+
+    private static string FindCSharpSampleProjectPath()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir, "CodeCompress.slnx")))
+            {
+                var samplePath = Path.Combine(dir, "samples", "csharp-sample-project");
+                if (Directory.Exists(samplePath))
+                {
+                    return Path.GetFullPath(samplePath);
+                }
+            }
+
+            dir = Directory.GetParent(dir)?.FullName;
+        }
+
+        throw new DirectoryNotFoundException(
+            "Could not find samples/csharp-sample-project from " + AppContext.BaseDirectory);
+    }
+
+    private string GetStoredRelativePath(string fileName, string? excludePattern = null)
+    {
+        var files = _store.GetFilesByRepoAsync(_repoId).GetAwaiter().GetResult();
+        var match = files.FirstOrDefault(f =>
+            f.RelativePath.Contains(
+                Path.GetFileNameWithoutExtension(fileName), StringComparison.OrdinalIgnoreCase)
+            && (excludePattern is null
+                || !f.RelativePath.Contains(excludePattern, StringComparison.OrdinalIgnoreCase)));
+        return match?.RelativePath
+               ?? throw new FileNotFoundException($"File not found in index: {fileName}");
+    }
+
+    private static int CountOutlineSymbols(IReadOnlyList<OutlineGroup> groups)
+    {
+        var count = 0;
+        foreach (var group in groups)
+        {
+            count += group.Symbols.Count;
+            count += CountOutlineSymbols(group.Children);
+        }
+
+        return count;
+    }
+
+    private static HashSet<string> CollectSymbolKinds(IReadOnlyList<OutlineGroup> groups)
+    {
+        var kinds = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var group in groups)
+        {
+            foreach (var symbol in group.Symbols)
+            {
+                kinds.Add(symbol.Kind);
+            }
+
+            foreach (var kind in CollectSymbolKinds(group.Children))
+            {
+                kinds.Add(kind);
+            }
+        }
+
+        return kinds;
+    }
+}

--- a/tests/CodeCompress.Integration.Tests/MixedLanguageTests.cs
+++ b/tests/CodeCompress.Integration.Tests/MixedLanguageTests.cs
@@ -1,0 +1,178 @@
+using CodeCompress.Core.Indexing;
+using CodeCompress.Core.Models;
+using CodeCompress.Core.Parsers;
+using CodeCompress.Core.Storage;
+using CodeCompress.Core.Validation;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CodeCompress.Integration.Tests;
+
+internal sealed class MixedLanguageTests : IDisposable
+{
+    private SqliteConnection _connection = null!;
+    private SqliteSymbolStore _store = null!;
+    private IndexEngine _engine = null!;
+    private string _tempDir = null!;
+    private string _repoId = null!;
+
+    public void Dispose()
+    {
+        _connection?.Dispose();
+    }
+
+    [Before(Test)]
+    public async Task SetUp()
+    {
+        _connection = new SqliteConnection("Data Source=:memory:");
+        await _connection.OpenAsync().ConfigureAwait(false);
+
+        await Migrations.ApplyAsync(_connection).ConfigureAwait(false);
+
+        _store = new SqliteSymbolStore(_connection);
+
+        // Register BOTH parsers
+        var parsers = new ILanguageParser[] { new LuauParser(), new CSharpParser() };
+        var fileHasher = new FileHasher();
+        var changeTracker = new ChangeTracker();
+        var pathValidator = new PathValidatorService();
+
+        _engine = new IndexEngine(
+            fileHasher,
+            changeTracker,
+            parsers,
+            _store,
+            pathValidator,
+            NullLogger<IndexEngine>.Instance);
+
+        _tempDir = Path.Combine(Path.GetTempPath(), $"codecompress-mixed-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+
+        CreateMixedLanguageFiles();
+
+        _repoId = IndexEngine.ComputeRepoId(Path.GetFullPath(_tempDir));
+    }
+
+    [After(Test)]
+    public async Task TearDown()
+    {
+        await _connection.DisposeAsync().ConfigureAwait(false);
+
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+    }
+
+    // ── Mixed Language Tests ─────────────────────────────────────────────
+
+    [Test]
+    public async Task MixedProjectBothParsersContribute()
+    {
+        var result = await _engine.IndexProjectAsync(_tempDir).ConfigureAwait(false);
+
+        // 2 files: 1 .cs + 1 .luau
+        await Assert.That(result.FilesIndexed).IsEqualTo(2);
+        await Assert.That(result.SymbolsFound).IsGreaterThanOrEqualTo(2);
+    }
+
+    [Test]
+    public async Task MixedProjectProjectOutlineShowsBothLanguages()
+    {
+        await _engine.IndexProjectAsync(_tempDir).ConfigureAwait(false);
+
+        var outline = await _store.GetProjectOutlineAsync(
+            _repoId, includePrivate: true, groupBy: "file", maxDepth: 0).ConfigureAwait(false);
+
+        var allSymbolNames = new List<string>();
+        CollectSymbolNames(outline.Groups, allSymbolNames);
+
+        // C# symbols
+        await Assert.That(allSymbolNames).Contains("PlayerService");
+
+        // Luau symbols
+        await Assert.That(allSymbolNames).Contains("greet");
+    }
+
+    [Test]
+    public async Task MixedProjectSearchSymbolsFindsBothLanguages()
+    {
+        await _engine.IndexProjectAsync(_tempDir).ConfigureAwait(false);
+
+        // Search for C# symbol
+        var csharpResults = await _store.SearchSymbolsAsync(
+            _repoId, "PlayerService", kind: null, limit: 10).ConfigureAwait(false);
+        await Assert.That(csharpResults).Count().IsGreaterThanOrEqualTo(1);
+
+        // Search for Luau symbol
+        var luauResults = await _store.SearchSymbolsAsync(
+            _repoId, "greet", kind: null, limit: 10).ConfigureAwait(false);
+        await Assert.That(luauResults).Count().IsGreaterThanOrEqualTo(1);
+    }
+
+    [Test]
+    public async Task ParserSelectionByExtensionCorrect()
+    {
+        await _engine.IndexProjectAsync(_tempDir).ConfigureAwait(false);
+
+        var files = await _store.GetFilesByRepoAsync(_repoId).ConfigureAwait(false);
+
+        var csFile = files.First(f => f.RelativePath.EndsWith(".cs", StringComparison.OrdinalIgnoreCase));
+        var luauFile = files.First(f => f.RelativePath.EndsWith(".luau", StringComparison.OrdinalIgnoreCase));
+
+        // C# file should have C#-style symbols (namespace = Module, class = Class)
+        var csSymbols = await _store.GetSymbolsByFileAsync(csFile.Id).ConfigureAwait(false);
+        var csKinds = csSymbols.Select(s => s.Kind).ToHashSet(StringComparer.Ordinal);
+        await Assert.That(csKinds).Contains("Module"); // namespace
+        await Assert.That(csKinds).Contains("Class"); // class
+
+        // Luau file should have Luau-style symbols (function = Function)
+        var luauSymbols = await _store.GetSymbolsByFileAsync(luauFile.Id).ConfigureAwait(false);
+        var luauKinds = luauSymbols.Select(s => s.Kind).ToHashSet(StringComparer.Ordinal);
+        await Assert.That(luauKinds).Contains("Function");
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    private void CreateMixedLanguageFiles()
+    {
+        // C# file
+        var csContent = """
+            using System;
+
+            namespace MixedProject;
+
+            public class PlayerService
+            {
+                public string GetName()
+                {
+                    return "Player";
+                }
+            }
+            """;
+        File.WriteAllText(Path.Combine(_tempDir, "PlayerService.cs"), csContent);
+
+        // Luau file
+        var luauContent = """
+            function greet(name: string): string
+                return "Hello, " .. name
+            end
+
+            return greet
+            """;
+        File.WriteAllText(Path.Combine(_tempDir, "greeter.luau"), luauContent);
+    }
+
+    private static void CollectSymbolNames(IReadOnlyList<OutlineGroup> groups, List<string> names)
+    {
+        foreach (var group in groups)
+        {
+            foreach (var symbol in group.Symbols)
+            {
+                names.Add(symbol.Name);
+            }
+
+            CollectSymbolNames(group.Children, names);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **12-001**: Regex-based C# parser for core type declarations (namespaces, classes, interfaces, records, enums, structs) with brace-depth tracking, modifier detection, visibility derivation, nested type parent tracking, and XML doc comment capture
- **12-002**: Extends C# parser with method extraction (regular, async, generic, constructors, finalizers, operators, indexers, expression-bodied, extension methods), property extraction (auto, init-only, expression-bodied, required), and using statement extraction as dependencies
- **12-003**: Adds 8 realistic C# sample files and 14 integration tests (10 C# end-to-end + 4 mixed-language) verifying both Luau and C# parsers coexist correctly

## Test plan

- [x] 409 total tests pass (`dotnet test --solution CodeCompress.slnx`)
- [x] Zero build warnings (`dotnet build CodeCompress.slnx`)
- [x] C# parser extracts 57 symbols from 8 sample files
- [x] Mixed-language tests verify parser selection by file extension
- [x] Dependency graph reflects using statement relationships

🤖 Generated with [Claude Code](https://claude.com/claude-code)