### PR TITLE
feat: add project_dependencies tool for cross-project dependency graph

### DIFF
--- a/src/CodeCompress.Core/Models/ProjectDependencyResult.cs
+++ b/src/CodeCompress.Core/Models/ProjectDependencyResult.cs
@@ -1,0 +1,14 @@
+namespace CodeCompress.Core.Models;
+
+public sealed record ProjectNode(
+    string Name,
+    string RelativePath);
+
+public sealed record ProjectDependencyEdge(
+    string FromProject,
+    string ToProject,
+    IReadOnlyList<string> SharedTypes);
+
+public sealed record ProjectDependencyResult(
+    IReadOnlyList<ProjectNode> Projects,
+    IReadOnlyList<ProjectDependencyEdge> Edges);

--- a/src/CodeCompress.Core/Storage/ISymbolStore.cs
+++ b/src/CodeCompress.Core/Storage/ISymbolStore.cs
@@ -49,5 +49,6 @@ public interface ISymbolStore
     public Task<ProjectOutline> GetProjectOutlineAsync(string repoId, bool includePrivate, string groupBy, int maxDepth, string? pathFilter = null, int offset = 0, int limit = 0);
     public Task<ModuleApi> GetModuleApiAsync(string repoId, string filePath);
     public Task<DependencyGraph> GetDependencyGraphAsync(string repoId, string? rootFile, string direction, int depth);
+    public Task<ProjectDependencyResult> GetProjectDependencyGraphAsync(string repoId, string? projectFilter);
     public Task<ChangedFilesResult> GetChangedFilesAsync(string repoId, long snapshotId);
 }

--- a/src/CodeCompress.Core/Storage/SqliteSymbolStore.cs
+++ b/src/CodeCompress.Core/Storage/SqliteSymbolStore.cs
@@ -1449,6 +1449,160 @@ public sealed class SqliteSymbolStore : ISymbolStore
             edges);
     }
 
