### PR TITLE
feat: add find_references tool for symbol usage search

### DIFF
--- a/src/CodeCompress.Core/Models/ReferenceResult.cs
+++ b/src/CodeCompress.Core/Models/ReferenceResult.cs
@@ -1,0 +1,7 @@
+namespace CodeCompress.Core.Models;
+
+public sealed record ReferenceResult(
+    string FilePath,
+    int Line,
+    string ContextSnippet,
+    double Rank);

--- a/src/CodeCompress.Core/Storage/ISymbolStore.cs
+++ b/src/CodeCompress.Core/Storage/ISymbolStore.cs
@@ -39,6 +39,7 @@ public interface ISymbolStore
     // Search
     public Task<IReadOnlyList<SymbolSearchResult>> SearchSymbolsAsync(string repoId, string query, string? kind, int limit, string? pathFilter = null, string? nameLikePattern = null);
     public Task<IReadOnlyList<TextSearchResult>> SearchTextAsync(string repoId, string query, string? glob, int limit, string? pathFilter = null);
+    public Task<IReadOnlyList<ReferenceResult>> FindReferencesAsync(string repoId, string symbolName, string projectRoot, int limit, string? pathFilter = null);
 
     // Lookups
     public Task<Symbol?> GetSymbolByNameAsync(string repoId, string symbolName);

--- a/src/CodeCompress.Core/Storage/SqliteSymbolStore.cs
+++ b/src/CodeCompress.Core/Storage/SqliteSymbolStore.cs
@@ -879,6 +879,120 @@ public sealed class SqliteSymbolStore : ISymbolStore
         return results;
     }
 
