### PR TITLE
fix: make C# records discoverable by name and kind

### DIFF
--- a/src/CodeCompress.Core/Models/SymbolKind.cs
+++ b/src/CodeCompress.Core/Models/SymbolKind.cs
@@ -9,5 +9,6 @@ public enum SymbolKind
     Interface,
     Export,
     Constant,
-    Module
+    Module,
+    Record
 }

--- a/src/CodeCompress.Core/Parsers/CSharpParser.cs
+++ b/src/CodeCompress.Core/Parsers/CSharpParser.cs
@@ -896,7 +896,7 @@ public sealed partial class CSharpParser : ILanguageParser
         string keyword;
         if (!string.IsNullOrEmpty(recordKeyword))
         {
-            kind = SymbolKind.Class;
+            kind = SymbolKind.Record;
             keyword = string.IsNullOrEmpty(recordSubKeyword)
                 ? "record"
                 : $"record {recordSubKeyword}";

--- a/src/CodeCompress.Server/Tools/QueryTools.cs
+++ b/src/CodeCompress.Server/Tools/QueryTools.cs
@@ -27,7 +27,7 @@ internal sealed class QueryTools
 
     private static readonly HashSet<string> ValidSymbolKinds = new(StringComparer.OrdinalIgnoreCase)
     {
-        "function", "method", "type", "class", "interface", "export", "constant", "module",
+        "function", "method", "type", "class", "interface", "export", "constant", "module", "record",
     };
 
     private readonly IPathValidator _pathValidator;
@@ -345,7 +345,7 @@ internal sealed class QueryTools
     public async Task<string> SearchSymbols(
         [Description("ABSOLUTE path to the project root directory — the same root used with index_project (e.g., 'C:\\Projects\\MyGame' or '/home/user/my-project'). Must NOT be a subdirectory or relative path.")] string path,
         [Description("Search query — supports plain text, FTS5 operators (AND, OR, NOT), and glob patterns (prefix*, *suffix, *contains*)")] string query,
-        [Description("Filter by symbol kind (function, method, class, type, interface, export, constant, module)")] string? kind = null,
+        [Description("Filter by symbol kind (function, method, class, record, type, interface, export, constant, module)")] string? kind = null,
         [Description("Filter results to files under this relative directory path (e.g., 'src/Core/Models')")] string? pathFilter = null,
         [Description("Maximum results to return (1-100)")] int limit = 20,
         CancellationToken cancellationToken = default)
@@ -376,7 +376,7 @@ internal sealed class QueryTools
         {
             if (!ValidSymbolKinds.Contains(kind))
             {
-                return SerializeError("Invalid symbol kind. Must be one of: function, method, type, class, interface, export, constant, module", "INVALID_KIND");
+                return SerializeError("Invalid symbol kind. Must be one of: function, method, type, class, record, interface, export, constant, module", "INVALID_KIND");
             }
 
             // Normalize to PascalCase to match DB storage (SymbolKind.ToString())

--- a/tests/CodeCompress.Core.Tests/Models/SymbolKindTests.cs
+++ b/tests/CodeCompress.Core.Tests/Models/SymbolKindTests.cs
@@ -13,6 +13,7 @@ internal sealed class SymbolKindTests
     [Arguments(SymbolKind.Export, 5)]
     [Arguments(SymbolKind.Constant, 6)]
     [Arguments(SymbolKind.Module, 7)]
+    [Arguments(SymbolKind.Record, 8)]
     public async Task EnumMemberHasExpectedIntValue(SymbolKind kind, int expectedValue)
     {
         var actualValue = (int)kind;
@@ -21,10 +22,10 @@ internal sealed class SymbolKindTests
     }
 
     [Test]
-    public async Task GetValuesReturnsExactlyEightMembers()
+    public async Task GetValuesReturnsExactlyNineMembers()
     {
         var values = Enum.GetValues<SymbolKind>();
 
-        await Assert.That(values).Count().IsEqualTo(8);
+        await Assert.That(values).Count().IsEqualTo(9);
     }
 }

--- a/tests/CodeCompress.Core.Tests/Parsers/CSharpParserTests.cs
+++ b/tests/CodeCompress.Core.Tests/Parsers/CSharpParserTests.cs
@@ -260,7 +260,7 @@ internal sealed class CSharpParserTests
         var result = Parse(source);
 
         var rec = result.Symbols.First(s => s.Name == "Foo");
-        await Assert.That(rec.Kind).IsEqualTo(SymbolKind.Class);
+        await Assert.That(rec.Kind).IsEqualTo(SymbolKind.Record);
         await Assert.That(rec.Signature).IsEqualTo("public record Foo(int X, string Y);");
     }
 
@@ -274,7 +274,7 @@ internal sealed class CSharpParserTests
         var result = Parse(source);
 
         var rec = result.Symbols.First(s => s.Name == "Point");
-        await Assert.That(rec.Kind).IsEqualTo(SymbolKind.Class);
+        await Assert.That(rec.Kind).IsEqualTo(SymbolKind.Record);
         await Assert.That(rec.Signature).IsEqualTo("public record struct Point(int X, int Y);");
     }
 
@@ -659,7 +659,7 @@ internal sealed class CSharpParserTests
         var result = Parse(source);
 
         var rec = result.Symbols.First(s => s.Name == "Foo");