+    public async Task<ProjectDependencyResult> GetProjectDependencyGraphAsync(string repoId, string? projectFilter)
+    {
+        ArgumentNullException.ThrowIfNull(repoId);
+
+        // 1. Find all .csproj / .fsproj / .vbproj files in the repo
+        var allFiles = await GetFilesByRepoAsync(repoId).ConfigureAwait(false);
+        var projectExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { ".csproj", ".fsproj", ".vbproj" };
+
+        var projectFiles = allFiles
+            .Where(f => projectExtensions.Contains(Path.GetExtension(f.RelativePath)))
+            .ToList();
+
+        // Build lookup: normalized relative path -> FileRecord
+        var projectByNormalizedPath = new Dictionary<string, FileRecord>(StringComparer.OrdinalIgnoreCase);
+        foreach (var pf in projectFiles)
+        {
+            var normalized = pf.RelativePath.Replace('\\', '/');
+            projectByNormalizedPath[normalized] = pf;
+        }
+
+        // Apply project filter
+        var filteredProjects = projectFiles;
+        if (!string.IsNullOrEmpty(projectFilter))
+        {
+            filteredProjects = projectFiles
+                .Where(f => Path.GetFileNameWithoutExtension(f.RelativePath)
+                    .Contains(projectFilter, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+        }
+
+        var projectNodes = new List<ProjectNode>();
+        var projectEdges = new List<ProjectDependencyEdge>();
+
+        foreach (var pf in filteredProjects)
+        {
+            var projectName = Path.GetFileNameWithoutExtension(pf.RelativePath);
+            var normalizedPath = pf.RelativePath.Replace('\\', '/');
+            projectNodes.Add(new ProjectNode(projectName, normalizedPath));
+
+            // 2. Get dependencies for this project file (these are <ProjectReference> entries)
+            var deps = await GetDependenciesByFileAsync(pf.Id).ConfigureAwait(false);
+            var edges = await ResolveProjectReferencesAsync(
+                projectName, normalizedPath, deps, projectByNormalizedPath, allFiles).ConfigureAwait(false);
+            projectEdges.AddRange(edges);
+        }
+
+        // Sort nodes by name
+        projectNodes.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparison.Ordinal));
+
+        return new ProjectDependencyResult(projectNodes, projectEdges);
+    }
+
+    private async Task<List<ProjectDependencyEdge>> ResolveProjectReferencesAsync(
+        string projectName,
+        string normalizedProjectPath,
+        IReadOnlyList<Dependency> deps,
+        Dictionary<string, FileRecord> projectByNormalizedPath,
+        IReadOnlyList<FileRecord> allFiles)
+    {
+        var edges = new List<ProjectDependencyEdge>();
+        var projectDir = Path.GetDirectoryName(normalizedProjectPath)?.Replace('\\', '/') ?? string.Empty;
+
+        // Resolve all dependency paths and match to known project files
+        var resolvedRefs = deps
+            .Select(dep =>
+            {
+                var rawCombined = projectDir.Length > 0
+                    ? projectDir + "/" + dep.RequiresPath.Replace('\\', '/')
+                    : dep.RequiresPath.Replace('\\', '/');
+                return NormalizeRelativePath(rawCombined);
+            })
+            .Select(resolvedPath => projectByNormalizedPath
+                .FirstOrDefault(kvp => kvp.Key.Equals(resolvedPath, StringComparison.OrdinalIgnoreCase)))
+            .Where(kvp => kvp.Value is not null)
+            .ToList();
+
+        // S3267: Loop cannot be simplified — body contains async calls
+#pragma warning disable S3267
+        foreach (var targetProjectFile in resolvedRefs)
+#pragma warning restore S3267
+        {
+            var targetName = Path.GetFileNameWithoutExtension(targetProjectFile.Key);
+            var sharedTypes = await GetPublicTypesForProjectAsync(targetProjectFile.Key, allFiles)
+                .ConfigureAwait(false);
+
+            edges.Add(new ProjectDependencyEdge(projectName, targetName, sharedTypes));
+        }
+
+        return edges;
+    }
+
+    private async Task<IReadOnlyList<string>> GetPublicTypesForProjectAsync(
+        string projectFilePath, IReadOnlyList<FileRecord> allFiles)
+    {
+        // Determine the project directory from its .csproj path
+        var projectDir = Path.GetDirectoryName(projectFilePath)?.Replace('\\', '/') ?? string.Empty;
+
+        // Find all source files under this project's directory (excluding .csproj, .props, etc.)
+        var sourceExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { ".cs", ".fs", ".vb", ".luau", ".lua" };
+        var sourceFiles = allFiles
+            .Where(f =>
+            {
+                var normalized = f.RelativePath.Replace('\\', '/');
+                return normalized.StartsWith(projectDir + "/", StringComparison.OrdinalIgnoreCase)
+                       && sourceExtensions.Contains(Path.GetExtension(normalized));
+            })
+            .ToList();
+
+        var publicTypes = new List<string>();
+
+        foreach (var sf in sourceFiles)
+        {
+            var symbols = await GetSymbolsByFileAsync(sf.Id).ConfigureAwait(false);
+            var types = symbols
+                .Where(sym => string.Equals(sym.Visibility, "Public", StringComparison.OrdinalIgnoreCase)
+                    && sym.ParentSymbol is null
+                    && IsTypeKind(sym.Kind))
+                .Select(sym => $"{sym.Kind}: {sym.Name}");
+
+            publicTypes.AddRange(types);
+        }
+
+        publicTypes.Sort(StringComparer.Ordinal);
+        return publicTypes;
+    }
+
+    private static bool IsTypeKind(string kind) =>
+        string.Equals(kind, "Class", StringComparison.OrdinalIgnoreCase)
+        || string.Equals(kind, "Interface", StringComparison.OrdinalIgnoreCase)
+        || string.Equals(kind, "Type", StringComparison.OrdinalIgnoreCase);
+
+    private static string NormalizeRelativePath(string path)
+    {
+        var segments = path.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        var stack = new List<string>();
+
+        foreach (var segment in segments)
+        {
+            if (segment == "..")
+            {
+                if (stack.Count > 0)
+                {
+                    stack.RemoveAt(stack.Count - 1);
+                }
+            }
+            else if (segment != ".")
+            {
+                stack.Add(segment);
+            }
+        }
+
+        return string.Join("/", stack);
+    }
+
     public async Task<ChangedFilesResult> GetChangedFilesAsync(string repoId, long snapshotId)
     {
         ArgumentNullException.ThrowIfNull(repoId);

--- a/src/CodeCompress.Server/Tools/DependencyTools.cs
+++ b/src/CodeCompress.Server/Tools/DependencyTools.cs
@@ -176,6 +176,126 @@ internal sealed class DependencyTools
         return sb.ToString();
     }
 
