### PR TITLE
Add pathFilter parameter to project_outline tool

### DIFF
--- a/src/CodeCompress.Core/Storage/ISymbolStore.cs
+++ b/src/CodeCompress.Core/Storage/ISymbolStore.cs
@@ -45,7 +45,7 @@ public interface ISymbolStore
     public Task<IReadOnlyList<Symbol>> GetSymbolsByNamesAsync(string repoId, IReadOnlyList<string> symbolNames);
 
     // Aggregation
-    public Task<ProjectOutline> GetProjectOutlineAsync(string repoId, bool includePrivate, string groupBy, int maxDepth);
+    public Task<ProjectOutline> GetProjectOutlineAsync(string repoId, bool includePrivate, string groupBy, int maxDepth, string? pathFilter = null);
     public Task<ModuleApi> GetModuleApiAsync(string repoId, string filePath);
     public Task<DependencyGraph> GetDependencyGraphAsync(string repoId, string? rootFile, string direction, int depth);
     public Task<ChangedFilesResult> GetChangedFilesAsync(string repoId, long snapshotId);

--- a/src/CodeCompress.Core/Storage/SqliteSymbolStore.cs
+++ b/src/CodeCompress.Core/Storage/SqliteSymbolStore.cs
@@ -966,7 +966,7 @@ public sealed class SqliteSymbolStore : ISymbolStore
 
     // ── Aggregation ─────────────────────────────────────────────────────
 
-    public async Task<ProjectOutline> GetProjectOutlineAsync(string repoId, bool includePrivate, string groupBy, int maxDepth)
+    public async Task<ProjectOutline> GetProjectOutlineAsync(string repoId, bool includePrivate, string groupBy, int maxDepth, string? pathFilter = null)
     {
         ArgumentNullException.ThrowIfNull(repoId);
         ArgumentNullException.ThrowIfNull(groupBy);
@@ -991,6 +991,11 @@ public sealed class SqliteSymbolStore : ISymbolStore
             sql.Append(" AND s.visibility != 'Private'");
         }
 
+        if (pathFilter is not null)
+        {
+            sql.Append(" AND f.relative_path LIKE @pathPrefix || '%'");
+        }
+
         sql.Append(" ORDER BY f.relative_path, s.line_start");
 
 #pragma warning disable CA2100 // SQL is built from static literals and parameterized placeholders only
@@ -998,6 +1003,12 @@ public sealed class SqliteSymbolStore : ISymbolStore
 #pragma warning restore CA2100
 
         command.Parameters.AddWithValue("@repoId", repoId);
+
+        if (pathFilter is not null)
+        {
+            var prefix = pathFilter.EndsWith('/') ? pathFilter : pathFilter + "/";
+            command.Parameters.AddWithValue("@pathPrefix", prefix);
+        }
 
         using var reader = await command.ExecuteReaderAsync().ConfigureAwait(false);
 

--- a/src/CodeCompress.Core/Validation/PathValidator.cs
+++ b/src/CodeCompress.Core/Validation/PathValidator.cs
@@ -99,6 +99,50 @@ public static class PathValidator
         }
     }
 
+    /// <summary>
+    /// Validates a path filter prefix used for scoping queries to a subdirectory.
+    /// Unlike ValidatePath/ValidateRelativePath, this is not a filesystem path —
+    /// it's a prefix match against stored relative_path values.
+    /// Returns the normalized, sanitized prefix.
+    /// </summary>
+    public static string ValidatePathFilter(string pathFilter)
+    {
+        ValidateInputNotEmpty(pathFilter, nameof(pathFilter));
+        RejectNullBytes(pathFilter, nameof(pathFilter));
+
+        // Normalize backslashes to forward slashes
+        var normalized = pathFilter.Replace('\\', '/');
+
+        // Trim whitespace
+        normalized = normalized.Trim();
+
+        // Reject absolute paths
+        if (normalized.StartsWith('/') || (normalized.Length >= 2 && normalized[1] == ':'))
+        {
+            throw new ArgumentException("Path filter must be a relative path.", nameof(pathFilter));
+        }
+
+        // Reject parent traversal
+        if (normalized.Split('/').Any(segment => segment == ".."))
+        {
+            throw new ArgumentException("Path filter must not contain parent directory traversal.", nameof(pathFilter));
+        }
+
+        // Strip LIKE wildcards to prevent unintended pattern matching
+        normalized = normalized.Replace("%", string.Empty, StringComparison.Ordinal)
+                               .Replace("_", string.Empty, StringComparison.Ordinal);
+
+        // Strip trailing slash
+        normalized = normalized.TrimEnd('/');
+
+        if (string.IsNullOrWhiteSpace(normalized))
+        {
+            throw new ArgumentException("Path filter is empty after sanitization.", nameof(pathFilter));
+        }
+
+        return normalized;
+    }
+
     private static void ValidateInputNotEmpty(string value, string paramName)
     {
         if (string.IsNullOrWhiteSpace(value))

--- a/src/CodeCompress.Server/Tools/QueryTools.cs
+++ b/src/CodeCompress.Server/Tools/QueryTools.cs
@@ -47,6 +47,7 @@ internal sealed class QueryTools
         [Description("Include private/local symbols")] bool includePrivate = false,
         [Description("Grouping strategy: file, kind, or directory")] string groupBy = "file",
         [Description("Limit directory traversal depth (null for unlimited)")] int? maxDepth = null,
+        [Description("Filter outline to files under this relative directory path (e.g., 'src/Core/Models'). Optional.")] string? pathFilter = null,
         CancellationToken cancellationToken = default)
     {
         string validatedPath;
@@ -64,6 +65,19 @@ internal sealed class QueryTools
             return SerializeError("Invalid group_by value. Must be one of: file, kind, directory", "INVALID_GROUP_BY");
         }
 