-        await Assert.That(rec.Kind).IsEqualTo(SymbolKind.Class);
+        await Assert.That(rec.Kind).IsEqualTo(SymbolKind.Record);
         await Assert.That(rec.LineEnd).IsEqualTo(4);
     }
 
@@ -1428,7 +1428,7 @@ internal sealed class CSharpParserTests
         var result = Parse(source);
 
         var rec = result.Symbols.First(s => s.Name == "Foo");
-        await Assert.That(rec.Kind).IsEqualTo(SymbolKind.Class);
+        await Assert.That(rec.Kind).IsEqualTo(SymbolKind.Record);
 
         var method = result.Symbols.First(s => s.Kind == SymbolKind.Method);
         await Assert.That(method.Name).IsEqualTo("Double");

--- a/tests/CodeCompress.Integration.Tests/CSharpEndToEndTests.cs
+++ b/tests/CodeCompress.Integration.Tests/CSharpEndToEndTests.cs
@@ -84,6 +84,7 @@ internal sealed class CSharpEndToEndTests : IDisposable
         // Verify some specific symbol kinds appear
         var allSymbolKinds = CollectSymbolKinds(outline.Groups);
         await Assert.That(allSymbolKinds).Contains("Class");
+        await Assert.That(allSymbolKinds).Contains("Record");
         await Assert.That(allSymbolKinds).Contains("Method");
         await Assert.That(allSymbolKinds).Contains("Interface");
         await Assert.That(allSymbolKinds).Contains("Module");
@@ -125,11 +126,36 @@ internal sealed class CSharpEndToEndTests : IDisposable
 
         // The record is stored as a Class kind
         var symbols = await _store.GetSymbolsByNamesAsync(_repoId, ["Player"]).ConfigureAwait(false);
-        var record = symbols.FirstOrDefault(s => s.Kind == "Class" && s.Name == "Player");
+        var record = symbols.FirstOrDefault(s => s.Kind == "Record" && s.Name == "Player");
 
         await Assert.That(record).IsNotNull();
         await Assert.That(record!.Signature).Contains("record");
         await Assert.That(record.Signature).Contains("Player");
+    }
+
+    [Test]
+    public async Task GetSymbolBySimpleNameFindsRecord()
+    {
+        await IndexSampleProjectAsync().ConfigureAwait(false);
+
+        // get_symbol uses GetSymbolByNameAsync — simple name lookup
+        var symbol = await _store.GetSymbolByNameAsync(_repoId, "Player").ConfigureAwait(false);
+
+        await Assert.That(symbol).IsNotNull();
+        await Assert.That(symbol!.Name).IsEqualTo("Player");
+        await Assert.That(symbol.Kind).IsEqualTo("Record");
+    }
+
+    [Test]
+    public async Task SearchSymbolsByKindRecordReturnsOnlyRecords()
+    {
+        await IndexSampleProjectAsync().ConfigureAwait(false);
+
+        var results = await _store.SearchSymbolsAsync(
+            _repoId, "Player", kind: "Record", limit: 10).ConfigureAwait(false);
+
+        await Assert.That(results).Count().IsGreaterThanOrEqualTo(1);
+        await Assert.That(results.All(r => r.Symbol.Kind == "Record")).IsTrue();
     }
 
     [Test]

--- a/tests/CodeCompress.Server.Tests/Tools/QueryToolsTests.cs
+++ b/tests/CodeCompress.Server.Tests/Tools/QueryToolsTests.cs
@@ -925,7 +925,7 @@ internal sealed class QueryToolsTests
         using var doc = JsonDocument.Parse(result);
         var root = doc.RootElement;
         await Assert.That(root.GetProperty("error").GetString())
-            .IsEqualTo("Invalid symbol kind. Must be one of: function, method, type, class, interface, export, constant, module");
+            .IsEqualTo("Invalid symbol kind. Must be one of: function, method, type, class, record, interface, export, constant, module");
         await Assert.That(root.GetProperty("code").GetString()).IsEqualTo("INVALID_KIND");
 
         await _store.DidNotReceive().SearchSymbolsAsync(


### PR DESCRIPTION
## Summary
- Added `SymbolKind.Record` enum variant so C# records have their own dedicated kind instead of being stored as `Class`
- Updated `CSharpParser` to emit `SymbolKind.Record` for `record`, `record class`, and `record struct` declarations
- Added `"record"` to the valid kind filter in `search_symbols` MCP tool, enabling `kind="record"` queries

## Root Cause
Records were parsed and stored with `kind="Class"`, making them indistinguishable from actual classes. The `search_symbols` tool's kind filter didn't accept `"record"`, so there was no way to filter for records specifically.

## Test Plan
- [x] All 551 existing tests pass (0 failures, 0 warnings)
- [x] Parser tests updated: records now assert `SymbolKind.Record` (4 tests)
- [x] New integration test: `GetSymbolBySimpleNameFindsRecord` — verifies `GetSymbolByNameAsync` returns records by simple name
- [x] New integration test: `SearchSymbolsByKindRecordReturnsOnlyRecords` — verifies `SearchSymbolsAsync` with `kind="Record"` filter
- [x] `SymbolKind` enum test updated for 9 members
- [x] QueryTools error message test updated

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)