### PR TITLE
fix: add SymbolKind.Enum so C# enums are discoverable by kind

### DIFF
--- a/src/CodeCompress.Core/Models/SymbolKind.cs
+++ b/src/CodeCompress.Core/Models/SymbolKind.cs
@@ -10,5 +10,6 @@ public enum SymbolKind
     Export,
     Constant,
     Module,
-    Record
+    Record,
+    Enum
 }

--- a/src/CodeCompress.Core/Parsers/CSharpParser.cs
+++ b/src/CodeCompress.Core/Parsers/CSharpParser.cs
@@ -732,7 +732,7 @@ public sealed partial class CSharpParser : ILanguageParser
             if (entry.IsContainer)
             {
                 // Don't match methods/properties inside enums
-                if (entry.Kind == SymbolKind.Type)
+                if (entry.Kind is SymbolKind.Type or SymbolKind.Enum)
                 {
                     return false;
                 }
@@ -857,7 +857,7 @@ public sealed partial class CSharpParser : ILanguageParser
 
         parentStack.Add(new PendingType(
             Name: name,
-            Kind: SymbolKind.Type,
+            Kind: SymbolKind.Enum,
             Signature: signature,
             ParentName: parentName,
             ByteOffset: byteOffset,

--- a/src/CodeCompress.Core/Storage/SqliteSymbolStore.cs
+++ b/src/CodeCompress.Core/Storage/SqliteSymbolStore.cs
@@ -734,7 +734,14 @@ public sealed class SqliteSymbolStore : ISymbolStore
 
         if (kind is not null)
         {
-            sql.Append(" AND s.kind = @kind");
+            if (string.Equals(kind, nameof(SymbolKind.Type), StringComparison.OrdinalIgnoreCase))
+            {
+                sql.Append(" AND s.kind IN (@kind, @kindEnum)");
+            }
+            else
+            {
+                sql.Append(" AND s.kind = @kind");
+            }
         }
 
         if (pathFilter is not null)
@@ -764,6 +771,11 @@ public sealed class SqliteSymbolStore : ISymbolStore
         if (kind is not null)
         {
             command.Parameters.AddWithValue("@kind", kind);
+
+            if (string.Equals(kind, nameof(SymbolKind.Type), StringComparison.OrdinalIgnoreCase))
+            {
+                command.Parameters.AddWithValue("@kindEnum", nameof(SymbolKind.Enum));
+            }
         }
 
         if (pathFilter is not null)

--- a/src/CodeCompress.Server/Tools/QueryTools.cs
+++ b/src/CodeCompress.Server/Tools/QueryTools.cs
@@ -352,7 +352,7 @@ internal sealed class QueryTools
     public async Task<string> SearchSymbols(
         [Description("ABSOLUTE path to the project root directory — the same root used with index_project (e.g., 'C:\\Projects\\MyGame' or '/home/user/my-project'). Must NOT be a subdirectory or relative path.")] string path,
         [Description("Search query — supports plain text, FTS5 operators (AND, OR, NOT), and glob patterns (prefix*, *suffix, *contains*)")] string query,
-        [Description("Filter by symbol kind (function, method, class, record, type, interface, export, constant, module)")] string? kind = null,
+        [Description("Filter by symbol kind (function, method, class, record, enum, type, interface, export, constant, module)")] string? kind = null,
         [Description("Filter results to files under this relative directory path (e.g., 'src/Core/Models')")] string? pathFilter = null,
         [Description("Maximum results to return (1-100)")] int limit = 20,
         CancellationToken cancellationToken = default)

--- a/tests/CodeCompress.Core.Tests/Models/SymbolKindTests.cs
+++ b/tests/CodeCompress.Core.Tests/Models/SymbolKindTests.cs
@@ -14,6 +14,7 @@ internal sealed class SymbolKindTests
     [Arguments(SymbolKind.Constant, 6)]
     [Arguments(SymbolKind.Module, 7)]
     [Arguments(SymbolKind.Record, 8)]
+    [Arguments(SymbolKind.Enum, 9)]
     public async Task EnumMemberHasExpectedIntValue(SymbolKind kind, int expectedValue)
     {
         var actualValue = (int)kind;
@@ -22,10 +23,10 @@ internal sealed class SymbolKindTests
     }
 
     [Test]
-    public async Task GetValuesReturnsExactlyNineMembers()
+    public async Task GetValuesReturnsExactlyTenMembers()
     {
         var values = Enum.GetValues<SymbolKind>();
 
-        await Assert.That(values).Count().IsEqualTo(9);
+        await Assert.That(values).Count().IsEqualTo(10);
     }
 }

--- a/tests/CodeCompress.Core.Tests/Parsers/CSharpParserTests.cs
+++ b/tests/CodeCompress.Core.Tests/Parsers/CSharpParserTests.cs
@@ -295,7 +295,7 @@ internal sealed class CSharpParserTests
         var result = Parse(source);
 
         var en = result.Symbols.First(s => s.Name == "Color");
-        await Assert.That(en.Kind).IsEqualTo(SymbolKind.Type);
+        await Assert.That(en.Kind).IsEqualTo(SymbolKind.Enum);
         await Assert.That(en.Visibility).IsEqualTo(Visibility.Public);
     }
 
@@ -1495,7 +1495,7 @@ internal sealed class CSharpParserTests
         var properties = result.Symbols.Where(s => s.Kind == SymbolKind.Constant).ToList();
         await Assert.That(properties.Count).IsGreaterThanOrEqualTo(2);
 
-        var enums = result.Symbols.Where(s => s.Kind == SymbolKind.Type).ToList();
+        var enums = result.Symbols.Where(s => s.Kind == SymbolKind.Enum).ToList();
         await Assert.That(enums).Count().IsEqualTo(1);
 
         // Dependencies from using statements

--- a/tests/CodeCompress.Integration.Tests/CSharpEndToEndTests.cs
+++ b/tests/CodeCompress.Integration.Tests/CSharpEndToEndTests.cs
@@ -89,7 +89,7 @@ internal sealed class CSharpEndToEndTests : IDisposable
         await Assert.That(allSymbolKinds).Contains("Interface");
         await Assert.That(allSymbolKinds).Contains("Module");
         await Assert.That(allSymbolKinds).Contains("Constant");
-        await Assert.That(allSymbolKinds).Contains("Type");
+        await Assert.That(allSymbolKinds).Contains("Enum");
     }
 
     [Test]