+        string? validatedPathFilter = null;
+        if (pathFilter is not null)
+        {
+            try
+            {
+                validatedPathFilter = PathValidator.ValidatePathFilter(pathFilter);
+            }
+            catch (ArgumentException)
+            {
+                return SerializeError("Invalid path filter", "INVALID_PATH_FILTER");
+            }
+        }
+
         var scope = await _scopeFactory.CreateAsync(validatedPath, cancellationToken).ConfigureAwait(false);
         await using (scope.ConfigureAwait(false))
         {
@@ -71,7 +85,8 @@ internal sealed class QueryTools
                 scope.RepoId,
                 includePrivate,
                 groupBy,
-                maxDepth ?? 0).ConfigureAwait(false);
+                maxDepth ?? 0,
+                validatedPathFilter).ConfigureAwait(false);
 
             return FormatOutline(outline);
         }

--- a/tests/CodeCompress.Core.Tests/Storage/SymbolStoreQueryTests.cs
+++ b/tests/CodeCompress.Core.Tests/Storage/SymbolStoreQueryTests.cs
@@ -247,6 +247,127 @@ internal sealed class SymbolStoreQueryTests
         await Assert.That(results[0].ParentSymbol).IsEqualTo("MyClass");
     }
 
+    // ── GetProjectOutlineAsync PathFilter Tests ─────────────────────────
+
+    private static async Task<SqliteSymbolStore> SeedMultiFileDataAsync(SqliteConnection connection)
+    {
+        var store = new SqliteSymbolStore(connection);
+        var repo = new Repository("repo1", "/test/path", "TestProject", "luau", 1000, 0, 0);
+        await store.UpsertRepositoryAsync(repo).ConfigureAwait(false);
+
+        var file1 = new FileRecord(0, "repo1", "src/services/Combat.luau", "hash1", 512, 20, 1000, 1000);
+        var file2 = new FileRecord(0, "repo1", "src/utils/Math.luau", "hash2", 256, 10, 1000, 1000);
+        var file3 = new FileRecord(0, "repo1", "src/Core/Models/Foo.luau", "hash3", 128, 5, 1000, 1000);
+        var file4 = new FileRecord(0, "repo1", "src/Core/Services/Bar.luau", "hash4", 128, 5, 1000, 1000);
+        var file5 = new FileRecord(0, "repo1", "src/servicesExtra/Bonus.luau", "hash5", 128, 5, 1000, 1000);
+        await store.InsertFilesAsync([file1, file2, file3, file4, file5]).ConfigureAwait(false);
+
+        var f1 = await store.GetFileByPathAsync("repo1", "src/services/Combat.luau").ConfigureAwait(false);
+        var f2 = await store.GetFileByPathAsync("repo1", "src/utils/Math.luau").ConfigureAwait(false);
+        var f3 = await store.GetFileByPathAsync("repo1", "src/Core/Models/Foo.luau").ConfigureAwait(false);
+        var f4 = await store.GetFileByPathAsync("repo1", "src/Core/Services/Bar.luau").ConfigureAwait(false);
+        var f5 = await store.GetFileByPathAsync("repo1", "src/servicesExtra/Bonus.luau").ConfigureAwait(false);
+
+        await store.InsertSymbolsAsync([
+            new Symbol(0, f1!.Id, "Attack", "Function", "function Attack()", null, 0, 50, 1, 5, "Public", null),
+            new Symbol(0, f2!.Id, "Add", "Function", "function Add(a, b)", null, 0, 30, 1, 3, "Public", null),
+            new Symbol(0, f3!.Id, "FooModel", "Class", "class FooModel", null, 0, 40, 1, 4, "Public", null),
+            new Symbol(0, f4!.Id, "BarService", "Class", "class BarService", null, 0, 40, 1, 4, "Public", null),
+            new Symbol(0, f5!.Id, "BonusFunc", "Function", "function BonusFunc()", null, 0, 30, 1, 3, "Private", null),
+        ]).ConfigureAwait(false);
+
+        return store;
+    }
+
+    [Test]
+    public async Task GetProjectOutlineAsyncFiltersByPathPrefix()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = await SeedMultiFileDataAsync(connection).ConfigureAwait(false);
+
+        var outline = await store.GetProjectOutlineAsync("repo1", true, "file", 1, "src/services").ConfigureAwait(false);
+
+        var allSymbols = outline.Groups.SelectMany(g => g.Symbols).ToList();
+        await Assert.That(allSymbols).Count().IsEqualTo(1);
+        await Assert.That(allSymbols[0].Name).IsEqualTo("Attack");
+    }
+
+    [Test]
+    public async Task GetProjectOutlineAsyncPathFilterWithTrailingSlash()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = await SeedMultiFileDataAsync(connection).ConfigureAwait(false);
+
+        var outline = await store.GetProjectOutlineAsync("repo1", true, "file", 1, "src/services/").ConfigureAwait(false);
+
+        var allSymbols = outline.Groups.SelectMany(g => g.Symbols).ToList();
+        await Assert.That(allSymbols).Count().IsEqualTo(1);
+        await Assert.That(allSymbols[0].Name).IsEqualTo("Attack");
+    }
+
+    [Test]
+    public async Task GetProjectOutlineAsyncPathFilterNestedPath()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = await SeedMultiFileDataAsync(connection).ConfigureAwait(false);
+
+        var outline = await store.GetProjectOutlineAsync("repo1", true, "file", 1, "src/Core/Models").ConfigureAwait(false);
+
+        var allSymbols = outline.Groups.SelectMany(g => g.Symbols).ToList();
+        await Assert.That(allSymbols).Count().IsEqualTo(1);
+        await Assert.That(allSymbols[0].Name).IsEqualTo("FooModel");
+    }
+
+    [Test]
+    public async Task GetProjectOutlineAsyncPathFilterNoMatchReturnsEmptyGroups()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = await SeedMultiFileDataAsync(connection).ConfigureAwait(false);
+
+        var outline = await store.GetProjectOutlineAsync("repo1", true, "file", 1, "nonexistent").ConfigureAwait(false);
+
+        await Assert.That(outline.Groups).Count().IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task GetProjectOutlineAsyncPathFilterNullReturnsAllSymbols()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = await SeedMultiFileDataAsync(connection).ConfigureAwait(false);
+
+        var outline = await store.GetProjectOutlineAsync("repo1", true, "file", 1, null).ConfigureAwait(false);
+
+        var allSymbols = outline.Groups.SelectMany(g => g.Symbols).ToList();
+        await Assert.That(allSymbols).Count().IsEqualTo(5);
+    }
+
+    [Test]
+    public async Task GetProjectOutlineAsyncPathFilterCombinesWithIncludePrivate()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = await SeedMultiFileDataAsync(connection).ConfigureAwait(false);
+
+        var outline = await store.GetProjectOutlineAsync("repo1", false, "file", 1, "src/servicesExtra").ConfigureAwait(false);
+
+        var allSymbols = outline.Groups.SelectMany(g => g.Symbols).ToList();
+        await Assert.That(allSymbols).Count().IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task GetProjectOutlineAsyncPathFilterDoesNotMatchPartialDirectoryName()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = await SeedMultiFileDataAsync(connection).ConfigureAwait(false);
+
+        var outline = await store.GetProjectOutlineAsync("repo1", true, "file", 1, "src/services").ConfigureAwait(false);
+
+        var allFiles = outline.Groups.Select(g => g.Name).ToList();
+        await Assert.That(allFiles).DoesNotContain("src/servicesExtra/Bonus.luau");
+        var allSymbols = outline.Groups.SelectMany(g => g.Symbols).ToList();
+        await Assert.That(allSymbols).Count().IsEqualTo(1);
+        await Assert.That(allSymbols[0].Name).IsEqualTo("Attack");
+    }
+
     // ── GetProjectOutlineAsync Tests ─────────────────────────────────────
 
     [Test]

