### PR TITLE
Fix kind filter case-sensitivity and C# parser gaps

### DIFF
--- a/src/CodeCompress.Core/Parsers/CSharpParser.cs
+++ b/src/CodeCompress.Core/Parsers/CSharpParser.cs
@@ -20,10 +20,10 @@ public sealed partial class CSharpParser : ILanguageParser
     [GeneratedRegex(@"^\s*namespace\s+([\w.]+)\s*;")]
     private static partial Regex FileScopedNamespacePattern();
 
-    [GeneratedRegex(@"^\s*namespace\s+([\w.]+)\s*$")]
+    [GeneratedRegex(@"^\s*namespace\s+([\w.]+)\s*(?:\{.*)?$")]
     private static partial Regex BlockScopedNamespacePattern();
 
-    [GeneratedRegex(@"^\s*((?:(?:public|internal|private|protected|static|abstract|sealed|partial|readonly|file|required|new)\s+)*)(?:(class|interface|struct)\s+|(record)\s+(?:(class|struct)\s+)?)([\w]+)\s*(<[^>]+>)?\s*(.*)$")]
+    [GeneratedRegex(@"^\s*((?:(?:public|internal|private|protected|static|abstract|sealed|partial|readonly|file|required|new)\s+)*)(?:(class|interface|struct)\s+|(record)\s+(?:(class|struct)\s+)?)([\w]+)\s*(.*)$")]
     private static partial Regex TypeDeclarationPattern();
 
     [GeneratedRegex(@"^\s*((?:(?:public|internal|private|protected|static|abstract|sealed|partial|readonly|file|required|new)\s+)*)enum\s+(\w+)\s*(.*)$")]
@@ -798,11 +798,13 @@ public sealed partial class CSharpParser : ILanguageParser
 
         var docComment = BuildDocComment(docCommentLines);
         var currentDepth = GetCurrentBraceDepth(parentStack);
+        var namespaceName = match.Groups[1].Value;
+        var signature = $"namespace {namespaceName}";
 
         parentStack.Add(new PendingType(
-            Name: match.Groups[1].Value,
+            Name: namespaceName,
             Kind: SymbolKind.Module,
-            Signature: trimmed,
+            Signature: signature,
             ParentName: null,
             ByteOffset: byteOffset,
             LineStart: lineNumber,
@@ -885,8 +887,10 @@ public sealed partial class CSharpParser : ILanguageParser
         var recordKeyword = match.Groups[3].Value;
         var recordSubKeyword = match.Groups[4].Value;
         var name = match.Groups[5].Value;
-        var genericParams = match.Groups[6].Value;
-        var rest = match.Groups[7].Value.Trim();
+        var restRaw = match.Groups[6].Value.Trim();
+
+        // Extract generic parameters using balanced angle-bracket matching
+        var (genericParams, rest) = ExtractGenericParameters(restRaw);
 
         SymbolKind kind;
         string keyword;
@@ -1160,6 +1164,34 @@ public sealed partial class CSharpParser : ILanguageParser
         }
 
         return -1;
+    }
+
+    private static (string? GenericPart, string Remainder) ExtractGenericParameters(string text)
+    {
+        if (text.Length == 0 || text[0] != '<')
+        {
+            return (null, text);
+        }
+
+        var depth = 0;
+        for (var i = 0; i < text.Length; i++)
+        {
+            if (text[i] == '<')
+            {
+                depth++;
+            }
+            else if (text[i] == '>')
+            {
+                depth--;
+            }
+
+            if (depth == 0)
+            {
+                return (text[..(i + 1)], text[(i + 1)..].TrimStart());
+            }
+        }
+
+        return (null, text); // Unbalanced — treat as no generics
     }
 
     private static int FindSignatureEnd(string text)

--- a/src/CodeCompress.Server/Tools/QueryTools.cs
+++ b/src/CodeCompress.Server/Tools/QueryTools.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Globalization;
 using System.Text;
 using System.Text.Json;
+using CodeCompress.Core.Models;
 using CodeCompress.Core.Validation;
 using CodeCompress.Server.Sanitization;
 using CodeCompress.Server.Scoping;
@@ -335,9 +336,18 @@ internal sealed class QueryTools
             return SerializeError("Search query cannot be empty", "EMPTY_QUERY");
         }
 