+    [McpServerTool(Name = "project_dependencies")]
+    [Description("Show inter-project dependency relationships in a .NET solution. Parses ProjectReference entries from indexed .csproj files to build a project-level dependency graph with shared public types.")]
+    public async Task<string> ProjectDependencies(
+        [Description("ABSOLUTE path to the project root directory — the same root used with index_project (e.g., 'C:\\Projects\\MySolution' or '/home/user/my-solution'). Must NOT be a subdirectory or relative path.")] string path,
+        [Description("Filter to projects whose name contains this string (case-insensitive). Omit for all projects.")] string? projectFilter = null,
+        CancellationToken cancellationToken = default)
+    {
+        _activityTracker.RecordActivity();
+
+        string validatedPath;
+        try
+        {
+            validatedPath = _pathValidator.ValidatePath(path, path);
+        }
+        catch (ArgumentException)
+        {
+            return SerializeError("Path validation failed", "INVALID_PATH");
+        }
+
+        var scope = await _scopeFactory.CreateAsync(validatedPath, cancellationToken).ConfigureAwait(false);
+        await using (scope.ConfigureAwait(false))
+        {
+            var result = await scope.Store.GetProjectDependencyGraphAsync(scope.RepoId, projectFilter)
+                .ConfigureAwait(false);
+
+            if (result.Projects.Count == 0)
+            {
+                return SerializeError("No project files (.csproj/.fsproj/.vbproj) found in index. Run index_project first.", "NO_PROJECTS");
+            }
+
+            return FormatProjectDependencies(result, projectFilter);
+        }
+    }
+
+    private static string FormatProjectDependencies(ProjectDependencyResult result, string? projectFilter)
+    {
+        var sb = new StringBuilder();
+
+        // Header
+        if (projectFilter is not null)
+        {
+            sb.AppendLine(CultureInfo.InvariantCulture,
+                $"Project dependencies (filter: \"{projectFilter}\"):");
+        }
+        else
+        {
+            sb.AppendLine("Project dependencies:");
+        }
+
+        sb.AppendLine();
+
+        // Build edge lookups
+        var outgoing = new Dictionary<string, List<ProjectDependencyEdge>>(StringComparer.Ordinal);
+        var incoming = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+
+        foreach (var edge in result.Edges)
+        {
+            if (!outgoing.TryGetValue(edge.FromProject, out var outList))
+            {
+                outList = [];
+                outgoing[edge.FromProject] = outList;
+            }
+
+            outList.Add(edge);
+
+            if (!incoming.TryGetValue(edge.ToProject, out var inList))
+            {
+                inList = [];
+                incoming[edge.ToProject] = inList;
+            }
+
+            inList.Add(edge.FromProject);
+        }
+
+        // Render each project node
+        foreach (var project in result.Projects)
+        {
+            sb.AppendLine(CultureInfo.InvariantCulture, $"[{project.Name}] ({project.RelativePath})");
+
+            // Show outgoing references
+            if (outgoing.TryGetValue(project.Name, out var refs))
+            {
+                sb.AppendLine(CultureInfo.InvariantCulture,
+                    $"  references -> {string.Join(", ", refs.Select(r => r.ToProject).Order(StringComparer.Ordinal))}");
+
+                // Show shared types per reference
+                foreach (var edge in refs.OrderBy(e => e.ToProject, StringComparer.Ordinal))
+                {
+                    if (edge.SharedTypes.Count > 0)
+                    {
+                        sb.AppendLine(CultureInfo.InvariantCulture,
+                            $"    via {edge.ToProject}: {string.Join(", ", edge.SharedTypes)}");
+                    }
+                }
+            }
+            else
+            {
+                sb.AppendLine("  references -> (none)");
+            }
+
+            // Show incoming references
+            if (incoming.TryGetValue(project.Name, out var inRefs))
+            {
+                sb.AppendLine(CultureInfo.InvariantCulture,
+                    $"  referenced by -> {string.Join(", ", inRefs.Order(StringComparer.Ordinal))}");
+            }
+            else
+            {
+                sb.AppendLine("  referenced by -> (none)");
+            }
+
+            sb.AppendLine();
+        }
+
+        sb.AppendLine(CultureInfo.InvariantCulture,
+            $"Total: {result.Projects.Count} projects, {result.Edges.Count} project references");
+
+        return sb.ToString();
+    }
+
     private static string SerializeError(string error, string code) =>
         JsonSerializer.Serialize(new { Error = error, Code = code }, SerializerOptions);
 }