--- a/tests/CodeCompress.Core.Tests/Validation/PathValidatorTests.cs
+++ b/tests/CodeCompress.Core.Tests/Validation/PathValidatorTests.cs
@@ -258,4 +258,103 @@ internal sealed class PathValidatorTests
 
         await Assert.That(result).IsEqualTo(Path.GetFullPath(literalPath));
     }
+
+    // ── ValidatePathFilter Tests ─────────────────────────────────
+
+    [Test]
+    public async Task ValidatePathFilterReturnsNormalizedPrefix()
+    {
+        var result = PathValidator.ValidatePathFilter("src/Core/Models/");
+
+        await Assert.That(result).IsEqualTo("src/Core/Models");
+    }
+
+    [Test]
+    public async Task ValidatePathFilterStripsTrailingSlash()
+    {
+        var result = PathValidator.ValidatePathFilter("src/services/");
+
+        await Assert.That(result).IsEqualTo("src/services");
+    }
+
+    [Test]
+    public async Task ValidatePathFilterNoTrailingSlashPassesThrough()
+    {
+        var result = PathValidator.ValidatePathFilter("src/services");
+
+        await Assert.That(result).IsEqualTo("src/services");
+    }
+
+    [Test]
+    public async Task ValidatePathFilterNormalizesBackslashes()
+    {
+        var result = PathValidator.ValidatePathFilter("src\\Core\\Models");
+
+        await Assert.That(result).IsEqualTo("src/Core/Models");
+    }
+
+    [Test]
+    public async Task ValidatePathFilterTrimsWhitespace()
+    {
+        var result = PathValidator.ValidatePathFilter("  src/Core  ");
+
+        await Assert.That(result).IsEqualTo("src/Core");
+    }
+
+    [Test]
+    [Arguments("")]
+    [Arguments("   ")]
+    public async Task ValidatePathFilterRejectsNullOrEmpty(string input)
+    {
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => Task.FromResult(PathValidator.ValidatePathFilter(input)));
+    }
+
+    [Test]
+    public async Task ValidatePathFilterRejectsNull()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => Task.FromResult(PathValidator.ValidatePathFilter(null!)));
+    }
+
+    [Test]
+    [Arguments("../etc")]
+    [Arguments("src/../../etc")]
+    public async Task ValidatePathFilterRejectsParentTraversal(string input)
+    {
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => Task.FromResult(PathValidator.ValidatePathFilter(input)));
+    }
+
+    [Test]
+    [Arguments("/etc/passwd")]
+    [Arguments("C:\\Windows")]
+    public async Task ValidatePathFilterRejectsAbsolutePath(string input)
+    {
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => Task.FromResult(PathValidator.ValidatePathFilter(input)));
+    }
+
+    [Test]
+    public async Task ValidatePathFilterRejectsNullBytes()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => Task.FromResult(PathValidator.ValidatePathFilter("src\0/evil")));
+    }
+
+    [Test]
+    public async Task ValidatePathFilterAcceptsSingleSegment()
+    {
+        var result = PathValidator.ValidatePathFilter("src");
+
+        await Assert.That(result).IsEqualTo("src");
+    }
+
+    [Test]
+    public async Task ValidatePathFilterStripsLikeWildcards()
+    {
+        var result = PathValidator.ValidatePathFilter("src/%models_");
+
+        await Assert.That(result).IsEqualTo("src/models");
+    }
 }