+    public async Task<IReadOnlyList<ReferenceResult>> FindReferencesAsync(string repoId, string symbolName, string projectRoot, int limit, string? pathFilter = null)
+    {
+        ArgumentNullException.ThrowIfNull(repoId);
+        ArgumentNullException.ThrowIfNull(symbolName);
+        ArgumentNullException.ThrowIfNull(projectRoot);
+
+        if (symbolName.Length == 0)
+        {
+            return [];
+        }
+
+        var clampedLimit = Math.Min(Math.Max(limit, 1), 100);
+
+        // Step 1: Use FTS5 to find files containing the symbol name
+        using var command = _connection.CreateCommand();
+
+        var sql = new StringBuilder();
+        sql.Append(
+            """
+            SELECT fts.relative_path, bm25(file_content_fts) AS rank
+            FROM file_content_fts AS fts
+            WHERE file_content_fts MATCH @query
+              AND fts.relative_path IN (SELECT relative_path FROM files WHERE repo_id = @repoId)
+            """);
+
+        if (pathFilter is not null)
+        {
+            sql.Append(@" AND fts.relative_path LIKE @pathPrefix || '%' ESCAPE '!'");
+        }
+
+        sql.Append(" ORDER BY rank LIMIT @fileLimit");
+
+#pragma warning disable CA2100 // SQL is built from static literals and parameterized placeholders only
+        command.CommandText = sql.ToString();
+#pragma warning restore CA2100
+
+        // Wrap as quoted phrase for exact matching
+        var quotedName = $"\"{symbolName.Replace("\"", string.Empty, StringComparison.Ordinal)}\"";
+        command.Parameters.AddWithValue("@query", quotedName);
+        command.Parameters.AddWithValue("@repoId", repoId);
+        command.Parameters.AddWithValue("@fileLimit", clampedLimit);
+
+        if (pathFilter is not null)
+        {
+            var normalizedPrefix = pathFilter.Replace('/', Path.DirectorySeparatorChar);
+            command.Parameters.AddWithValue("@pathPrefix", normalizedPrefix + Path.DirectorySeparatorChar);
+        }
+
+        using var reader = await command.ExecuteReaderAsync().ConfigureAwait(false);
+        var matchedFiles = new List<(string RelativePath, double Rank)>();
+
+        while (await reader.ReadAsync().ConfigureAwait(false))
+        {
+            matchedFiles.Add((reader.GetString(0), reader.GetDouble(1)));
+        }
+
+        // Step 2: Read each matched file from disk, find line-level matches with context
+        var results = new List<ReferenceResult>();
+
+        foreach (var (relativePath, rank) in matchedFiles)
+        {
+            var fullPath = Path.Combine(projectRoot, relativePath);
+            if (!File.Exists(fullPath))
+            {
+                continue;
+            }
+
+            var lines = await File.ReadAllLinesAsync(fullPath).ConfigureAwait(false);
+
+            for (var i = 0; i < lines.Length; i++)
+            {
+                if (!lines[i].Contains(symbolName, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                var snippetBuilder = new StringBuilder();
+
+                // 1 line before
+                if (i > 0)
+                {
+                    snippetBuilder.AppendLine(lines[i - 1]);
+                }
+
+                // Matching line
+                snippetBuilder.AppendLine(lines[i]);
+
+                // 1 line after
+                if (i < lines.Length - 1)
+                {
+                    snippetBuilder.Append(lines[i + 1]);
+                }
+
+                results.Add(new ReferenceResult(
+                    relativePath,
+                    i + 1, // 1-based line number
+                    snippetBuilder.ToString(),
+                    rank));
+
+                if (results.Count >= clampedLimit)
+                {
+                    return results;
+                }
+            }
+
+            if (results.Count >= clampedLimit)
+            {
+                break;
+            }
+        }
+
+        return results;
+    }
+
     // ── Lookups ─────────────────────────────────────────────────────────
 
     public async Task<Symbol?> GetSymbolByNameAsync(string repoId, string symbolName)

--- a/src/CodeCompress.Server/Tools/ReferenceTools.cs
+++ b/src/CodeCompress.Server/Tools/ReferenceTools.cs
@@ -1,0 +1,128 @@
+using System.ComponentModel;
+using System.Text.Json;
+using CodeCompress.Core.Models;
+using CodeCompress.Core.Validation;
+using CodeCompress.Server.Sanitization;
+using CodeCompress.Server.Scoping;
+using CodeCompress.Server.Services;
+using ModelContextProtocol.Server;
+
+namespace CodeCompress.Server.Tools;
+
+[McpServerToolType]
+internal sealed class ReferenceTools
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+    };
+
+    private readonly IPathValidator _pathValidator;
+    private readonly IProjectScopeFactory _scopeFactory;
+    private readonly IActivityTracker _activityTracker;
+
+    public ReferenceTools(IPathValidator pathValidator, IProjectScopeFactory scopeFactory, IActivityTracker activityTracker)
+    {
+        ArgumentNullException.ThrowIfNull(pathValidator);
+        ArgumentNullException.ThrowIfNull(scopeFactory);
+        ArgumentNullException.ThrowIfNull(activityTracker);
+
+        _pathValidator = pathValidator;
+        _scopeFactory = scopeFactory;
+        _activityTracker = activityTracker;
+    }
+
+    [McpServerTool(Name = "find_references")]
+    [Description("Find all locations where a symbol is referenced across the indexed codebase. Returns file paths, line numbers, and 3-line context snippets (1 line before + matching line + 1 line after). Works for functions, types, interfaces, DI registrations, and any text pattern. Requires index_project to have been called first.")]
+    public async Task<string> FindReferences(
+        [Description("ABSOLUTE path to the project root directory — the same root used with index_project (e.g., 'C:\\Projects\\MyGame' or '/home/user/my-project'). Must NOT be a subdirectory or relative path.")] string path,
+        [Description("Symbol name to search for references (e.g., 'ProcessAttack', 'ISymbolStore'). Does not need to exist in the symbol table — text search is used.")] string symbolName,
+        [Description("Filter results to files under this relative directory path (e.g., 'src/')")] string? pathFilter = null,
+        [Description("Maximum results to return (1-100, default 20)")] int limit = 20,
+        CancellationToken cancellationToken = default)
+    {
+        _activityTracker.RecordActivity();
+
+        string validatedPath;
+        try
+        {
+            validatedPath = _pathValidator.ValidatePath(path, path);
+        }
+        catch (ArgumentException)
+        {
+            return SerializeError("Path validation failed", "INVALID_PATH");
+        }
+
+        if (string.IsNullOrWhiteSpace(symbolName))
+        {
+            return SerializeError("Symbol name cannot be empty", "EMPTY_SYMBOL_NAME");
+        }
+
+        string? validatedPathFilter = null;
+        if (pathFilter is not null)
+        {
+            try
+            {
+                validatedPathFilter = PathValidator.ValidatePathFilter(pathFilter);
+            }
+            catch (ArgumentException)
+            {
+                return SerializeError("Invalid path filter", "INVALID_PATH_FILTER");
+            }
+        }
+
+        var clampedLimit = Math.Clamp(limit, 1, 100);
+
+        var scope = await _scopeFactory.CreateAsync(validatedPath, cancellationToken).ConfigureAwait(false);
+        await using (scope.ConfigureAwait(false))
+        {
+            IReadOnlyList<ReferenceResult> results;
+            try
+            {
+                results = await scope.Store.FindReferencesAsync(
+                    scope.RepoId, symbolName, validatedPath, clampedLimit, validatedPathFilter).ConfigureAwait(false);
+            }
+            catch (System.Data.Common.DbException)
+            {
+                // FTS5 syntax error — return empty results
+                results = [];
+            }
+
+            var response = new
+            {
+                Symbol = SanitizeSymbolName(symbolName),
+                TotalMatches = results.Count,
+                Results = results.Select((r, index) => new
+                {
+                    File = r.FilePath,
+                    r.Line,
+                    ContextSnippet = r.ContextSnippet,
+                    Rank = index + 1,
+                }),
+            };
+
+            return JsonSerializer.Serialize(response, SerializerOptions);
+        }
+    }
+
+    private static string SanitizeSymbolName(string name)
+    {
+        if (string.IsNullOrEmpty(name))
+        {
+            return string.Empty;
+        }
+
+        // Allow only alphanumeric, colon, underscore, dot, hyphen
+        var sb = new System.Text.StringBuilder(name.Length);
+        foreach (var c in name.Where(c => char.IsLetterOrDigit(c) || c is ':' or '_' or '.' or '-'))
+        {
+            sb.Append(c);
+        }
+
+        var result = sb.ToString();
+        return result.Length > 256 ? result[..256] : result;
+    }
+
+    private static string SerializeError(string error, string code) =>
+        JsonSerializer.Serialize(new { Error = error, Code = code }, SerializerOptions);
+}