--- a/tests/CodeCompress.Integration.Tests/ProjectDependencyGraphTests.cs
+++ b/tests/CodeCompress.Integration.Tests/ProjectDependencyGraphTests.cs
@@ -1,0 +1,234 @@
+using CodeCompress.Core.Indexing;
+using CodeCompress.Core.Models;
+using CodeCompress.Core.Parsers;
+using CodeCompress.Core.Storage;
+using CodeCompress.Core.Validation;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CodeCompress.Integration.Tests;
+
+internal sealed class ProjectDependencyGraphTests : IDisposable
+{
+    private SqliteConnection _connection = null!;
+    private SqliteSymbolStore _store = null!;
+    private IndexEngine _engine = null!;
+    private string _tempDir = null!;
+    private string _repoId = null!;
+
+    public void Dispose()
+    {
+        _connection?.Dispose();
+
+        if (_tempDir is not null && Directory.Exists(_tempDir))
+        {
+            try { Directory.Delete(_tempDir, recursive: true); }
+            catch (IOException) { /* best effort cleanup */ }
+        }
+    }
+
+    [Before(Test)]
+    public async Task SetUp()
+    {
+        _connection = new SqliteConnection("Data Source=:memory:");
+        await _connection.OpenAsync().ConfigureAwait(false);
+        await Migrations.ApplyAsync(_connection).ConfigureAwait(false);
+
+        _store = new SqliteSymbolStore(_connection);
+
+        // Register both CSharp and DotNetProject parsers
+        var parsers = new ILanguageParser[] { new CSharpParser(), new DotNetProjectParser() };
+        var fileHasher = new FileHasher();
+        var changeTracker = new ChangeTracker();
+        var pathValidator = new PathValidatorService();
+
+        _engine = new IndexEngine(
+            fileHasher,
+            changeTracker,
+            parsers,
+            _store,
+            pathValidator,
+            NullLogger<IndexEngine>.Instance);
+
+        _tempDir = Path.Combine(Path.GetTempPath(), "codecompress-test-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_tempDir);
+
+        await CreateMultiProjectStructureAsync().ConfigureAwait(false);
+
+        _repoId = IndexEngine.ComputeRepoId(Path.GetFullPath(_tempDir));
+    }
+
+    [After(Test)]
+    public async Task TearDown()
+    {
+        await _connection.DisposeAsync().ConfigureAwait(false);
+    }
+
+    // ── Tests ────────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task ProjectDependencyGraphShowsInterProjectReferences()
+    {
+        await IndexAsync().ConfigureAwait(false);
+
+        var result = await _store.GetProjectDependencyGraphAsync(_repoId, projectFilter: null)
+            .ConfigureAwait(false);
+
+        // Should find both project files
+        await Assert.That(result.Projects).Count().IsGreaterThanOrEqualTo(2);
+
+        var projectNames = result.Projects.Select(p => p.Name).ToList();
+        await Assert.That(projectNames).Contains("MyApp");
+        await Assert.That(projectNames).Contains("MyCore");
+    }
+
+    [Test]
+    public async Task ProjectDependencyGraphShowsEdgeFromAppToCore()
+    {
+        await IndexAsync().ConfigureAwait(false);
+
+        var result = await _store.GetProjectDependencyGraphAsync(_repoId, projectFilter: null)
+            .ConfigureAwait(false);
+
+        // MyApp references MyCore
+        var appToCore = result.Edges.FirstOrDefault(
+            e => e.FromProject == "MyApp" && e.ToProject == "MyCore");
+
+        await Assert.That(appToCore).IsNotNull();
+    }
+
+    [Test]
+    public async Task ProjectDependencyGraphShowsSharedPublicTypes()
+    {
+        await IndexAsync().ConfigureAwait(false);
+
+        var result = await _store.GetProjectDependencyGraphAsync(_repoId, projectFilter: null)
+            .ConfigureAwait(false);
+
+        var appToCore = result.Edges.First(
+            e => e.FromProject == "MyApp" && e.ToProject == "MyCore");
+
+        // MyCore has public interface IService and class ServiceBase
+        await Assert.That(appToCore.SharedTypes).Contains("Interface: IService");
+        await Assert.That(appToCore.SharedTypes).Contains("Class: ServiceBase");
+    }
+
+    [Test]
+    public async Task ProjectFilterReturnsOnlyMatchingProjects()
+    {
+        await IndexAsync().ConfigureAwait(false);
+
+        var result = await _store.GetProjectDependencyGraphAsync(_repoId, projectFilter: "MyApp")
+            .ConfigureAwait(false);
+
+        await Assert.That(result.Projects).Count().IsEqualTo(1);
+        await Assert.That(result.Projects[0].Name).IsEqualTo("MyApp");
+    }
+
+    [Test]
+    public async Task NoProjectFilesReturnsEmptyResult()
+    {
+        // Index a directory with no .csproj files
+        var emptyDir = Path.Combine(_tempDir, "empty");
+        Directory.CreateDirectory(emptyDir);
+        await File.WriteAllTextAsync(Path.Combine(emptyDir, "test.cs"), "namespace Test; public class Foo { }").ConfigureAwait(false);
+
+        var emptyRepoId = IndexEngine.ComputeRepoId(Path.GetFullPath(emptyDir));
+        await _engine.IndexProjectAsync(emptyDir, "csharp").ConfigureAwait(false);
+
+        var result = await _store.GetProjectDependencyGraphAsync(emptyRepoId, projectFilter: null)
+            .ConfigureAwait(false);
+
+        await Assert.That(result.Projects).Count().IsEqualTo(0);
+        await Assert.That(result.Edges).Count().IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ProjectWithNoReferencesHasNoEdges()
+    {
+        await IndexAsync().ConfigureAwait(false);
+
+        var result = await _store.GetProjectDependencyGraphAsync(_repoId, projectFilter: "MyCore")
+            .ConfigureAwait(false);
+
+        // MyCore doesn't reference anything
+        var coreEdges = result.Edges.Where(e => e.FromProject == "MyCore").ToList();
+        await Assert.That(coreEdges).Count().IsEqualTo(0);
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    private async Task IndexAsync()
+    {
+        await _engine.IndexProjectAsync(_tempDir).ConfigureAwait(false);
+    }
+
+    private async Task CreateMultiProjectStructureAsync()
+    {
+        // Create src/MyCore/MyCore.csproj
+        var coreDir = Path.Combine(_tempDir, "src", "MyCore");
+        Directory.CreateDirectory(coreDir);
+
+        await File.WriteAllTextAsync(Path.Combine(coreDir, "MyCore.csproj"),
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+              </PropertyGroup>
+            </Project>
+            """).ConfigureAwait(false);
+
+        await File.WriteAllTextAsync(Path.Combine(coreDir, "IService.cs"),
+            """
+            namespace MyCore;
+            public interface IService
+            {
+                void Execute();
+            }
+            """).ConfigureAwait(false);
+
+        await File.WriteAllTextAsync(Path.Combine(coreDir, "ServiceBase.cs"),
+            """
+            namespace MyCore;
+            public class ServiceBase : IService
+            {
+                public virtual void Execute() { }
+            }
+            """).ConfigureAwait(false);
+
+        // Internal type should NOT appear in shared types
+        await File.WriteAllTextAsync(Path.Combine(coreDir, "InternalHelper.cs"),
+            """
+            namespace MyCore;
+            internal class InternalHelper
+            {
+                public static void DoWork() { }
+            }
+            """).ConfigureAwait(false);
+
+        // Create src/MyApp/MyApp.csproj with ProjectReference to MyCore
+        var appDir = Path.Combine(_tempDir, "src", "MyApp");
+        Directory.CreateDirectory(appDir);
+
+        await File.WriteAllTextAsync(Path.Combine(appDir, "MyApp.csproj"),
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+              </PropertyGroup>
+              <ItemGroup>
+                <ProjectReference Include="..\MyCore\MyCore.csproj" />
+              </ItemGroup>
+            </Project>
+            """).ConfigureAwait(false);
+
+        await File.WriteAllTextAsync(Path.Combine(appDir, "Program.cs"),
+            """
+            namespace MyApp;
+            public class Program
+            {
+                public static void Main() { }
+            }
+            """).ConfigureAwait(false);
+    }
+}

--- a/tests/CodeCompress.Server.Tests/Tools/ProjectDependenciesToolTests.cs
+++ b/tests/CodeCompress.Server.Tests/Tools/ProjectDependenciesToolTests.cs
@@ -1,0 +1,218 @@
+using System.Text.Json;
+using CodeCompress.Core.Indexing;
+using CodeCompress.Core.Models;
+using CodeCompress.Core.Storage;
+using CodeCompress.Core.Validation;
+using CodeCompress.Server.Scoping;
+using CodeCompress.Server.Services;
+using CodeCompress.Server.Tools;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace CodeCompress.Server.Tests.Tools;
+
+internal sealed class ProjectDependenciesToolTests
+{
+    private IPathValidator _pathValidator = null!;
+    private IProjectScopeFactory _scopeFactory = null!;
+    private IProjectScope _scope = null!;
+    private IIndexEngine _engine = null!;
+    private ISymbolStore _store = null!;
+    private IActivityTracker _activityTracker = null!;
+    private DependencyTools _tools = null!;
+
+    [Before(Test)]
+    public void SetUp()
+    {
+        _pathValidator = Substitute.For<IPathValidator>();
+        _scopeFactory = Substitute.For<IProjectScopeFactory>();
+        _scope = Substitute.For<IProjectScope>();
+        _engine = Substitute.For<IIndexEngine>();
+        _store = Substitute.For<ISymbolStore>();
+        _activityTracker = Substitute.For<IActivityTracker>();
+
+        _scope.Engine.Returns(_engine);
+        _scope.Store.Returns(_store);
+        _scope.RepoId.Returns("test-repo-id");
+        _scopeFactory.CreateAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(_scope);
+        _pathValidator.ValidatePath(Arg.Any<string>(), Arg.Any<string>()).Returns(callInfo => callInfo.ArgAt<string>(0));
+
+        _tools = new DependencyTools(_pathValidator, _scopeFactory, _activityTracker);
+    }
+
+    // ── 1. BasicProjectGraphShowsReferences ─────────────────────────
+
+    [Test]
+    public async Task BasicProjectGraphShowsReferences()
+    {
+        var result = new ProjectDependencyResult(
+            [
+                new ProjectNode("Core", "src/Core/Core.csproj"),
+                new ProjectNode("Server", "src/Server/Server.csproj"),
+            ],
+            [
+                new ProjectDependencyEdge("Server", "Core", ["Interface: IService", "Class: ServiceBase"]),
+            ]);
+
+        _store.GetProjectDependencyGraphAsync("test-repo-id", null).Returns(result);
+
+        var output = await _tools.ProjectDependencies("/valid/path").ConfigureAwait(false);
+
+        await Assert.That(output).Contains("Project dependencies:");
+        await Assert.That(output).Contains("[Core]");
+        await Assert.That(output).Contains("[Server]");
+        await Assert.That(output).Contains("references -> Core");
+        await Assert.That(output).Contains("via Core: Interface: IService, Class: ServiceBase");
+    }
+
+    // ── 2. ProjectFilterShowsFilteredResults ────────────────────────
+
+    [Test]
+    public async Task ProjectFilterShowsFilteredResults()
+    {
+        var result = new ProjectDependencyResult(
+            [new ProjectNode("Server", "src/Server/Server.csproj")],
+            [new ProjectDependencyEdge("Server", "Core", [])]);
+
+        _store.GetProjectDependencyGraphAsync("test-repo-id", "Server").Returns(result);
+
+        var output = await _tools.ProjectDependencies("/valid/path", projectFilter: "Server").ConfigureAwait(false);
+
+        await Assert.That(output).Contains("filter: \"Server\"");
+        await Assert.That(output).Contains("[Server]");
+    }
+
+    // ── 3. NoProjectsFoundReturnsError ──────────────────────────────
+
+    [Test]
+    public async Task NoProjectsFoundReturnsError()
+    {
+        var result = new ProjectDependencyResult([], []);
+
+        _store.GetProjectDependencyGraphAsync("test-repo-id", null).Returns(result);
+
+        var output = await _tools.ProjectDependencies("/valid/path").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(output);
+        var root = doc.RootElement;
+        await Assert.That(root.GetProperty("code").GetString()).IsEqualTo("NO_PROJECTS");
+    }
+
+    // ── 4. PathValidationRejectsTraversal ───────────────────────────
+
+    [Test]
+    public async Task PathValidationRejectsTraversal()
+    {
+        _pathValidator.ValidatePath(Arg.Any<string>(), Arg.Any<string>())
+            .Throws(new ArgumentException("Path traversal detected"));
+
+        var output = await _tools.ProjectDependencies("/../../../etc/passwd").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(output);
+        var root = doc.RootElement;
+        await Assert.That(root.GetProperty("code").GetString()).IsEqualTo("INVALID_PATH");
+    }
+
+    // ── 5. ProjectWithNoReferencesShowsNone ─────────────────────────
+
+    [Test]
+    public async Task ProjectWithNoReferencesShowsNone()
+    {
+        var result = new ProjectDependencyResult(
+            [new ProjectNode("Standalone", "src/Standalone/Standalone.csproj")],
+            []);
+
+        _store.GetProjectDependencyGraphAsync("test-repo-id", null).Returns(result);
+
+        var output = await _tools.ProjectDependencies("/valid/path").ConfigureAwait(false);
+
+        await Assert.That(output).Contains("[Standalone]");
+        await Assert.That(output).Contains("references -> (none)");
+        await Assert.That(output).Contains("referenced by -> (none)");
+    }
+
+    // ── 6. SummaryShowsTotalCounts ──────────────────────────────────
+
+    [Test]
+    public async Task SummaryShowsTotalCounts()
+    {
+        var result = new ProjectDependencyResult(
+            [
+                new ProjectNode("A", "src/A/A.csproj"),
+                new ProjectNode("B", "src/B/B.csproj"),
+                new ProjectNode("C", "src/C/C.csproj"),
+            ],
+            [
+                new ProjectDependencyEdge("B", "A", []),
+                new ProjectDependencyEdge("C", "A", []),
+            ]);
+
+        _store.GetProjectDependencyGraphAsync("test-repo-id", null).Returns(result);
+
+        var output = await _tools.ProjectDependencies("/valid/path").ConfigureAwait(false);
+
+        await Assert.That(output).Contains("Total: 3 projects, 2 project references");
+    }
+
+    // ── 7. ReferencedByShowsIncomingEdges ───────────────────────────
+
+    [Test]
+    public async Task ReferencedByShowsIncomingEdges()
+    {
+        var result = new ProjectDependencyResult(
+            [
+                new ProjectNode("Core", "src/Core/Core.csproj"),
+                new ProjectNode("Server", "src/Server/Server.csproj"),
+                new ProjectNode("Cli", "src/Cli/Cli.csproj"),
+            ],
+            [
+                new ProjectDependencyEdge("Server", "Core", []),
+                new ProjectDependencyEdge("Cli", "Core", []),
+            ]);
+
+        _store.GetProjectDependencyGraphAsync("test-repo-id", null).Returns(result);
+
+        var output = await _tools.ProjectDependencies("/valid/path").ConfigureAwait(false);
+
+        await Assert.That(output).Contains("referenced by -> Cli, Server");
+    }
+
+    // ── 8. RecordsActivity ──────────────────────────────────────────
+
+    [Test]
+    public async Task RecordsActivity()
+    {
+        var result = new ProjectDependencyResult(
+            [new ProjectNode("A", "src/A/A.csproj")],
+            []);
+
+        _store.GetProjectDependencyGraphAsync("test-repo-id", null).Returns(result);
+
+        await _tools.ProjectDependencies("/valid/path").ConfigureAwait(false);
+
+        _activityTracker.Received(1).RecordActivity();
+    }
+
+    // ── 9. MultipleReferencesFromSameProjectSorted ──────────────────
+
+    [Test]
+    public async Task MultipleReferencesFromSameProjectSorted()
+    {
+        var result = new ProjectDependencyResult(
+            [
+                new ProjectNode("App", "src/App/App.csproj"),
+                new ProjectNode("Core", "src/Core/Core.csproj"),
+                new ProjectNode("Infra", "src/Infra/Infra.csproj"),
+            ],
+            [
+                new ProjectDependencyEdge("App", "Infra", []),
+                new ProjectDependencyEdge("App", "Core", []),
+            ]);
+
+        _store.GetProjectDependencyGraphAsync("test-repo-id", null).Returns(result);
+
+        var output = await _tools.ProjectDependencies("/valid/path").ConfigureAwait(false);
+
+        await Assert.That(output).Contains("references -> Core, Infra");
+    }
+}


### PR DESCRIPTION
## Summary
- Adds new `project_dependencies` MCP tool that shows inter-project dependency relationships by resolving `<ProjectReference>` entries from indexed `.csproj` files
- Shows project-to-project edges with shared public types (interfaces, classes) that flow between projects
- Supports optional `projectFilter` parameter for filtering by project name
- Token-efficient output format with references, shared types, and incoming reference directions

## Implementation
- **New models**: `ProjectNode`, `ProjectDependencyEdge`, `ProjectDependencyResult` in `Core/Models/`
- **New store method**: `GetProjectDependencyGraphAsync` on `ISymbolStore`/`SqliteSymbolStore` — discovers `.csproj` files from the index, resolves relative ProjectReference paths, queries public types from referenced projects
- **New tool**: `project_dependencies` in `DependencyTools.cs` with path validation, error handling, and formatted output
- No schema changes needed — leverages existing `DotNetProjectParser` data

## Test plan
- [x] 9 unit tests for tool layer (mocked store, path validation, error cases, formatting)
- [x] 6 integration tests with real SQLite and temp multi-project fixtures (edge resolution, shared types, filtering, empty results)
- [x] All 614 tests pass
- [ ] Manual testing with real .NET solution

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)