-        if (kind is not null && !ValidSymbolKinds.Contains(kind))
+        if (kind is not null)
         {
-            return SerializeError("Invalid symbol kind. Must be one of: function, method, type, class, interface, export, constant, module", "INVALID_KIND");
+            if (!ValidSymbolKinds.Contains(kind))
+            {
+                return SerializeError("Invalid symbol kind. Must be one of: function, method, type, class, interface, export, constant, module", "INVALID_KIND");
+            }
+
+            // Normalize to PascalCase to match DB storage (SymbolKind.ToString())
+            if (Enum.TryParse<SymbolKind>(kind, ignoreCase: true, out var parsedKind))
+            {
+                kind = parsedKind.ToString();
+            }
         }
 
         var clampedLimit = Math.Clamp(limit, 1, 100);

--- a/tests/CodeCompress.Core.Tests/Parsers/CSharpParserTests.cs
+++ b/tests/CodeCompress.Core.Tests/Parsers/CSharpParserTests.cs
@@ -1162,6 +1162,281 @@ internal sealed class CSharpParserTests
         await Assert.That(method.Visibility).IsEqualTo(Visibility.Private);
     }
 
+    // ── Block-scoped namespace with brace on same line ─────────
+
+    [Test]
+    public async Task BlockScopedNamespaceWithBraceOnSameLine()
+    {
+        var source = """
+            namespace Foo.Bar {
+              public class Baz { }
+            }
+            """;
+
+        var result = Parse(source);
+
+        var ns = result.Symbols.First(s => s.Kind == SymbolKind.Module);
+        await Assert.That(ns.Name).IsEqualTo("Foo.Bar");
+        await Assert.That(ns.Signature).IsEqualTo("namespace Foo.Bar");
+
+        var cls = result.Symbols.First(s => s.Kind == SymbolKind.Class);
+        await Assert.That(cls.Name).IsEqualTo("Baz");
+    }
+
+    [Test]
+    public async Task BlockScopedNamespaceWithBraceNoSpace()
+    {
+        var source = """
+            namespace Foo.Bar{
+            }
+            """;
+
+        var result = Parse(source);
+
+        var ns = result.Symbols.First(s => s.Kind == SymbolKind.Module);
+        await Assert.That(ns.Name).IsEqualTo("Foo.Bar");
+    }
+
+    // ── Nested generic type parameters ──────────────────────────
+
+    [Test]
+    public async Task NestedGenericTypeParametersExtracted()
+    {
+        var source = """
+            public class Repo<Dictionary<string, int>>
+            {
+            }
+            """;
+
+        var result = Parse(source);
+
+        var cls = result.Symbols.First(s => s.Kind == SymbolKind.Class);
+        await Assert.That(cls.Name).IsEqualTo("Repo");
+        await Assert.That(cls.Signature).IsEqualTo("public class Repo<Dictionary<string, int>>");
+    }
+
+    [Test]
+    public async Task DeeplyNestedGenericsExtracted()
+    {
+        var source = """
+            public class Cache<Dict<string, List<int>>>
+            {
+            }
+            """;
+
+        var result = Parse(source);
+
+        var cls = result.Symbols.First(s => s.Kind == SymbolKind.Class);
+        await Assert.That(cls.Name).IsEqualTo("Cache");
+        await Assert.That(cls.Signature).IsEqualTo("public class Cache<Dict<string, List<int>>>");
+    }
+
+    [Test]
+    public async Task GenericWithNestedGenericsAndBaseType()
+    {
+        var source = """
+            public class Foo<Dict<string, int>> : IBar
+            {
+            }
+            """;
+
+        var result = Parse(source);
+
+        var cls = result.Symbols.First(s => s.Kind == SymbolKind.Class);
+        await Assert.That(cls.Name).IsEqualTo("Foo");
+        await Assert.That(cls.Signature).IsEqualTo("public class Foo<Dict<string, int>> : IBar");
+    }
+
+    // ── Extension method tests ──────────────────────────────────
+
+    [Test]
+    public async Task ExtensionMethodWithGenericReturnType()
+    {
+        var source = """
+            public static class Extensions
+            {
+                public static IServiceCollection AddFoo(this IServiceCollection services)
+                {
+                    return services;
+                }
+            }
+            """;
+
+        var result = Parse(source);
+
+        var method = result.Symbols.First(s => s.Kind == SymbolKind.Method);
+        await Assert.That(method.Name).IsEqualTo("AddFoo");
+        await Assert.That(method.ParentSymbol).IsEqualTo("Extensions");
+        await Assert.That(method.Signature).IsEqualTo("public static IServiceCollection AddFoo(this IServiceCollection services)");
+    }
+
+    [Test]
+    public async Task MultipleExtensionMethodsInStaticClass()
+    {
+        var source = """
+            public static class Extensions
+            {
+                public static void Foo(this string s) { }
+                public static void Bar(this string s) { }
+                public static void Baz(this string s) { }
+            }
+            """;
+
+        var result = Parse(source);
+
+        var methods = result.Symbols.Where(s => s.Kind == SymbolKind.Method).ToList();
+        await Assert.That(methods).Count().IsEqualTo(3);
+        await Assert.That(methods[0].ParentSymbol).IsEqualTo("Extensions");
+        await Assert.That(methods[1].ParentSymbol).IsEqualTo("Extensions");
+        await Assert.That(methods[2].ParentSymbol).IsEqualTo("Extensions");
+    }
+
+    [Test]
+    public async Task ExtensionMethodWithGenericConstraints()
+    {
+        var source = """
+            public static class Extensions
+            {
+                public static T Find<T>(this IQueryable<T> query) where T : class
+                {
+                    return default;
+                }
+            }
+            """;
+
+        var result = Parse(source);
+
+        var method = result.Symbols.First(s => s.Kind == SymbolKind.Method);
+        await Assert.That(method.Name).IsEqualTo("Find");
+        await Assert.That(method.Signature).IsEqualTo("public static T Find<T>(this IQueryable<T> query) where T : class");
+    }
+
+    [Test]
+    public async Task ExtensionMethodWithAttributes()
+    {
+        var source = """
+            public static class Extensions
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                public static int Count(this IEnumerable<int> source)
+                {
+                    return 0;
+                }
+            }
+            """;
+
+        var result = Parse(source);
+
+        var method = result.Symbols.First(s => s.Kind == SymbolKind.Method);
+        await Assert.That(method.Name).IsEqualTo("Count");
+    }
+
+    // ── Additional parser robustness tests ──────────────────────
+
+    [Test]
+    public async Task AbstractClassWithGenericBase()
+    {
+        var source = """
+            public abstract class BaseEntity<TId> where TId : struct
+            {
+            }
+            """;
+
+        var result = Parse(source);
+
+        var cls = result.Symbols.First(s => s.Kind == SymbolKind.Class);
+        await Assert.That(cls.Name).IsEqualTo("BaseEntity");
+        await Assert.That(cls.Signature).IsEqualTo("public abstract class BaseEntity<TId> where TId : struct");
+    }
+
+    [Test]
+    public async Task PartialClassMultipleFiles()
+    {
+        var source1 = """
+            public partial class Foo
+            {
+                public void A() { }
+            }
+            """;
+
+        var source2 = """
+            public partial class Foo
+            {
+                public void B() { }
+            }
+            """;
+
+        var result1 = Parse(source1);
+        var result2 = Parse(source2);
+
+        var cls1 = result1.Symbols.First(s => s.Kind == SymbolKind.Class);
+        var cls2 = result2.Symbols.First(s => s.Kind == SymbolKind.Class);
+        await Assert.That(cls1.Name).IsEqualTo("Foo");
+        await Assert.That(cls2.Name).IsEqualTo("Foo");
+    }
+
+    [Test]
+    public async Task StaticClassWithMethods()
+    {
+        var source = """
+            public static class Extensions
+            {
+                public static void Foo() { }
+            }
+            """;
+
+        var result = Parse(source);
+
+        var cls = result.Symbols.First(s => s.Kind == SymbolKind.Class);
+        await Assert.That(cls.Name).IsEqualTo("Extensions");
+
+        var method = result.Symbols.First(s => s.Kind == SymbolKind.Method);
+        await Assert.That(method.Name).IsEqualTo("Foo");
+        await Assert.That(method.ParentSymbol).IsEqualTo("Extensions");
+    }
+
+    [Test]
+    public async Task SealedAbstractStaticModifierCombinations()
+    {
+        var source = """
+            public sealed class A { }
+            public abstract class B { }
+            public static class C { }
+            internal sealed class D { }
+            """;
+
+        var result = Parse(source);
+
+        var classes = result.Symbols.Where(s => s.Kind == SymbolKind.Class).ToList();
+        await Assert.That(classes).Count().IsEqualTo(4);
+        await Assert.That(classes[0].Name).IsEqualTo("A");
+        await Assert.That(classes[1].Name).IsEqualTo("B");
+        await Assert.That(classes[2].Name).IsEqualTo("C");
+        await Assert.That(classes[3].Name).IsEqualTo("D");
+    }
+
+    [Test]
+    public async Task RecordWithBodyAndMethods()
+    {
+        var source = """
+            public record Foo(int X)
+            {
+                public int Double() => X * 2;
+            }
+            """;
+
+        var result = Parse(source);
+
+        var rec = result.Symbols.First(s => s.Name == "Foo");
+        await Assert.That(rec.Kind).IsEqualTo(SymbolKind.Class);
+
+        var method = result.Symbols.First(s => s.Kind == SymbolKind.Method);
+        await Assert.That(method.Name).IsEqualTo("Double");
+        await Assert.That(method.ParentSymbol).IsEqualTo("Foo");
+    }
+
+    // ── Complex real-world file ─────────────────────────────────
+
     [Test]
     public async Task ComplexRealWorldFileAllSymbolsExtracted()
     {

--- a/tests/CodeCompress.Server.Tests/Tools/QueryToolsTests.cs
+++ b/tests/CodeCompress.Server.Tests/Tools/QueryToolsTests.cs
@@ -787,7 +787,7 @@ internal sealed class QueryToolsTests
         {
             new(CreateSymbol(1, 1, "ProcessAttack", "Method", "function CombatService:ProcessAttack()", parent: "CombatService"), "src/services/CombatService.luau", 1.0),
         };
-        _store.SearchSymbolsAsync("test-repo-id", Arg.Any<string>(), "method", Arg.Any<int>()).Returns(searchResults);
+        _store.SearchSymbolsAsync("test-repo-id", Arg.Any<string>(), "Method", Arg.Any<int>()).Returns(searchResults);
 
         var result = await _tools.SearchSymbols("/valid/path", "attack", kind: "method").ConfigureAwait(false);
 
@@ -796,7 +796,43 @@ internal sealed class QueryToolsTests
         await Assert.That(root.GetProperty("total_matches").GetInt32()).IsEqualTo(1);
 
         await _store.Received(1).SearchSymbolsAsync(
-            "test-repo-id", Arg.Any<string>(), "method", Arg.Any<int>()).ConfigureAwait(false);
+            "test-repo-id", Arg.Any<string>(), "Method", Arg.Any<int>()).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task SearchSymbolsKindNormalizedToPascalCase()
+    {
+        _store.SearchSymbolsAsync("test-repo-id", Arg.Any<string>(), "Class", Arg.Any<int>())
+            .Returns(new List<SymbolSearchResult>());
+
+        await _tools.SearchSymbols("/valid/path", "WorkItem", kind: "class").ConfigureAwait(false);
+
+        await _store.Received(1).SearchSymbolsAsync(
+            "test-repo-id", Arg.Any<string>(), "Class", Arg.Any<int>()).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task SearchSymbolsKindUppercaseNormalized()
+    {
+        _store.SearchSymbolsAsync("test-repo-id", Arg.Any<string>(), "Class", Arg.Any<int>())
+            .Returns(new List<SymbolSearchResult>());
+
+        await _tools.SearchSymbols("/valid/path", "WorkItem", kind: "CLASS").ConfigureAwait(false);
+
+        await _store.Received(1).SearchSymbolsAsync(
+            "test-repo-id", Arg.Any<string>(), "Class", Arg.Any<int>()).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task SearchSymbolsKindMixedCaseNormalized()
+    {
+        _store.SearchSymbolsAsync("test-repo-id", Arg.Any<string>(), "Class", Arg.Any<int>())
+            .Returns(new List<SymbolSearchResult>());
+
+        await _tools.SearchSymbols("/valid/path", "WorkItem", kind: "cLaSs").ConfigureAwait(false);
+
+        await _store.Received(1).SearchSymbolsAsync(
+            "test-repo-id", Arg.Any<string>(), "Class", Arg.Any<int>()).ConfigureAwait(false);
     }
 
     [Test]


### PR DESCRIPTION
## Summary
Closes #20

- **Kind filter fix:** `search_symbols` with `kind: "class"` (lowercase) now correctly matches DB-stored PascalCase values (`"Class"`) by normalizing via `Enum.TryParse` at the input boundary
- **Namespace regex fix:** Block-scoped namespaces with brace on the same line (`namespace Foo.Bar {`) are now recognized
- **Nested generics fix:** Replaced simple `<[^>]+>` regex capture with a balanced angle-bracket helper, so types like `Repository<Dictionary<string, int>>` have complete signatures
- **17 new tests** covering kind normalization (3), namespace edge cases (2), nested generics (3), extension methods (4), and parser robustness (5)

## Test plan
- [x] `dotnet build CodeCompress.slnx` — zero warnings
- [x] `dotnet test --solution CodeCompress.slnx` — 437 tests pass (was 420)
- [ ] Manual: index a .NET project, call `search_symbols` with `kind: "class"` — should return results
- [ ] Manual: verify nested generic signatures are complete in `project_outline`

🤖 Generated with [Claude Code](https://claude.com/claude-code)