--- a/tests/CodeCompress.Integration.Tests/EndToEndTests.cs
+++ b/tests/CodeCompress.Integration.Tests/EndToEndTests.cs
@@ -546,6 +546,84 @@ internal sealed class EndToEndTests : IDisposable
         await Assert.That(results.All(r => r.Symbol.Kind == "Class" && r.Symbol.Name.EndsWith("Service", StringComparison.OrdinalIgnoreCase))).IsTrue();
     }
 
+    // ── Find References Tests ────────────────────────────────────────────
+
+    [Test]
+    public async Task FindReferencesFindsCallSitesAcrossFiles()
+    {
+        await IndexSampleProjectAsync().ConfigureAwait(false);
+
+        // "CombatService" should appear in multiple files (definition + usages)
+        var results = await _store.FindReferencesAsync(_repoId, "CombatService", _sampleProjectPath, 50).ConfigureAwait(false);
+
+        await Assert.That(results.Count).IsGreaterThanOrEqualTo(1);
+        await Assert.That(results.All(r => r.ContextSnippet.Contains("CombatService", StringComparison.Ordinal))).IsTrue();
+        await Assert.That(results.All(r => r.Line > 0)).IsTrue();
+    }
+
+    [Test]
+    public async Task FindReferencesReturnsLineNumbersAndSnippets()
+    {
+        await IndexSampleProjectAsync().ConfigureAwait(false);
+
+        var results = await _store.FindReferencesAsync(_repoId, "ProcessAttack", _sampleProjectPath, 50).ConfigureAwait(false);
+
+        await Assert.That(results.Count).IsGreaterThanOrEqualTo(1);
+
+        foreach (var result in results)
+        {
+            // Line numbers are 1-based
+            await Assert.That(result.Line).IsGreaterThan(0);
+            // Snippet should contain the symbol name
+            await Assert.That(result.ContextSnippet).Contains("ProcessAttack");
+            // Snippet should have context (multiple lines)
+            await Assert.That(result.ContextSnippet).Contains("\n");
+        }
+    }
+
+    [Test]
+    public async Task FindReferencesWithPathFilterScopesToDirectory()
+    {
+        await IndexSampleProjectAsync().ConfigureAwait(false);
+
+        var servicesPath = GetDirectoryPrefix("CombatService.luau");
+        var results = await _store.FindReferencesAsync(_repoId, "CombatService", _sampleProjectPath, 50, servicesPath).ConfigureAwait(false);
+
+        await Assert.That(results.Count).IsGreaterThanOrEqualTo(1);
+        await Assert.That(results.All(r => r.FilePath.StartsWith(servicesPath + "/", StringComparison.OrdinalIgnoreCase)
+            || r.FilePath.StartsWith(servicesPath + "\\", StringComparison.OrdinalIgnoreCase))).IsTrue();
+    }
+
+    [Test]
+    public async Task FindReferencesRespectsLimit()
+    {
+        await IndexSampleProjectAsync().ConfigureAwait(false);
+
+        var results = await _store.FindReferencesAsync(_repoId, "function", _sampleProjectPath, 3).ConfigureAwait(false);
+
+        await Assert.That(results.Count).IsLessThanOrEqualTo(3);
+    }
+
+    [Test]
+    public async Task FindReferencesNoMatchesReturnsEmpty()
+    {
+        await IndexSampleProjectAsync().ConfigureAwait(false);
+
+        var results = await _store.FindReferencesAsync(_repoId, "zzz_completely_nonexistent_xyz", _sampleProjectPath, 20).ConfigureAwait(false);
+
+        await Assert.That(results).Count().IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task FindReferencesEmptySymbolNameReturnsEmpty()
+    {
+        await IndexSampleProjectAsync().ConfigureAwait(false);
+
+        var results = await _store.FindReferencesAsync(_repoId, "", _sampleProjectPath, 20).ConfigureAwait(false);
+
+        await Assert.That(results).Count().IsEqualTo(0);
+    }
+
     // ── Helpers ──────────────────────────────────────────────────────────
 
     /// <summary>

--- a/tests/CodeCompress.Server.Tests/Tools/ReferenceToolsTests.cs
+++ b/tests/CodeCompress.Server.Tests/Tools/ReferenceToolsTests.cs
@@ -1,0 +1,241 @@
+using System.Text.Json;
+using CodeCompress.Core.Models;
+using CodeCompress.Core.Storage;
+using CodeCompress.Core.Validation;
+using CodeCompress.Server.Scoping;
+using CodeCompress.Server.Services;
+using CodeCompress.Server.Tools;
+using NSubstitute;
+using Microsoft.Data.Sqlite;
+using NSubstitute.ExceptionExtensions;
+
+namespace CodeCompress.Server.Tests.Tools;
+
+internal sealed class ReferenceToolsTests
+{
+    private IPathValidator _pathValidator = null!;
+    private IProjectScopeFactory _scopeFactory = null!;
+    private IProjectScope _scope = null!;
+    private ISymbolStore _store = null!;
+    private IActivityTracker _activityTracker = null!;
+    private ReferenceTools _tools = null!;
+
+    [Before(Test)]
+    public void SetUp()
+    {
+        _pathValidator = Substitute.For<IPathValidator>();
+        _scopeFactory = Substitute.For<IProjectScopeFactory>();
+        _scope = Substitute.For<IProjectScope>();
+        _store = Substitute.For<ISymbolStore>();
+        _activityTracker = Substitute.For<IActivityTracker>();
+
+        _scope.Store.Returns(_store);
+        _scope.RepoId.Returns("test-repo-id");
+        _scopeFactory.CreateAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(_scope);
+        _pathValidator.ValidatePath(Arg.Any<string>(), Arg.Any<string>()).Returns(callInfo => callInfo.ArgAt<string>(0));
+
+        _tools = new ReferenceTools(_pathValidator, _scopeFactory, _activityTracker);
+    }
+
+    [Test]
+    public async Task FindReferencesReturnsAllMatchingLocations()
+    {
+        var references = new List<ReferenceResult>
+        {
+            new("src/services/CombatService.luau", 10, "-- context before\nProcessAttack(attacker)\n-- context after", 1.0),
+            new("src/services/DamageService.luau", 25, "-- setup\nresult = ProcessAttack(data)\n-- next line", 2.0),
+            new("src/tests/CombatTests.luau", 5, "\nProcessAttack(mock)\n-- verify", 3.0),
+        };
+        _store.FindReferencesAsync("test-repo-id", "ProcessAttack", "/valid/path", 20, null)
+            .Returns(references);
+
+        var result = await _tools.FindReferences("/valid/path", "ProcessAttack").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        var root = doc.RootElement;
+        await Assert.That(root.GetProperty("total_matches").GetInt32()).IsEqualTo(3);
+        var results = root.GetProperty("results");
+        await Assert.That(results.GetArrayLength()).IsEqualTo(3);
+        await Assert.That(results[0].GetProperty("file").GetString()).IsEqualTo("src/services/CombatService.luau");
+        await Assert.That(results[0].GetProperty("line").GetInt32()).IsEqualTo(10);
+        await Assert.That(results[0].GetProperty("context_snippet").GetString()).Contains("ProcessAttack");
+        await Assert.That(results[0].GetProperty("rank").GetInt32()).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task FindReferencesTypeUsagesReturnsAllLocations()
+    {
+        var references = new List<ReferenceResult>
+        {
+            new("src/Storage/SqliteSymbolStore.cs", 9, "public sealed class SqliteSymbolStore : ISymbolStore\n{", 1.0),
+            new("src/DI/ServiceCollectionExtensions.cs", 15, "services.AddSingleton<ISymbolStore, SqliteSymbolStore>();", 1.0),
+            new("src/Server/Tools/QueryTools.cs", 33, "private readonly ISymbolStore _store;\n", 1.0),
+            new("tests/Mocks/MockStore.cs", 8, "internal class MockStore : ISymbolStore", 1.0),
+            new("src/Scoping/ProjectScope.cs", 12, "public ISymbolStore Store { get; }", 1.0),
+        };
+        _store.FindReferencesAsync("test-repo-id", "ISymbolStore", "/valid/path", 20, null)
+            .Returns(references);
+
+        var result = await _tools.FindReferences("/valid/path", "ISymbolStore").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        var root = doc.RootElement;
+        await Assert.That(root.GetProperty("total_matches").GetInt32()).IsEqualTo(5);
+    }
+
+    [Test]
+    public async Task FindReferencesWithPathFilterPassesFilterToStore()
+    {
+        _store.FindReferencesAsync("test-repo-id", "Logger", Arg.Any<string>(), Arg.Any<int>(), "src")
+            .Returns(new List<ReferenceResult>
+            {
+                new("src/services/LogService.luau", 3, "local Logger = require(...)\n", 1.0),
+            });
+
+        var result = await _tools.FindReferences("/valid/path", "Logger", pathFilter: "src").ConfigureAwait(false);
+
+        await _store.Received(1).FindReferencesAsync(
+            "test-repo-id", "Logger", "/valid/path", 20, "src").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        await Assert.That(doc.RootElement.GetProperty("total_matches").GetInt32()).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task FindReferencesWithLimitRespectsLimit()
+    {
+        _store.FindReferencesAsync("test-repo-id", "ToString", "/valid/path", 10, null)
+            .Returns(new List<ReferenceResult>());
+
+        await _tools.FindReferences("/valid/path", "ToString", limit: 10).ConfigureAwait(false);
+
+        await _store.Received(1).FindReferencesAsync(
+            "test-repo-id", "ToString", "/valid/path", 10, null).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task FindReferencesLimitClampedAbove100()
+    {
+        _store.FindReferencesAsync("test-repo-id", "Foo", "/valid/path", 100, null)
+            .Returns(new List<ReferenceResult>());
+
+        await _tools.FindReferences("/valid/path", "Foo", limit: 200).ConfigureAwait(false);
+
+        await _store.Received(1).FindReferencesAsync(
+            "test-repo-id", "Foo", "/valid/path", 100, null).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task FindReferencesLimitClampedBelow1()
+    {
+        _store.FindReferencesAsync("test-repo-id", "Foo", "/valid/path", 1, null)
+            .Returns(new List<ReferenceResult>());
+
+        await _tools.FindReferences("/valid/path", "Foo", limit: -5).ConfigureAwait(false);
+
+        await _store.Received(1).FindReferencesAsync(
+            "test-repo-id", "Foo", "/valid/path", 1, null).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task FindReferencesNoMatchesReturnsEmptyResults()
+    {
+        _store.FindReferencesAsync("test-repo-id", "UnusedHelper", "/valid/path", 20, null)
+            .Returns(new List<ReferenceResult>());
+
+        var result = await _tools.FindReferences("/valid/path", "UnusedHelper").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        var root = doc.RootElement;
+        await Assert.That(root.GetProperty("total_matches").GetInt32()).IsEqualTo(0);
+        await Assert.That(root.GetProperty("results").GetArrayLength()).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task FindReferencesInvalidPathReturnsError()
+    {
+        _pathValidator.ValidatePath(Arg.Any<string>(), Arg.Any<string>())
+            .Throws(new ArgumentException("Invalid path"));
+
+        var result = await _tools.FindReferences("../../../etc/passwd", "Foo").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        await Assert.That(doc.RootElement.GetProperty("code").GetString()).IsEqualTo("INVALID_PATH");
+    }
+
+    [Test]
+    public async Task FindReferencesEmptySymbolNameReturnsError()
+    {
+        var result = await _tools.FindReferences("/valid/path", "").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        await Assert.That(doc.RootElement.GetProperty("code").GetString()).IsEqualTo("EMPTY_SYMBOL_NAME");
+    }
+
+    [Test]
+    public async Task FindReferencesWhitespaceSymbolNameReturnsError()
+    {
+        var result = await _tools.FindReferences("/valid/path", "   ").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        await Assert.That(doc.RootElement.GetProperty("code").GetString()).IsEqualTo("EMPTY_SYMBOL_NAME");
+    }
+
+    [Test]
+    public async Task FindReferencesInvalidPathFilterReturnsError()
+    {
+        var result = await _tools.FindReferences("/valid/path", "Foo", pathFilter: "../../../etc").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        await Assert.That(doc.RootElement.GetProperty("code").GetString()).IsEqualTo("INVALID_PATH_FILTER");
+    }
+
+    [Test]
+    public async Task FindReferencesFts5ErrorReturnsEmptyResults()
+    {
+        _store.FindReferencesAsync("test-repo-id", Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<string?>())
+            .Throws(new SqliteException("FTS5 syntax error", 1));
+
+        var result = await _tools.FindReferences("/valid/path", "bad\"query").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        await Assert.That(doc.RootElement.GetProperty("total_matches").GetInt32()).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task FindReferencesSymbolNameSanitizedInResponse()
+    {
+        _store.FindReferencesAsync("test-repo-id", Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<string?>())
+            .Returns(new List<ReferenceResult>());
+
+        var result = await _tools.FindReferences("/valid/path", "Process<script>Attack").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        // Script tags should be stripped from the response
+        await Assert.That(doc.RootElement.GetProperty("symbol").GetString()).IsEqualTo("ProcessscriptAttack");
+    }
+
+    [Test]
+    public async Task FindReferencesDoesNotEchoRawPathOnError()
+    {
+        _pathValidator.ValidatePath(Arg.Any<string>(), Arg.Any<string>())
+            .Throws(new ArgumentException("Invalid path"));
+
+        var maliciousPath = "/tmp/<script>alert(1)</script>";
+        var result = await _tools.FindReferences(maliciousPath, "Foo").ConfigureAwait(false);
+
+        await Assert.That(result).DoesNotContain("<script>");
+        await Assert.That(result).DoesNotContain("alert(1)");
+    }
+
+    [Test]
+    public async Task FindReferencesRecordsActivity()
+    {
+        _store.FindReferencesAsync("test-repo-id", Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<string?>())
+            .Returns(new List<ReferenceResult>());
+
+        await _tools.FindReferences("/valid/path", "Foo").ConfigureAwait(false);
+
+        _activityTracker.Received(1).RecordActivity();
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `find_references` MCP tool that locates all usages of a symbol across the indexed codebase
- Uses FTS5 to find matching files, then extracts line-level references with 3-line context snippets (1 before + match + 1 after)
- Supports `pathFilter` to scope results to a directory and `limit` (1-100, default 20) to cap results
- Includes path validation, symbol name sanitization, and FTS5 error handling following existing patterns

Closes #41

## Changes
- **`ReferenceResult`** model: `FilePath`, `Line`, `ContextSnippet`, `Rank`
- **`ISymbolStore.FindReferencesAsync`** + `SqliteSymbolStore` implementation
- **`ReferenceTools.cs`** — new `[McpServerToolType]` with `find_references` tool
- **13 unit tests** (ReferenceToolsTests) covering all acceptance criteria
- **6 integration tests** (EndToEndTests) validating FTS5 search accuracy against sample project

## Test plan
- [x] All 597 tests pass (0 failures, 0 warnings)
- [x] Unit tests cover: call site lookup, type usages, path filter, limit clamping, empty results, path validation, empty symbol name, FTS5 errors, symbol name sanitization, activity tracking
- [x] Integration tests cover: cross-file references, line numbers + snippets, path filter scoping, limit enforcement, no-match empty results, empty symbol name

🤖 Generated with [Claude Code](https://claude.com/claude-code)