@@ -156,6 +156,30 @@ internal sealed class CSharpEndToEndTests : IDisposable
 
         await Assert.That(results).Count().IsGreaterThanOrEqualTo(1);
         await Assert.That(results.All(r => r.Symbol.Kind == "Record")).IsTrue();
+    }
+
+    [Test]
+    public async Task SearchSymbolsByKindEnumReturnsOnlyEnums()
+    {
+        await IndexSampleProjectAsync().ConfigureAwait(false);
+
+        var results = await _store.SearchSymbolsAsync(
+            _repoId, "GameState", kind: "Enum", limit: 10).ConfigureAwait(false);
+
+        await Assert.That(results).Count().IsGreaterThanOrEqualTo(1);
+        await Assert.That(results.All(r => r.Symbol.Kind == "Enum")).IsTrue();
+    }
+
+    [Test]
+    public async Task SearchSymbolsByKindTypeAlsoReturnsEnums()
+    {
+        await IndexSampleProjectAsync().ConfigureAwait(false);
+
+        var results = await _store.SearchSymbolsAsync(
+            _repoId, "GameState", kind: "Type", limit: 10).ConfigureAwait(false);
+
+        await Assert.That(results).Count().IsGreaterThanOrEqualTo(1);
+        await Assert.That(results.Any(r => r.Symbol.Kind == "Enum")).IsTrue();
     }
 
     [Test]
@@ -240,7 +264,7 @@ internal sealed class CSharpEndToEndTests : IDisposable
         await Assert.That(symbols).Count().IsGreaterThanOrEqualTo(1);
         var itemRarity = symbols.First(s => s.Name == "ItemRarity");
         await Assert.That(itemRarity.ParentSymbol).IsEqualTo("Inventory");
-        await Assert.That(itemRarity.Kind).IsEqualTo("Type");
+        await Assert.That(itemRarity.Kind).IsEqualTo("Enum");
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- Adds `SymbolKind.Enum` (value 9) so C# enums are stored with a dedicated kind instead of `Type`
- C# parser now emits `SymbolKind.Enum` for enum declarations
- `search_symbols` with `kind:"type"` also returns enums (backwards compatibility via SQL `IN` clause)
- `search_symbols` tool description now lists `enum` as a valid kind filter

## Test plan
- [x] `SymbolKindTests` updated for 10 members including `Enum = 9`
- [x] `CSharpParserTests.EnumExtracted` asserts `SymbolKind.Enum`
- [x] Integration test: `SearchSymbolsByKindEnumReturnsOnlyEnums` — `kind:"Enum"` finds enums
- [x] Integration test: `SearchSymbolsByKindTypeAlsoReturnsEnums` — `kind:"Type"` still returns enums
- [x] All 570 tests pass (568 existing + 2 new)

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)