### PR TITLE
Fix query bugs, overhaul CLI, store DB in project root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,8 +44,9 @@ launchSettings.json
 *.coveragexml
 coverage/
 
-# CodeCompress runtime data
-.codecompress/
+# CodeCompress index — commit index.db, ignore WAL files
+.code-compress/index.db-wal
+.code-compress/index.db-shm
 
 # OS files
 Thumbs.db

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -327,7 +327,7 @@ The primary package is `CodeCompress.Server` — the MCP server that AI agents c
 No install needed — `dnx` downloads and runs the package in one shot:
 
 ```bash
-dnx CodeCompress.Server --yes
+dnx CodeCompress.Server
 ```
 
 MCP clients call this command as the stdio server process. See the [README](../README.md#mcp-client-configuration) for client-specific configuration examples (Claude Code, VS Code, Claude Desktop).
@@ -346,7 +346,7 @@ codecompress-server
 On native Windows (not WSL), stdio MCP servers that use `dnx` may require the `cmd /c` wrapper:
 
 ```bash
-cmd /c dnx CodeCompress.Server --yes
+cmd /c dnx CodeCompress.Server
 ```
 
 ---

--- a/src/CodeCompress.Cli/CliArgs.cs
+++ b/src/CodeCompress.Cli/CliArgs.cs
@@ -1,0 +1,79 @@
+namespace CodeCompress.Cli;
+
+internal sealed class CliArgs
+{
+    public string Command { get; }
+    public bool HelpRequested { get; }
+
+    private readonly Dictionary<string, string> _options;
+
+    private CliArgs(string command, Dictionary<string, string> options, bool helpRequested)
+    {
+        Command = command;
+        _options = options;
+        HelpRequested = helpRequested;
+    }
+
+    public string? GetOption(string name) =>
+        _options.TryGetValue(name, out var value) ? value : null;
+
+    public string RequireOption(string name) =>
+        GetOption(name) ?? throw new CliException($"Missing required option: --{name}");
+
+    public static CliArgs Parse(string[] args)
+    {
+        if (args.Length == 0)
+        {
+            return new CliArgs(string.Empty, new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase), helpRequested: true);
+        }
+
+        var command = string.Empty;
+        var options = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var helpRequested = false;
+
+        var i = 0;
+
+        // First non-option token is the command (store as-is, compare case-insensitively)
+        if (args[0].Length > 0 && args[0][0] != '-')
+        {
+            command = args[0];
+            i = 1;
+        }
+
+        while (i < args.Length)
+        {
+            var arg = args[i];
+
+            if (string.Equals(arg, "--help", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(arg, "-h", StringComparison.OrdinalIgnoreCase))
+            {
+                helpRequested = true;
+                i++;
+                continue;
+            }
+
+            if (arg.StartsWith("--", StringComparison.Ordinal) && arg.Length > 2)
+            {
+                var key = arg[2..];
+
+                if (i + 1 < args.Length && !args[i + 1].StartsWith("--", StringComparison.Ordinal))
+                {
+                    options[key] = args[i + 1];
+                    i += 2;
+                }
+                else
+                {
+                    // Boolean flag (no value)
+                    options[key] = "true";
+                    i++;
+                }
+            }
+            else
+            {
+                throw new CliException($"Unexpected argument: {arg}. Use --<option> <value> syntax.");
+            }
+        }
+
+        return new CliArgs(command, options, helpRequested);
+    }
+}

--- a/src/CodeCompress.Cli/CliException.cs
+++ b/src/CodeCompress.Cli/CliException.cs
@@ -1,0 +1,18 @@
+namespace CodeCompress.Cli;
+
+#pragma warning disable CA1515 // S3871 requires exceptions to be public; CA1515 conflicts in Exe projects
+public sealed class CliException : Exception
+#pragma warning restore CA1515
+{
+    public CliException() : base()
+    {
+    }
+
+    public CliException(string message) : base(message)
+    {
+    }
+
+    public CliException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+}

--- a/src/CodeCompress.Cli/HelpText.cs
+++ b/src/CodeCompress.Cli/HelpText.cs
@@ -1,0 +1,204 @@
+using System.Globalization;
+using System.Text;
+
+namespace CodeCompress.Cli;
+
+internal static class HelpText
+{
+    private sealed record CommandHelp(
+        string Name,
+        string Summary,
+        string Description,
+        IReadOnlyList<ParamHelp> Parameters,
+        IReadOnlyList<string> Examples);
+
+    private sealed record ParamHelp(string Name, string Description, bool Required, string? DefaultValue = null);
+
+    private static readonly IReadOnlyList<CommandHelp> Commands =
+    [
+        new("index",
+            "Index a project to build a searchable symbol database",
+            "Scans the project directory, parses all supported source files, and stores symbols\n" +
+            "in a SQLite database. Re-running performs an incremental update — only changed files\n" +
+            "are re-parsed. Must be run before any query commands.",
+            [
+                new("path", "Absolute path to the project root directory", Required: true),
+                new("language", "Filter to a specific language (e.g., luau, csharp)", Required: false),
+            ],
+            [
+                "codecompress index --path C:\\Projects\\MyGame",
+                "codecompress index --path /home/user/my-project --language luau",
+            ]),
+
+        new("outline",
+            "Show a compressed project outline with symbol signatures",
+            "Displays all indexed symbols grouped by file, kind, or directory.\n" +
+            "Useful for getting a quick overview of a codebase structure.",
+            [
+                new("path", "Absolute path to the project root directory", Required: true),
+            ],
+            [
+                "codecompress outline --path C:\\Projects\\MyGame",
+            ]),
+
+        new("get-symbol",
+            "Retrieve the full source code of a specific symbol",
+            "Looks up a symbol by its qualified name and extracts its source code using\n" +
+            "byte-offset seeking. Use 'Parent:Child' for nested symbols.",
+            [
+                new("path", "Absolute path to the project root directory", Required: true),
+                new("name", "Qualified symbol name (e.g., CombatService:ProcessAttack)", Required: true),
+            ],
+            [
+                "codecompress get-symbol --path C:\\Projects\\MyGame --name CombatService:ProcessAttack",
+                "codecompress get-symbol --path /home/user/project --name globalFunction",
+            ]),
+
+        new("search",
+            "Search the symbol index using full-text search",
+            "Searches indexed symbol names using FTS5 syntax.\n" +
+            "Supports AND, OR, NOT, quoted phrases, and prefix* matching.",
+            [
+                new("path", "Absolute path to the project root directory", Required: true),
+                new("query", "FTS5 search query (e.g., Combat*, \"process attack\")", Required: true),
+            ],
+            [
+                "codecompress search --path C:\\Projects\\MyGame --query Combat*",
+                "codecompress search --path /home/user/project --query \"process AND attack\"",
+            ]),
+
+        new("search-text",
+            "Search raw file contents using full-text search",
+            "Searches the full text of indexed files using FTS5 syntax.\n" +
+            "Use for string literals, comments, or patterns that are not symbol names.",
+            [
+                new("path", "Absolute path to the project root directory", Required: true),
+                new("query", "FTS5 search query", Required: true),
+            ],
+            [
+                "codecompress search-text --path C:\\Projects\\MyGame --query TODO",
+                "codecompress search-text --path /home/user/project --query \"error handling\"",
+            ]),
+
+        new("changes",
+            "Show what changed since a named snapshot",
+            "Compares the current index state against a previously created snapshot.\n" +
+            "Shows new, modified, and deleted files with symbol-level diffs.",
+            [
+                new("path", "Absolute path to the project root directory", Required: true),
+                new("label", "Snapshot label to compare against", Required: true),
+            ],
+            [
+                "codecompress changes --path C:\\Projects\\MyGame --label before-refactor",
+            ]),
+
+        new("snapshot",
+            "Create a named snapshot of the current index state",
+            "Saves the current file hashes and symbol state under a label.\n" +
+            "Use before making changes, then run 'changes' to see what changed.",
+            [
+                new("path", "Absolute path to the project root directory", Required: true),
+                new("label", "Human-readable label (auto-generated if omitted)", Required: false),
+            ],
+            [
+                "codecompress snapshot --path C:\\Projects\\MyGame --label before-refactor",
+                "codecompress snapshot --path /home/user/project",
+            ]),
+
+        new("file-tree",
+            "Show an annotated directory tree with file and line counts",
+            "Displays the project directory structure with file counts and total line counts\n" +
+            "per directory. Does NOT require an index — reads the filesystem directly.",
+            [
+                new("path", "Absolute path to the directory to display", Required: true),
+                new("depth", "Maximum directory depth (1-20)", Required: false, DefaultValue: "5"),
+            ],
+            [
+                "codecompress file-tree --path C:\\Projects\\MyGame",
+                "codecompress file-tree --path /home/user/project --depth 3",
+            ]),
+
+        new("deps",
+            "Show the import/require dependency graph",
+            "Displays which files depend on which, based on indexed import/require statements.\n" +
+            "Can show the full project graph or start from a specific file.",
+            [
+                new("path", "Absolute path to the project root directory", Required: true),
+                new("file", "Start from a specific file (relative path)", Required: false),
+            ],
+            [
+                "codecompress deps --path C:\\Projects\\MyGame",
+                "codecompress deps --path /home/user/project --file src/services/CombatService.luau",
+            ]),
+    ];
+
+    private static readonly Dictionary<string, CommandHelp> CommandsByName =
+        Commands.ToDictionary(c => c.Name, StringComparer.OrdinalIgnoreCase);
+
+    public static bool IsKnownCommand(string name) =>
+        CommandsByName.ContainsKey(name);
+
+    public static string FormatGeneralHelp()
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("CodeCompress CLI — Index and query code symbols");
+        sb.AppendLine();
+        sb.AppendLine("Usage: codecompress <command> [options]");
+        sb.AppendLine();
+        sb.AppendLine("Commands:");
+
+        var maxLen = Commands.Max(c => c.Name.Length);
+        foreach (var cmd in Commands)
+        {
+            sb.Append("  ");
+            sb.Append(cmd.Name.PadRight(maxLen + 2));
+            sb.AppendLine(cmd.Summary);
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("Run 'codecompress <command> --help' for details and examples.");
+        return sb.ToString();
+    }
+
+    public static string FormatCommandHelp(string commandName)
+    {
+        if (!CommandsByName.TryGetValue(commandName, out var cmd))
+        {
+            return $"Unknown command: {commandName}\n\n{FormatGeneralHelp()}";
+        }
+
+        var sb = new StringBuilder();
+        sb.AppendLine(CultureInfo.InvariantCulture, $"codecompress {cmd.Name} — {cmd.Summary}");
+        sb.AppendLine();
+        sb.AppendLine(cmd.Description);
+        sb.AppendLine();
+
+        sb.AppendLine("Options:");
+        var maxLen = cmd.Parameters.Max(p => p.Name.Length);
+        foreach (var param in cmd.Parameters)
+        {
+            sb.Append(CultureInfo.InvariantCulture, $"  --{param.Name.PadRight(maxLen + 2)}");
+            if (param.Required)
+            {
+                sb.Append("(required) ");
+            }
+
+            sb.Append(param.Description);
+            if (param.DefaultValue is not null)
+            {
+                sb.Append(CultureInfo.InvariantCulture, $" [default: {param.DefaultValue}]");
+            }
+
+            sb.AppendLine();
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("Examples:");
+        foreach (var example in cmd.Examples)
+        {
+            sb.AppendLine(CultureInfo.InvariantCulture, $"  {example}");
+        }
+
+        return sb.ToString();
+    }
+}

--- a/src/CodeCompress.Cli/Program.cs
+++ b/src/CodeCompress.Cli/Program.cs
@@ -14,13 +14,6 @@ services.AddLogging(b => b.AddConsole().SetMinimumLevel(LogLevel.Warning));
 
 using var provider = services.BuildServiceProvider();
 
-if (args.Length == 0)
-{
-    await PrintUsageAsync().ConfigureAwait(false);
-    return 1;
-}
-
-var command = args[0];
 var serializerOptions = new JsonSerializerOptions
 {
     PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
@@ -29,7 +22,33 @@ var serializerOptions = new JsonSerializerOptions
 
 try
 {
-    return await RunCommandAsync(command, args, provider, serializerOptions).ConfigureAwait(false);
+    var cli = CliArgs.Parse(args);
+
+    if (cli.Command.Length == 0)
+    {
+        await Console.Out.WriteLineAsync(HelpText.FormatGeneralHelp()).ConfigureAwait(false);
+        return 1;
+    }
+
+    if (cli.HelpRequested)
+    {
+        await Console.Out.WriteLineAsync(HelpText.FormatCommandHelp(cli.Command)).ConfigureAwait(false);
+        return 0;
+    }
+
+    if (!HelpText.IsKnownCommand(cli.Command))
+    {
+        await Console.Error.WriteLineAsync($"Unknown command: {cli.Command}").ConfigureAwait(false);
+        await Console.Out.WriteLineAsync(HelpText.FormatGeneralHelp()).ConfigureAwait(false);
+        return 1;
+    }
+
+    return await RunCommandAsync(cli, provider, serializerOptions).ConfigureAwait(false);
+}
+catch (CliException ex)
+{
+    await Console.Error.WriteLineAsync($"Error: {ex.Message}").ConfigureAwait(false);
+    return 1;
 }
 catch (Exception ex) when (ex is DirectoryNotFoundException or FileNotFoundException)
 {
@@ -43,50 +62,71 @@ catch (ArgumentException ex)
 }
 
 static async Task<int> RunCommandAsync(
-    string command,
-    string[] args,
+    CliArgs cli,
     ServiceProvider provider,
     JsonSerializerOptions serializerOptions)
 {
-    switch (command)
+    var cmd = cli.Command;
+    if (string.Equals(cmd, "index", StringComparison.OrdinalIgnoreCase))
     {
-        case "index":
-            return await IndexCommandAsync(args, provider, serializerOptions).ConfigureAwait(false);
-        case "outline":
-            return await OutlineCommandAsync(args, provider, serializerOptions).ConfigureAwait(false);
-        case "get-symbol":
-            return await GetSymbolCommandAsync(args, provider, serializerOptions).ConfigureAwait(false);
-        case "search":
-            return await SearchCommandAsync(args, provider, serializerOptions).ConfigureAwait(false);
-        case "search-text":
-            return await SearchTextCommandAsync(args, provider, serializerOptions).ConfigureAwait(false);
-        case "changes":
-            return await ChangesCommandAsync(args, provider).ConfigureAwait(false);
-        case "snapshot":
-            return await SnapshotCommandAsync(args, provider, serializerOptions).ConfigureAwait(false);
-        case "file-tree":
-            return await FileTreeCommandAsync(args, provider).ConfigureAwait(false);
-        case "deps":
-            return await DepsCommandAsync(args, provider, serializerOptions).ConfigureAwait(false);
-        default:
-            await Console.Error.WriteLineAsync($"Unknown command: {command}").ConfigureAwait(false);
-            await PrintUsageAsync().ConfigureAwait(false);
-            return 1;
+        return await IndexCommandAsync(cli, provider, serializerOptions).ConfigureAwait(false);
     }
+
+    if (string.Equals(cmd, "outline", StringComparison.OrdinalIgnoreCase))
+    {
+        return await OutlineCommandAsync(cli, provider, serializerOptions).ConfigureAwait(false);
+    }
+
+    if (string.Equals(cmd, "get-symbol", StringComparison.OrdinalIgnoreCase))
+    {
+        return await GetSymbolCommandAsync(cli, provider, serializerOptions).ConfigureAwait(false);
+    }
+
+    if (string.Equals(cmd, "search-text", StringComparison.OrdinalIgnoreCase))
+    {
+        return await SearchTextCommandAsync(cli, provider, serializerOptions).ConfigureAwait(false);
+    }
+
+    if (string.Equals(cmd, "search", StringComparison.OrdinalIgnoreCase))
+    {
+        return await SearchCommandAsync(cli, provider, serializerOptions).ConfigureAwait(false);
+    }
+
+    if (string.Equals(cmd, "changes", StringComparison.OrdinalIgnoreCase))
+    {
+        return await ChangesCommandAsync(cli, provider).ConfigureAwait(false);
+    }
+
+    if (string.Equals(cmd, "snapshot", StringComparison.OrdinalIgnoreCase))
+    {
+        return await SnapshotCommandAsync(cli, provider, serializerOptions).ConfigureAwait(false);
+    }
+
+    if (string.Equals(cmd, "file-tree", StringComparison.OrdinalIgnoreCase))
+    {
+        return await FileTreeCommandAsync(cli, provider).ConfigureAwait(false);
+    }
+
+    if (string.Equals(cmd, "deps", StringComparison.OrdinalIgnoreCase))
+    {
+        return await DepsCommandAsync(cli, provider, serializerOptions).ConfigureAwait(false);
+    }
+
+    throw new CliException($"Unknown command: {cli.Command}");
 }
 
-static async Task<int> IndexCommandAsync(string[] args, ServiceProvider provider, JsonSerializerOptions options)
+static async Task<int> IndexCommandAsync(CliArgs cli, ServiceProvider provider, JsonSerializerOptions options)
 {
-    if (args.Length < 2)
-    {
-        await Console.Error.WriteLineAsync("Usage: codecompress index <path>").ConfigureAwait(false);
-        return 1;
-    }
+    var path = cli.RequireOption("path");
+    var language = cli.GetOption("language");
 
-    var scope = await CreateProjectScopeAsync(args[1], provider).ConfigureAwait(false);
+    var scope = await CreateProjectScopeAsync(path, provider).ConfigureAwait(false);
     await using (scope.ConfigureAwait(false))
     {
-        var result = await scope.Engine.IndexProjectAsync(scope.ProjectRoot, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        var result = await scope.Engine.IndexProjectAsync(
+            scope.ProjectRoot,
+            language,
+            cancellationToken: CancellationToken.None).ConfigureAwait(false);
 
         await Console.Out.WriteLineAsync(JsonSerializer.Serialize(
             new
@@ -102,15 +142,11 @@ static async Task<int> IndexCommandAsync(string[] args, ServiceProvider provider
     }
 }
 
-static async Task<int> OutlineCommandAsync(string[] args, ServiceProvider provider, JsonSerializerOptions options)
+static async Task<int> OutlineCommandAsync(CliArgs cli, ServiceProvider provider, JsonSerializerOptions options)
 {
-    if (args.Length < 2)
-    {
-        await Console.Error.WriteLineAsync("Usage: codecompress outline <path>").ConfigureAwait(false);
-        return 1;
-    }
+    var path = cli.RequireOption("path");
 
-    var scope = await CreateProjectScopeAsync(args[1], provider).ConfigureAwait(false);
+    var scope = await CreateProjectScopeAsync(path, provider).ConfigureAwait(false);
     await using (scope.ConfigureAwait(false))
     {
         var outline = await scope.Store.GetProjectOutlineAsync(scope.RepoId, false, "file", 3).ConfigureAwait(false);
@@ -119,22 +155,19 @@ static async Task<int> OutlineCommandAsync(string[] args, ServiceProvider provid
     }
 }
 
-static async Task<int> GetSymbolCommandAsync(string[] args, ServiceProvider provider, JsonSerializerOptions options)
+static async Task<int> GetSymbolCommandAsync(CliArgs cli, ServiceProvider provider, JsonSerializerOptions options)
 {
-    if (args.Length < 3)
-    {
-        await Console.Error.WriteLineAsync("Usage: codecompress get-symbol <path> <name>").ConfigureAwait(false);
-        return 1;
-    }
+    var path = cli.RequireOption("path");
+    var name = cli.RequireOption("name");
 
-    var scope = await CreateProjectScopeAsync(args[1], provider).ConfigureAwait(false);
+    var scope = await CreateProjectScopeAsync(path, provider).ConfigureAwait(false);
     await using (scope.ConfigureAwait(false))
     {
-        var symbol = await scope.Store.GetSymbolByNameAsync(scope.RepoId, args[2]).ConfigureAwait(false);
+        var symbol = await scope.Store.GetSymbolByNameAsync(scope.RepoId, name).ConfigureAwait(false);
 
         if (symbol is null)
         {
-            await Console.Error.WriteLineAsync($"Symbol not found: {args[2]}").ConfigureAwait(false);
+            await Console.Error.WriteLineAsync($"Symbol not found: {name}").ConfigureAwait(false);
             return 1;
         }
 
@@ -143,61 +176,52 @@ static async Task<int> GetSymbolCommandAsync(string[] args, ServiceProvider prov
     }
 }
 
-static async Task<int> SearchCommandAsync(string[] args, ServiceProvider provider, JsonSerializerOptions options)
+static async Task<int> SearchCommandAsync(CliArgs cli, ServiceProvider provider, JsonSerializerOptions options)
 {
-    if (args.Length < 3)
-    {
-        await Console.Error.WriteLineAsync("Usage: codecompress search <path> <query>").ConfigureAwait(false);
-        return 1;
-    }
+    var path = cli.RequireOption("path");
+    var query = cli.RequireOption("query");
 
-    var scope = await CreateProjectScopeAsync(args[1], provider).ConfigureAwait(false);
+    var scope = await CreateProjectScopeAsync(path, provider).ConfigureAwait(false);
     await using (scope.ConfigureAwait(false))
     {
-        var results = await scope.Store.SearchSymbolsAsync(scope.RepoId, args[2], null, 50).ConfigureAwait(false);
+        var results = await scope.Store.SearchSymbolsAsync(scope.RepoId, query, null, 50).ConfigureAwait(false);
         await Console.Out.WriteLineAsync(JsonSerializer.Serialize(results, options)).ConfigureAwait(false);
         return 0;
     }
 }
 
-static async Task<int> SearchTextCommandAsync(string[] args, ServiceProvider provider, JsonSerializerOptions options)
+static async Task<int> SearchTextCommandAsync(CliArgs cli, ServiceProvider provider, JsonSerializerOptions options)
 {
-    if (args.Length < 3)
-    {
-        await Console.Error.WriteLineAsync("Usage: codecompress search-text <path> <query>").ConfigureAwait(false);
-        return 1;
-    }
+    var path = cli.RequireOption("path");
+    var query = cli.RequireOption("query");
 
-    var scope = await CreateProjectScopeAsync(args[1], provider).ConfigureAwait(false);
+    var scope = await CreateProjectScopeAsync(path, provider).ConfigureAwait(false);
     await using (scope.ConfigureAwait(false))
     {
-        var results = await scope.Store.SearchTextAsync(scope.RepoId, args[2], null, 50).ConfigureAwait(false);
+        var results = await scope.Store.SearchTextAsync(scope.RepoId, query, null, 50).ConfigureAwait(false);
         await Console.Out.WriteLineAsync(JsonSerializer.Serialize(results, options)).ConfigureAwait(false);
         return 0;
     }
 }
 
-static async Task<int> ChangesCommandAsync(string[] args, ServiceProvider provider)
+static async Task<int> ChangesCommandAsync(CliArgs cli, ServiceProvider provider)
 {
-    if (args.Length < 3)
-    {
-        await Console.Error.WriteLineAsync("Usage: codecompress changes <path> <label>").ConfigureAwait(false);
-        return 1;
-    }
+    var path = cli.RequireOption("path");
+    var label = cli.RequireOption("label");
 
-    var scope = await CreateProjectScopeAsync(args[1], provider).ConfigureAwait(false);
+    var scope = await CreateProjectScopeAsync(path, provider).ConfigureAwait(false);
     await using (scope.ConfigureAwait(false))
     {
-        var snapshot = await scope.Store.GetSnapshotByLabelAsync(scope.RepoId, args[2]).ConfigureAwait(false);
+        var snapshot = await scope.Store.GetSnapshotByLabelAsync(scope.RepoId, label).ConfigureAwait(false);
 
         if (snapshot is null)
         {
-            await Console.Error.WriteLineAsync($"Snapshot not found: {args[2]}").ConfigureAwait(false);
+            await Console.Error.WriteLineAsync($"Snapshot not found: {label}").ConfigureAwait(false);
             return 1;
         }
 
         var changedFiles = await scope.Store.GetChangedFilesAsync(scope.RepoId, snapshot.Id).ConfigureAwait(false);
-        await Console.Out.WriteLineAsync($"Changes since snapshot \"{args[2]}\":").ConfigureAwait(false);
+        await Console.Out.WriteLineAsync($"Changes since snapshot \"{label}\":").ConfigureAwait(false);
         await Console.Out.WriteLineAsync($"  New files: {changedFiles.Added.Count}").ConfigureAwait(false);
         await Console.Out.WriteLineAsync($"  Modified files: {changedFiles.Modified.Count}").ConfigureAwait(false);
         await Console.Out.WriteLineAsync($"  Deleted files: {changedFiles.Removed.Count}").ConfigureAwait(false);
@@ -212,26 +236,22 @@ static async Task<int> ChangesCommandAsync(string[] args, ServiceProvider provid
             await Console.Out.WriteLineAsync($"  ~ {file.RelativePath}").ConfigureAwait(false);
         }
 
-        foreach (var path in changedFiles.Removed)
+        foreach (var filePath in changedFiles.Removed)
         {
-            await Console.Out.WriteLineAsync($"  - {path}").ConfigureAwait(false);
+            await Console.Out.WriteLineAsync($"  - {filePath}").ConfigureAwait(false);
         }
 
         return 0;
     }
 }
 
-static async Task<int> SnapshotCommandAsync(string[] args, ServiceProvider provider, JsonSerializerOptions options)
+static async Task<int> SnapshotCommandAsync(CliArgs cli, ServiceProvider provider, JsonSerializerOptions options)
 {
-    if (args.Length < 2)
-    {
-        await Console.Error.WriteLineAsync("Usage: codecompress snapshot <path> [label]").ConfigureAwait(false);
-        return 1;
-    }
+    var path = cli.RequireOption("path");
+    var label = cli.GetOption("label")
+        ?? DateTimeOffset.UtcNow.ToString("yyyy-MM-dd-HHmmss", System.Globalization.CultureInfo.InvariantCulture);
 
-    var label = args.Length >= 3 ? args[2] : DateTimeOffset.UtcNow.ToString("yyyy-MM-dd-HHmmss", System.Globalization.CultureInfo.InvariantCulture);
-
-    var scope = await CreateProjectScopeAsync(args[1], provider).ConfigureAwait(false);
+    var scope = await CreateProjectScopeAsync(path, provider).ConfigureAwait(false);
     await using (scope.ConfigureAwait(false))
     {
         var snapshot = new CodeCompress.Core.Models.IndexSnapshot(
@@ -250,16 +270,14 @@ static async Task<int> SnapshotCommandAsync(string[] args, ServiceProvider provi
     }
 }
 
-static async Task<int> FileTreeCommandAsync(string[] args, ServiceProvider provider)
+static async Task<int> FileTreeCommandAsync(CliArgs cli, ServiceProvider provider)
 {
-    if (args.Length < 2)
-    {
-        await Console.Error.WriteLineAsync("Usage: codecompress file-tree <path>").ConfigureAwait(false);
-        return 1;
-    }
+    var path = cli.RequireOption("path");
+    var depthStr = cli.GetOption("depth");
+    var maxDepth = depthStr is not null && int.TryParse(depthStr, out var d) ? Math.Clamp(d, 1, 20) : 5;
 
     var pathValidator = provider.GetRequiredService<IPathValidator>();
-    var validatedPath = pathValidator.ValidatePath(args[1], args[1]);
+    var validatedPath = pathValidator.ValidatePath(path, path);
 
     if (!Directory.Exists(validatedPath))
     {
@@ -267,21 +285,16 @@ static async Task<int> FileTreeCommandAsync(string[] args, ServiceProvider provi
         return 1;
     }
 
-    await PrintDirectoryTreeAsync(validatedPath, validatedPath, 5, 0).ConfigureAwait(false);
+    await PrintDirectoryTreeAsync(validatedPath, validatedPath, maxDepth, 0).ConfigureAwait(false);
     return 0;
 }
 
-static async Task<int> DepsCommandAsync(string[] args, ServiceProvider provider, JsonSerializerOptions options)
+static async Task<int> DepsCommandAsync(CliArgs cli, ServiceProvider provider, JsonSerializerOptions options)
 {
-    if (args.Length < 2)
-    {
-        await Console.Error.WriteLineAsync("Usage: codecompress deps <path> [file]").ConfigureAwait(false);
-        return 1;
-    }
+    var path = cli.RequireOption("path");
+    var rootFile = cli.GetOption("file");
 
-    var rootFile = args.Length >= 3 ? args[2] : null;
-
-    var scope = await CreateProjectScopeAsync(args[1], provider).ConfigureAwait(false);
+    var scope = await CreateProjectScopeAsync(path, provider).ConfigureAwait(false);
     await using (scope.ConfigureAwait(false))
     {
         var graph = await scope.Store.GetDependencyGraphAsync(scope.RepoId, rootFile, "both", 3).ConfigureAwait(false);
@@ -349,24 +362,4 @@ static async Task PrintDirectoryTreeAsync(string rootPath, string currentPath, i
     {
         // Skip inaccessible directories
     }
-}
-
-static async Task PrintUsageAsync()
-{
-    await Console.Out.WriteLineAsync("""
-        CodeCompress CLI — Index and query code symbols
-
-        Usage: codecompress <command> [arguments]
-
-        Commands:
-          index <path>                  Index a project directory
-          outline <path>                Show project outline
-          get-symbol <path> <name>      Retrieve a specific symbol
-          search <path> <query>         Search symbols by name
-          search-text <path> <query>    Full-text search in files
-          changes <path> <label>        Show changes since snapshot
-          snapshot <path> [label]       Create a snapshot
-          file-tree <path>              Show annotated file tree
-          deps <path> [file]            Show dependency graph
-        """).ConfigureAwait(false);
 }

--- a/src/CodeCompress.Core/Indexing/IndexEngine.cs
+++ b/src/CodeCompress.Core/Indexing/IndexEngine.cs
@@ -139,6 +139,7 @@ public sealed partial class IndexEngine : IIndexEngine
         filesToParse.AddRange(changeSet.ModifiedFiles);
 
         var parseResults = new ConcurrentDictionary<string, ParseResult>(StringComparer.OrdinalIgnoreCase);
+        var fileContents = new ConcurrentDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         var totalSymbols = 0;
 
         await Parallel.ForEachAsync(
@@ -166,6 +167,7 @@ public sealed partial class IndexEngine : IIndexEngine
                     var bytes = await File.ReadAllBytesAsync(absPath, ct).ConfigureAwait(false);
                     var result = parser.Parse(relPath, bytes);
                     parseResults[relPath] = result;
+                    fileContents[relPath] = Encoding.UTF8.GetString(bytes);
                 }
                 catch (OperationCanceledException)
                 {
@@ -186,6 +188,7 @@ public sealed partial class IndexEngine : IIndexEngine
             {
                 await _symbolStore.DeleteSymbolsByFileAsync(delFile.Id).ConfigureAwait(false);
                 await _symbolStore.DeleteDependenciesByFileAsync(delFile.Id).ConfigureAwait(false);
+                await _symbolStore.DeleteFileContentAsync(delFile.RelativePath).ConfigureAwait(false);
                 await _symbolStore.DeleteFileAsync(delFile.Id).ConfigureAwait(false);
             }
         }
@@ -213,6 +216,11 @@ public sealed partial class IndexEngine : IIndexEngine
 
                     var deps = ConvertDependencies(pr.Dependencies, modFile.Id);
                     await _symbolStore.InsertDependenciesAsync(deps).ConfigureAwait(false);
+                }
+
+                if (fileContents.TryGetValue(modPath, out var modContent))
+                {
+                    await _symbolStore.UpsertFileContentAsync(modPath, modContent).ConfigureAwait(false);
                 }
             }
         }
@@ -267,6 +275,11 @@ public sealed partial class IndexEngine : IIndexEngine
 
                 var deps = ConvertDependencies(pr.Dependencies, newFile.Id);
                 await _symbolStore.InsertDependenciesAsync(deps).ConfigureAwait(false);
+            }
+
+            if (fileContents.TryGetValue(newPath, out var newContent))
+            {
+                await _symbolStore.UpsertFileContentAsync(newPath, newContent).ConfigureAwait(false);
             }
         }
 
@@ -441,8 +454,19 @@ public sealed partial class IndexEngine : IIndexEngine
     public static string ComputeRepoId(string canonicalRoot)
     {
         ArgumentNullException.ThrowIfNull(canonicalRoot);
-        var bytes = Encoding.UTF8.GetBytes(canonicalRoot.ToUpperInvariant());
-        var hash = SHA256.HashData(bytes);
+
+        // Normalize identically to SqliteConnectionFactory.ComputeRepoHash:
+        // forward-slash, trim trailing slash, case-fold for Windows.
+        var normalized = canonicalRoot
+            .Replace('\\', '/')
+            .TrimEnd('/');
+
+        if (OperatingSystem.IsWindows())
+        {
+            normalized = normalized.ToUpperInvariant();
+        }
+
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(normalized));
         return Convert.ToHexStringLower(hash);
     }
 }

--- a/src/CodeCompress.Core/Storage/ISymbolStore.cs
+++ b/src/CodeCompress.Core/Storage/ISymbolStore.cs
@@ -32,6 +32,10 @@ public interface ISymbolStore
     public Task<IndexSnapshot?> GetSnapshotByLabelAsync(string repoId, string snapshotLabel);
     public Task<IReadOnlyList<IndexSnapshot>> GetSnapshotsByRepoAsync(string repoId);
 
+    // File Content FTS
+    public Task UpsertFileContentAsync(string relativePath, string content);
+    public Task DeleteFileContentAsync(string relativePath);
+
     // Search
     public Task<IReadOnlyList<SymbolSearchResult>> SearchSymbolsAsync(string repoId, string query, string? kind, int limit);
     public Task<IReadOnlyList<TextSearchResult>> SearchTextAsync(string repoId, string query, string? glob, int limit);

--- a/src/CodeCompress.Core/Storage/SqliteConnectionFactory.cs
+++ b/src/CodeCompress.Core/Storage/SqliteConnectionFactory.cs
@@ -6,6 +6,36 @@ namespace CodeCompress.Core.Storage;
 
 public sealed class SqliteConnectionFactory : IConnectionFactory
 {
+    internal const string DbDirectoryName = ".code-compress";
+    internal const string DbFileName = "index.db";
+
+    private const string ReadmeContent =
+        """
+        # .code-compress
+
+        This directory contains the [CodeCompress](https://github.com/MCrank/code-compress) index database.
+
+        CodeCompress is an MCP server that indexes codebases and provides AI agents with compressed,
+        surgical access to code symbols — reducing token consumption by 80-90%.
+
+        ## What's in here?
+
+        - **index.db** — SQLite database containing parsed symbols, file metadata, and FTS indexes.
+        - **index.db-wal / index.db-shm** — SQLite WAL (write-ahead log) files. Safe to delete when
+          the database is not in use; they will be recreated automatically.
+
+        ## Can I commit this?
+
+        Yes. Committing `index.db` lets other developers (and CI) skip the initial full index.
+        The index is updated incrementally — only changed files are re-parsed.
+
+        Add the WAL files to `.gitignore`:
+        ```
+        .code-compress/index.db-wal
+        .code-compress/index.db-shm
+        ```
+        """;
+
     public async Task<SqliteConnection> CreateConnectionAsync(string projectRootPath)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(projectRootPath);
@@ -21,14 +51,12 @@ public sealed class SqliteConnectionFactory : IConnectionFactory
             throw new ArgumentException("Project root path must not contain path traversal.", nameof(projectRootPath));
         }
 
-        var repoHash = ComputeRepoHash(fullPath);
-
-        var dbDirectory = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-            ".codecompress");
+        var dbDirectory = Path.Combine(fullPath, DbDirectoryName);
         Directory.CreateDirectory(dbDirectory);
 
-        var dbPath = Path.Combine(dbDirectory, $"{repoHash}.db");
+        EnsureReadmeExists(dbDirectory);
+
+        var dbPath = Path.Combine(dbDirectory, DbFileName);
         var connection = new SqliteConnection($"Data Source={dbPath};Foreign Keys=True");
         await connection.OpenAsync().ConfigureAwait(false);
 
@@ -46,8 +74,22 @@ public sealed class SqliteConnectionFactory : IConnectionFactory
             .Replace('\\', '/')
             .TrimEnd('/');
 
+        if (OperatingSystem.IsWindows())
+        {
+            normalized = normalized.ToUpperInvariant();
+        }
+
         var hashBytes = SHA256.HashData(Encoding.UTF8.GetBytes(normalized));
         return Convert.ToHexStringLower(hashBytes);
+    }
+
+    private static void EnsureReadmeExists(string dbDirectory)
+    {
+        var readmePath = Path.Combine(dbDirectory, "README.md");
+        if (!File.Exists(readmePath))
+        {
+            File.WriteAllText(readmePath, ReadmeContent);
+        }
     }
 
     private static async Task ExecutePragmaAsync(SqliteConnection connection, string pragma)

--- a/src/CodeCompress.Core/Storage/SqliteSymbolStore.cs
+++ b/src/CodeCompress.Core/Storage/SqliteSymbolStore.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text;
 using System.Text.Json;
 using CodeCompress.Core.Models;
@@ -262,6 +263,50 @@ public sealed class SqliteSymbolStore : ISymbolStore
 #pragma warning restore CA2100
 
         command.Parameters.AddWithValue("@id", fileId);
+
+        await command.ExecuteNonQueryAsync().ConfigureAwait(false);
+    }
+
+    // ── File Content FTS ─────────────────────────────────────────────────
+
+    public async Task UpsertFileContentAsync(string relativePath, string content)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(relativePath);
+        ArgumentNullException.ThrowIfNull(content);
+
+        // Delete any existing entry first, then insert fresh
+        await DeleteFileContentAsync(relativePath).ConfigureAwait(false);
+
+        using var command = _connection.CreateCommand();
+
+#pragma warning disable CA2100
+        command.CommandText =
+            """
+            INSERT INTO file_content_fts (relative_path, content)
+            VALUES (@relativePath, @content)
+            """;
+#pragma warning restore CA2100
+
+        command.Parameters.AddWithValue("@relativePath", relativePath);
+        command.Parameters.AddWithValue("@content", content);
+
+        await command.ExecuteNonQueryAsync().ConfigureAwait(false);
+    }
+
+    public async Task DeleteFileContentAsync(string relativePath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(relativePath);
+
+        using var command = _connection.CreateCommand();
+
+#pragma warning disable CA2100
+        command.CommandText =
+            """
+            DELETE FROM file_content_fts WHERE relative_path = @relativePath
+            """;
+#pragma warning restore CA2100
+
+        command.Parameters.AddWithValue("@relativePath", relativePath);
 
         await command.ExecuteNonQueryAsync().ConfigureAwait(false);
     }
@@ -852,17 +897,35 @@ public sealed class SqliteSymbolStore : ISymbolStore
 
         using var command = _connection.CreateCommand();
 
-        var placeholders = new StringBuilder();
-        for (int i = 0; i < symbolNames.Count; i++)
+        // Split names into simple (unqualified) and qualified (Parent:Child / Parent.Child)
+        var conditions = new StringBuilder();
+        var paramIndex = 0;
+
+        for (var i = 0; i < symbolNames.Count; i++)
         {
             if (i > 0)
             {
-                placeholders.Append(", ");
+                conditions.Append(" OR ");
             }
 
-            var paramName = $"@p{i}";
-            placeholders.Append(paramName);
-            command.Parameters.AddWithValue(paramName, symbolNames[i]);
+            var separatorIndex = symbolNames[i].IndexOfAny(['.', ':']);
+
+            if (separatorIndex > 0 && separatorIndex < symbolNames[i].Length - 1)
+            {
+                var parentParam = $"@parent{paramIndex}";
+                var childParam = $"@child{paramIndex}";
+                conditions.Append(CultureInfo.InvariantCulture, $"(s.parent_symbol = {parentParam} AND s.name = {childParam})");
+                command.Parameters.AddWithValue(parentParam, symbolNames[i][..separatorIndex]);
+                command.Parameters.AddWithValue(childParam, symbolNames[i][(separatorIndex + 1)..]);
+            }
+            else
+            {
+                var nameParam = $"@p{paramIndex}";
+                conditions.Append(CultureInfo.InvariantCulture, $"s.name = {nameParam}");
+                command.Parameters.AddWithValue(nameParam, symbolNames[i]);
+            }
+
+            paramIndex++;
         }
 
 #pragma warning disable CA2100 // SQL is built from static literals and parameterized placeholder names only
@@ -872,7 +935,7 @@ public sealed class SqliteSymbolStore : ISymbolStore
                     s.byte_offset, s.byte_length, s.line_start, s.line_end, s.visibility, s.doc_comment
              FROM symbols s
              JOIN files f ON f.id = s.file_id
-             WHERE s.name IN ({placeholders}) AND f.repo_id = @repoId
+             WHERE ({conditions}) AND f.repo_id = @repoId
              """;
 #pragma warning restore CA2100
 

--- a/src/CodeCompress.Server/Tools/DeltaTools.cs
+++ b/src/CodeCompress.Server/Tools/DeltaTools.cs
@@ -36,10 +36,10 @@ internal sealed partial class DeltaTools
     }
 
     [McpServerTool(Name = "changes_since")]
-    [Description("Show what changed since a named snapshot: new, modified, and deleted files with symbol-level diffs.")]
+    [Description("Show what changed since a named snapshot: new, modified, and deleted files with symbol-level diffs. Call snapshot_create first to set a baseline.")]
     public async Task<string> ChangesSince(
-        [Description("Absolute path to the project root directory")] string path,
-        [Description("Label of the snapshot to compare against")] string snapshotLabel,
+        [Description("ABSOLUTE path to the project root directory — the same root used with index_project (e.g., 'C:\\Projects\\MyGame' or '/home/user/my-project'). Must NOT be a subdirectory or relative path.")] string path,
+        [Description("Label of a previously created snapshot. Available labels are returned in the error if the snapshot is not found.")] string snapshotLabel,
         CancellationToken cancellationToken = default)
     {
         string validatedPath;
@@ -194,9 +194,9 @@ internal sealed partial class DeltaTools
     }
 
     [McpServerTool(Name = "file_tree")]
-    [Description("Get an annotated directory tree with file counts and line counts per directory.")]
+    [Description("Get an annotated directory tree with file counts and line counts per directory. Does NOT require an index — reads the filesystem directly.")]
     public async Task<string> FileTree(
-        [Description("Absolute path to the project root directory")] string path,
+        [Description("ABSOLUTE path to the project root directory — the same root used with index_project (e.g., 'C:\\Projects\\MyGame' or '/home/user/my-project'). Must NOT be a subdirectory or relative path.")] string path,
         [Description("Maximum directory depth (1-20, default 5)")] int maxDepth = 5,
         CancellationToken cancellationToken = default)
     {

--- a/src/CodeCompress.Server/Tools/DependencyTools.cs
+++ b/src/CodeCompress.Server/Tools/DependencyTools.cs
@@ -35,9 +35,9 @@ internal sealed class DependencyTools
     }
 
     [McpServerTool(Name = "dependency_graph")]
-    [Description("Get the import/require dependency graph for a project or a specific file.")]
+    [Description("Get the import/require dependency graph for a project or specific file. Shows which files depend on which others.")]
     public async Task<string> DependencyGraph(
-        [Description("Absolute path to the project root directory")] string path,
+        [Description("ABSOLUTE path to the project root directory — the same root used with index_project (e.g., 'C:\\Projects\\MyGame' or '/home/user/my-project'). Must NOT be a subdirectory or relative path.")] string path,
         [Description("Start traversal from a specific file (relative path). Omit for full project graph.")] string? rootFile = null,
         [Description("Direction: dependencies (outgoing), dependents (incoming), or both")] string direction = "both",
         [Description("Maximum traversal depth (1-50). Omit for unlimited.")] int? depth = null,

--- a/src/CodeCompress.Server/Tools/IndexingTools.cs
+++ b/src/CodeCompress.Server/Tools/IndexingTools.cs
@@ -28,9 +28,9 @@ internal sealed partial class IndexingTools
     }
 
     [McpServerTool(Name = "index_project")]
-    [Description("Index a codebase to build a searchable symbol database.")]
+    [Description("Index a codebase to build a searchable symbol database. Must be called before any query tools. Re-running performs an incremental update — only changed files are re-parsed.")]
     public async Task<string> IndexProject(
-        [Description("Absolute path to the project root directory")] string path,
+        [Description("ABSOLUTE path to the project root directory — the same root used with index_project (e.g., 'C:\\Projects\\MyGame' or '/home/user/my-project'). Must NOT be a subdirectory or relative path.")] string path,
         [Description("Filter to a specific language (e.g., 'luau')")] string? language = null,
         [Description("Glob patterns for files to include")] string[]? includePatterns = null,
         [Description("Glob patterns for files to exclude")] string[]? excludePatterns = null,
@@ -77,9 +77,9 @@ internal sealed partial class IndexingTools
     }
 
     [McpServerTool(Name = "snapshot_create")]
-    [Description("Create a named snapshot of the current index state for delta queries.")]
+    [Description("Create a named snapshot of the current index state. Use before making changes, then call changes_since to see a symbol-level diff.")]
     public async Task<string> SnapshotCreate(
-        [Description("Absolute path to the project root directory")] string path,
+        [Description("ABSOLUTE path to the project root directory — the same root used with index_project (e.g., 'C:\\Projects\\MyGame' or '/home/user/my-project'). Must NOT be a subdirectory or relative path.")] string path,
         [Description("Human-readable snapshot label")] string label,
         CancellationToken cancellationToken = default)
     {
@@ -124,9 +124,9 @@ internal sealed partial class IndexingTools
     }
 
     [McpServerTool(Name = "invalidate_cache")]
-    [Description("Invalidate the index cache, forcing a full re-index on the next index_project call.")]
+    [Description("Delete the entire index for a project, forcing a full re-index on the next index_project call.")]
     public async Task<string> InvalidateCache(
-        [Description("Absolute path to the project root directory")] string path,
+        [Description("ABSOLUTE path to the project root directory — the same root used with index_project (e.g., 'C:\\Projects\\MyGame' or '/home/user/my-project'). Must NOT be a subdirectory or relative path.")] string path,
         CancellationToken cancellationToken = default)
     {
         string validatedPath;

--- a/src/CodeCompress.Server/Tools/QueryTools.cs
+++ b/src/CodeCompress.Server/Tools/QueryTools.cs
@@ -40,9 +40,9 @@ internal sealed class QueryTools
     }
 
     [McpServerTool(Name = "project_outline")]
-    [Description("Get a compressed, token-efficient overview of an entire codebase with signatures only.")]
+    [Description("Get a compressed overview of the indexed codebase showing symbol signatures grouped by file, kind, or directory. Requires index_project to have been called first.")]
     public async Task<string> ProjectOutline(
-        [Description("Absolute path to the project root directory")] string path,
+        [Description("ABSOLUTE path to the project root directory — the same root used with index_project (e.g., 'C:\\Projects\\MyGame' or '/home/user/my-project'). Must NOT be a subdirectory or relative path.")] string path,
         [Description("Include private/local symbols")] bool includePrivate = false,
         [Description("Grouping strategy: file, kind, or directory")] string groupBy = "file",
         [Description("Limit directory traversal depth (null for unlimited)")] int? maxDepth = null,
@@ -77,10 +77,10 @@ internal sealed class QueryTools
     }
 
     [McpServerTool(Name = "get_module_api")]
-    [Description("Get the full public API surface of a single module file.")]
+    [Description("Get the full public API surface of a single module file — all exported symbols, signatures, and import dependencies.")]
     public async Task<string> GetModuleApi(
-        [Description("Absolute path to the project root directory")] string path,
-        [Description("Relative path to the module file (e.g., src/services/CombatService.luau)")] string modulePath,
+        [Description("ABSOLUTE path to the project root directory — the same root used with index_project (e.g., 'C:\\Projects\\MyGame' or '/home/user/my-project'). Must NOT be a subdirectory or relative path.")] string path,
+        [Description("Relative path from the project root to the module file (e.g., 'src/services/CombatService.luau'). Forward slashes only, NOT an absolute path.")] string modulePath,
         CancellationToken cancellationToken = default)
     {
         string validatedPath;
@@ -138,10 +138,10 @@ internal sealed class QueryTools
     }
 
     [McpServerTool(Name = "get_symbol")]
-    [Description("Get the source code of a specific symbol by its qualified name using byte-offset seeking.")]
+    [Description("Retrieve the full source code of a specific symbol by its qualified name using byte-offset seeking.")]
     public async Task<string> GetSymbol(
-        [Description("Absolute path to the project root directory")] string path,
-        [Description("Fully qualified symbol name (e.g., CombatService:ProcessAttack)")] string symbolName,
+        [Description("ABSOLUTE path to the project root directory — the same root used with index_project (e.g., 'C:\\Projects\\MyGame' or '/home/user/my-project'). Must NOT be a subdirectory or relative path.")] string path,
+        [Description("Fully qualified symbol name — use 'Parent:Child' for nested symbols (e.g., 'CombatService:ProcessAttack') or just the name for top-level symbols. Use search_symbols to discover names.")] string symbolName,
         [Description("Include 5 lines of context before and after the symbol")] bool includeContext = false,
         CancellationToken cancellationToken = default)
     {
@@ -205,10 +205,10 @@ internal sealed class QueryTools
     }
 
     [McpServerTool(Name = "get_symbols")]
-    [Description("Batch retrieve source code for multiple symbols by their qualified names.")]
+    [Description("Batch retrieve source code for multiple symbols in one call. More efficient than calling get_symbol repeatedly. Maximum 50 names per call.")]
     public async Task<string> GetSymbols(
-        [Description("Absolute path to the project root directory")] string path,
-        [Description("Array of fully qualified symbol names")] string[] symbolNames,
+        [Description("ABSOLUTE path to the project root directory — the same root used with index_project (e.g., 'C:\\Projects\\MyGame' or '/home/user/my-project'). Must NOT be a subdirectory or relative path.")] string path,
+        [Description("Array of fully qualified symbol names (same format as get_symbol). Maximum 50 per call.")] string[] symbolNames,
         CancellationToken cancellationToken = default)
     {
         string validatedPath;
@@ -312,9 +312,9 @@ internal sealed class QueryTools
     }
 
     [McpServerTool(Name = "search_symbols")]
-    [Description("Search the symbol index using full-text search (supports AND, OR, NOT, prefix matching).")]
+    [Description("Search the symbol index using FTS5 full-text search. Supports AND, OR, NOT, quoted phrases, and prefix* matching.")]
     public async Task<string> SearchSymbols(
-        [Description("Absolute path to the project root directory")] string path,
+        [Description("ABSOLUTE path to the project root directory — the same root used with index_project (e.g., 'C:\\Projects\\MyGame' or '/home/user/my-project'). Must NOT be a subdirectory or relative path.")] string path,
         [Description("FTS5 search query (supports AND, OR, NOT, quoted phrases, prefix*)")] string query,
         [Description("Filter by symbol kind (function, method, class, type, interface, export, constant, module)")] string? kind = null,
         [Description("Maximum results to return (1-100)")] int limit = 20,
@@ -387,9 +387,9 @@ internal sealed class QueryTools
     }
 
     [McpServerTool(Name = "search_text")]
-    [Description("Search raw file contents using full-text search (supports AND, OR, NOT, prefix matching).")]
+    [Description("Search raw indexed file contents using FTS5 full-text search. Use for string literals, comments, or non-symbol patterns. Supports glob filtering.")]
     public async Task<string> SearchText(
-        [Description("Absolute path to the project root directory")] string path,
+        [Description("ABSOLUTE path to the project root directory — the same root used with index_project (e.g., 'C:\\Projects\\MyGame' or '/home/user/my-project'). Must NOT be a subdirectory or relative path.")] string path,
         [Description("FTS5 search query (supports AND, OR, NOT, quoted phrases, prefix*)")] string query,
         [Description("File pattern filter (e.g., *.luau, src/services/*.lua)")] string? glob = null,
         [Description("Maximum results to return (1-100)")] int limit = 20,

--- a/tests/CodeCompress.Core.Tests/Storage/SymbolStoreQueryTests.cs
+++ b/tests/CodeCompress.Core.Tests/Storage/SymbolStoreQueryTests.cs
@@ -220,6 +220,33 @@ internal sealed class SymbolStoreQueryTests
         await Assert.That(results).Count().IsEqualTo(0);
     }
 
+    [Test]
+    public async Task GetSymbolsByNamesAsyncHandlesQualifiedNames()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var (store, _) = await SeedTestDataAsync(connection).ConfigureAwait(false);
+
+        var results = await store.GetSymbolsByNamesAsync("repo1", ["MyClass:DoWork", "Initialize"]).ConfigureAwait(false);
+
+        await Assert.That(results).Count().IsEqualTo(2);
+        var names = results.Select(s => s.Name).ToList();
+        await Assert.That(names).Contains("DoWork");
+        await Assert.That(names).Contains("Initialize");
+    }
+
+    [Test]
+    public async Task GetSymbolsByNamesAsyncHandlesDotQualifiedNames()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var (store, _) = await SeedTestDataAsync(connection).ConfigureAwait(false);
+
+        var results = await store.GetSymbolsByNamesAsync("repo1", ["MyClass.DoWork"]).ConfigureAwait(false);
+
+        await Assert.That(results).Count().IsEqualTo(1);
+        await Assert.That(results[0].Name).IsEqualTo("DoWork");
+        await Assert.That(results[0].ParentSymbol).IsEqualTo("MyClass");
+    }
+
     // ── GetProjectOutlineAsync Tests ─────────────────────────────────────
 
     [Test]
@@ -537,5 +564,75 @@ internal sealed class SymbolStoreQueryTests
         await Assert.That(changes.Added).Count().IsEqualTo(0);
         await Assert.That(changes.Modified).Count().IsEqualTo(0);
         await Assert.That(changes.Removed).Count().IsEqualTo(0);
+    }
+
+    // ── File Content FTS Tests ───────────────────────────────────────────
+
+    [Test]
+    public async Task UpsertFileContentMakesContentSearchable()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var (store, _) = await SeedTestDataAsync(connection).ConfigureAwait(false);
+
+        await store.UpsertFileContentAsync("src/main.luau", "local function Initialize()\n  print('hello world')\nend").ConfigureAwait(false);
+
+        var results = await store.SearchTextAsync("repo1", "hello", null, 10).ConfigureAwait(false);
+
+        await Assert.That(results.Count).IsGreaterThan(0);
+        await Assert.That(results[0].FilePath).IsEqualTo("src/main.luau");
+    }
+
+    [Test]
+    public async Task UpsertFileContentReplacesExistingContent()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var (store, _) = await SeedTestDataAsync(connection).ConfigureAwait(false);
+
+        await store.UpsertFileContentAsync("src/main.luau", "old content alpha").ConfigureAwait(false);
+        await store.UpsertFileContentAsync("src/main.luau", "new content beta").ConfigureAwait(false);
+
+        var oldResults = await store.SearchTextAsync("repo1", "alpha", null, 10).ConfigureAwait(false);
+        var newResults = await store.SearchTextAsync("repo1", "beta", null, 10).ConfigureAwait(false);
+
+        await Assert.That(oldResults).Count().IsEqualTo(0);
+        await Assert.That(newResults.Count).IsGreaterThan(0);
+    }
+
+    [Test]
+    public async Task DeleteFileContentRemovesFromSearch()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var (store, _) = await SeedTestDataAsync(connection).ConfigureAwait(false);
+
+        await store.UpsertFileContentAsync("src/main.luau", "searchable content gamma").ConfigureAwait(false);
+        await store.DeleteFileContentAsync("src/main.luau").ConfigureAwait(false);
+
+        var results = await store.SearchTextAsync("repo1", "gamma", null, 10).ConfigureAwait(false);
+
+        await Assert.That(results).Count().IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task SearchTextAsyncReturnsEmptyForUnindexedContent()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var (store, _) = await SeedTestDataAsync(connection).ConfigureAwait(false);
+
+        var results = await store.SearchTextAsync("repo1", "nonexistent", null, 10).ConfigureAwait(false);
+
+        await Assert.That(results).Count().IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task SearchTextAsyncFiltersbyRepoViaFileJoin()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var (store, _) = await SeedTestDataAsync(connection).ConfigureAwait(false);
+
+        await store.UpsertFileContentAsync("src/main.luau", "unique token zeta").ConfigureAwait(false);
+
+        var results = await store.SearchTextAsync("nonexistent-repo", "zeta", null, 10).ConfigureAwait(false);
+
+        await Assert.That(results).Count().IsEqualTo(0);
     }
 }

--- a/tests/CodeCompress.Integration.Tests/EndToEndTests.cs
+++ b/tests/CodeCompress.Integration.Tests/EndToEndTests.cs
@@ -404,6 +404,49 @@ internal sealed class EndToEndTests : IDisposable
         await Assert.That(retrieved!.FileHashes).IsNotEqualTo(string.Empty);
     }
 
+    // ── Search Text (File Content FTS) Tests ───────────────────────────
+
+    [Test]
+    public async Task SearchTextReturnsResultsAfterIndexing()
+    {
+        await IndexSampleProjectAsync().ConfigureAwait(false);
+
+        var results = await _store.SearchTextAsync(_repoId, "CombatService", null, 10).ConfigureAwait(false);
+
+        await Assert.That(results.Count).IsGreaterThan(0);
+    }
+
+    [Test]
+    public async Task SearchTextFindsStringLiteralsInFileContent()
+    {
+        await IndexSampleProjectAsync().ConfigureAwait(false);
+
+        // Search for a keyword that appears in file content but may not be a symbol name
+        var results = await _store.SearchTextAsync(_repoId, "function", null, 50).ConfigureAwait(false);
+
+        await Assert.That(results.Count).IsGreaterThan(0);
+    }
+
+    [Test]
+    public async Task SearchTextReturnsEmptyForNonexistentContent()
+    {
+        await IndexSampleProjectAsync().ConfigureAwait(false);
+
+        var results = await _store.SearchTextAsync(_repoId, "zzz_nonexistent_token_xyz", null, 10).ConfigureAwait(false);
+
+        await Assert.That(results).Count().IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task SearchTextReturnsEmptyForWrongRepo()
+    {
+        await IndexSampleProjectAsync().ConfigureAwait(false);
+
+        var results = await _store.SearchTextAsync("wrong-repo-id", "CombatService", null, 10).ConfigureAwait(false);
+
+        await Assert.That(results).Count().IsEqualTo(0);
+    }
+
     // ── Helpers ──────────────────────────────────────────────────────────
 
     private async Task IndexSampleProjectAsync()


### PR DESCRIPTION
## Summary

- **Fix repo hash mismatch** — unified path normalization and case-folding between `IndexEngine.ComputeRepoId` and `SqliteConnectionFactory.ComputeRepoHash`, resolving query tools returning empty results after successful indexing
- **Fix `search_text` returning 0 results** — populate `file_content_fts` table during indexing via new `UpsertFileContentAsync`/`DeleteFileContentAsync` store methods
- **Fix `get_symbols` batch lookup** — handle `Parent:Child` and `Parent.Child` qualified name formats in `GetSymbolsByNamesAsync`
- **Store DB in project root** — move SQLite database from `~/.codecompress/{hash}.db` to `{projectRoot}/.code-compress/index.db` so it can be committed to the repo; auto-generate a README.md explaining the directory
- **Overhaul CLI** — replace positional args with `--option value` syntax, add rich help text with descriptions and examples per command
- **Improve MCP tool descriptions** — make path parameter requirements explicit to prevent agents from passing sub-paths instead of absolute project roots
- **Update `.gitignore`** — ignore WAL/SHM files, allow committing `index.db`

## Test plan

- [x] All 420 tests pass (269 Core + 117 Server + 34 Integration)
- [x] Build succeeds with 0 warnings in Release mode
- [x] New unit tests for file content FTS (upsert, delete, search, repo filtering)
- [x] New unit tests for qualified name batch lookups (colon and dot separators)
- [x] New integration tests for search_text end-to-end flow
- [x] Live MCP server testing confirmed query tools return results after indexing

🤖 Generated with [Claude Code](https://claude.com/claude-code)