--- a/tests/CodeCompress.Server.Tests/Tools/QueryToolsTests.cs
+++ b/tests/CodeCompress.Server.Tests/Tools/QueryToolsTests.cs
@@ -196,11 +196,90 @@ internal sealed class QueryToolsTests
     {
         var distinctivePath = "/very/unique/distinctive/test/path/12345";
         var outline = new ProjectOutline("test-repo-id", []);
-        _store.GetProjectOutlineAsync("test-repo-id", false, "file", Arg.Any<int>()).Returns(outline);
+        _store.GetProjectOutlineAsync("test-repo-id", false, "file", Arg.Any<int>(), Arg.Any<string?>()).Returns(outline);
 
         var result = await _tools.ProjectOutline(distinctivePath).ConfigureAwait(false);
 
         await Assert.That(result).DoesNotContain(distinctivePath);
+    }
+
+    [Test]
+    public async Task ProjectOutlinePathFilterPassesToStore()
+    {
+        var outline = new ProjectOutline("test-repo-id", []);
+        _store.GetProjectOutlineAsync("test-repo-id", false, "file", Arg.Any<int>(), "src/services").Returns(outline);
+
+        await _tools.ProjectOutline("/valid/path", pathFilter: "src/services").ConfigureAwait(false);
+
+        await _store.Received(1).GetProjectOutlineAsync(
+            "test-repo-id", false, "file", Arg.Any<int>(), "src/services").ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task ProjectOutlinePathFilterNullPassesNullToStore()
+    {
+        var outline = new ProjectOutline("test-repo-id", []);
+        _store.GetProjectOutlineAsync("test-repo-id", false, "file", Arg.Any<int>(), null).Returns(outline);
+
+        await _tools.ProjectOutline("/valid/path").ConfigureAwait(false);
+
+        await _store.Received(1).GetProjectOutlineAsync(
+            "test-repo-id", false, "file", Arg.Any<int>(), null).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task ProjectOutlinePathFilterWithTraversalReturnsError()
+    {
+        var result = await _tools.ProjectOutline("/valid/path", pathFilter: "../etc").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        var root = doc.RootElement;
+        await Assert.That(root.GetProperty("error").GetString()).IsEqualTo("Invalid path filter");
+        await Assert.That(root.GetProperty("code").GetString()).IsEqualTo("INVALID_PATH_FILTER");
+    }
+
+    [Test]
+    public async Task ProjectOutlinePathFilterAbsolutePathReturnsError()
+    {
+        var result = await _tools.ProjectOutline("/valid/path", pathFilter: "/etc/passwd").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        var root = doc.RootElement;
+        await Assert.That(root.GetProperty("code").GetString()).IsEqualTo("INVALID_PATH_FILTER");
+    }
+
+    [Test]
+    public async Task ProjectOutlinePathFilterEmptyStringReturnsError()
+    {
+        var result = await _tools.ProjectOutline("/valid/path", pathFilter: "  ").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        var root = doc.RootElement;
+        await Assert.That(root.GetProperty("code").GetString()).IsEqualTo("INVALID_PATH_FILTER");
+    }
+
+    [Test]
+    public async Task ProjectOutlinePathFilterDoesNotEchoRawFilter()
+    {
+        var maliciousFilter = "src/<script>alert(1)</script>";
+        var outline = new ProjectOutline("test-repo-id", []);
+        _store.GetProjectOutlineAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<string?>()).Returns(outline);
+
+        var result = await _tools.ProjectOutline("/valid/path", pathFilter: maliciousFilter).ConfigureAwait(false);
+
+        await Assert.That(result).DoesNotContain(maliciousFilter);
+    }
+
+    [Test]
+    public async Task ProjectOutlinePathFilterCombinesWithGroupBy()
+    {
+        var outline = new ProjectOutline("test-repo-id", []);
+        _store.GetProjectOutlineAsync("test-repo-id", false, "kind", Arg.Any<int>(), "src/services").Returns(outline);
+
+        await _tools.ProjectOutline("/valid/path", groupBy: "kind", pathFilter: "src/services").ConfigureAwait(false);
+
+        await _store.Received(1).GetProjectOutlineAsync(
+            "test-repo-id", false, "kind", Arg.Any<int>(), "src/services").ConfigureAwait(false);
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- Adds optional `pathFilter` parameter to `project_outline` MCP tool, allowing users to scope output to a subdirectory (e.g., `src/Core/Models`) instead of receiving the full codebase outline
- Implements `PathValidator.ValidatePathFilter` for input sanitization — rejects traversal, absolute paths, null bytes, and LIKE wildcards
- Applies parameterized `LIKE` SQL filter with trailing `/` normalization to prevent partial directory name matches (e.g., `src/services` won't match `src/servicesExtra/`)

Closes #21

## Test plan
- [x] 11 unit tests for `PathValidator.ValidatePathFilter` (normalization, rejection cases, edge cases)
- [x] 7 integration tests for `SqliteSymbolStore` path filtering (prefix match, trailing slash, nested paths, no-match, null passthrough, includePrivate combo, partial dir name prevention)
- [x] 7 unit tests for `QueryTools.ProjectOutline` pathFilter (passthrough, null, traversal error, absolute path error, empty string error, no echo, groupBy combo)
- [x] All 466 tests pass, zero build warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)