### PR TITLE
Fix search_symbols wildcard queries with pathFilter (#29)

### DIFF
--- a/src/CodeCompress.Core/Storage/GlobPattern.cs
+++ b/src/CodeCompress.Core/Storage/GlobPattern.cs
@@ -28,6 +28,9 @@ public sealed class GlobPattern
     public static GlobPattern CreatePrefix(string fts5Query) =>
         new(GlobMatchStrategy.Prefix, fts5Query, null);
 
+    public static GlobPattern CreateSqlLike(string fts5Query, string sqlLikePattern) =>
+        new(GlobMatchStrategy.SqlLike, fts5Query, sqlLikePattern);
+
     public static bool IsWildcardOnly(string query)
     {
         if (string.IsNullOrWhiteSpace(query))

--- a/src/CodeCompress.Server/Tools/QueryTools.cs
+++ b/src/CodeCompress.Server/Tools/QueryTools.cs
@@ -353,7 +353,7 @@ internal sealed class QueryTools
             return SerializeError("Search query cannot be empty", "EMPTY_QUERY");
         }
 
-        if (GlobPattern.IsWildcardOnly(query))
+        if (GlobPattern.IsWildcardOnly(query) && pathFilter is null)
         {
             return SerializeError("Search query is too broad — provide at least one non-wildcard term", "QUERY_TOO_BROAD");
         }
@@ -387,6 +387,12 @@ internal sealed class QueryTools
 
         var clampedLimit = Math.Clamp(limit, 1, 100);
         var glob = Fts5QuerySanitizer.SanitizeAsGlob(query);
+
+        // Wildcard-only query with pathFilter: browse all symbols under that path
+        if (string.IsNullOrWhiteSpace(glob.Fts5Query) && string.IsNullOrWhiteSpace(glob.SqlLikePattern) && validatedPathFilter is not null)
+        {
+            glob = GlobPattern.CreateSqlLike(string.Empty, "%");
+        }
 
         if (string.IsNullOrWhiteSpace(glob.Fts5Query) && string.IsNullOrWhiteSpace(glob.SqlLikePattern))
         {

--- a/tests/CodeCompress.Server.Tests/Tools/QueryToolsTests.cs
+++ b/tests/CodeCompress.Server.Tests/Tools/QueryToolsTests.cs
@@ -1082,6 +1082,21 @@ internal sealed class QueryToolsTests
     }
 
     [Test]
+    public async Task SearchSymbolsWildcardWithPathFilterBrowsesAllSymbols()
+    {
+        _store.SearchSymbolsAsync("test-repo-id", Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<int>(), Arg.Any<string?>(), "%")
+            .Returns(new List<SymbolSearchResult>());
+
+        var result = await _tools.SearchSymbols("/valid/path", "*", pathFilter: "src/Core").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        var root = doc.RootElement;
+        await Assert.That(root.TryGetProperty("error", out _)).IsFalse();
+        await _store.Received(1).SearchSymbolsAsync(
+            "test-repo-id", Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<int>(), "src/Core", "%").ConfigureAwait(false);
+    }
+
+    [Test]
     public async Task SearchSymbolsPrefixGlobPassesFts5PrefixQuery()
     {
         _store.SearchSymbolsAsync("test-repo-id", Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>())


### PR DESCRIPTION
## Summary
- Allow wildcard-only queries (`*`) in `search_symbols` when a `pathFilter` is provided, enabling directory-scoped symbol browsing
- Without `pathFilter`, wildcard-only queries are still rejected as `QUERY_TOO_BROAD`
- Added `GlobPattern.CreateSqlLike` factory method to Core for the wildcard+pathFilter code path

## Test plan
- [x] All 493 tests pass (347 Core + 146 Server)
- [x] Zero build warnings
- [x] MCP validation: `search_symbols` with `query: "*"` and `pathFilter: "src/CodeCompress.Core/Validation"` returns 17 symbols
- [x] MCP validation: `query: "*"` without pathFilter still returns `QUERY_TOO_BROAD`
- [x] MCP validation: `query: "*"` with pathFilter + `kind: "class"` correctly combines both filters (2 results)
- [ ] CI passes on all 3 platforms

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)