### PR TITLE
feat: add topic_outline MCP tool for topic-scoped outline

### DIFF
--- a/src/CodeCompress.Core/Storage/ISymbolStore.cs
+++ b/src/CodeCompress.Core/Storage/ISymbolStore.cs
@@ -51,4 +51,7 @@ public interface ISymbolStore
     public Task<DependencyGraph> GetDependencyGraphAsync(string repoId, string? rootFile, string direction, int depth);
     public Task<ProjectDependencyResult> GetProjectDependencyGraphAsync(string repoId, string? projectFilter);
     public Task<ChangedFilesResult> GetChangedFilesAsync(string repoId, long snapshotId);
+
+    // Topic outline
+    public Task<ProjectOutline> SearchTopicOutlineAsync(string repoId, string query, int limit, string? pathFilter = null);
 }

--- a/src/CodeCompress.Core/Storage/SqliteSymbolStore.cs
+++ b/src/CodeCompress.Core/Storage/SqliteSymbolStore.cs
@@ -1647,4 +1647,135 @@ public sealed class SqliteSymbolStore : ISymbolStore
 
         return new ChangedFilesResult(added, modified, removed);
     }
+
+    public async Task<ProjectOutline> SearchTopicOutlineAsync(string repoId, string query, int limit, string? pathFilter = null)
+    {
+        ArgumentNullException.ThrowIfNull(repoId);
+        ArgumentNullException.ThrowIfNull(query);
+
+        if (query.Length == 0)
+        {
+            return new ProjectOutline(repoId, [], 0, false);
+        }
+
+        var clampedLimit = Math.Min(Math.Max(limit, 1), 200);
+
+        // Step 1: Count total FTS5 matches for truncation detection
+        using var countCommand = _connection.CreateCommand();
+        var countSql = new StringBuilder();
+        countSql.Append(
+            """
+            SELECT COUNT(*)
+            FROM symbols_fts
+            JOIN symbols s ON s.id = symbols_fts.rowid
+            JOIN files f ON f.id = s.file_id
+            WHERE symbols_fts MATCH @query AND f.repo_id = @repoId
+            """);
+
+        if (pathFilter is not null)
+        {
+            countSql.Append(@" AND f.relative_path LIKE @pathPrefix || '%' ESCAPE '!'");
+        }
+
+#pragma warning disable CA2100 // SQL is built from static literals and parameterized placeholders only
+        countCommand.CommandText = countSql.ToString();
+#pragma warning restore CA2100
+
+        countCommand.Parameters.AddWithValue("@query", query);
+        countCommand.Parameters.AddWithValue("@repoId", repoId);
+
+        string? normalizedPrefix = null;
+        if (pathFilter is not null)
+        {
+            normalizedPrefix = pathFilter.Replace('/', Path.DirectorySeparatorChar);
+            normalizedPrefix = normalizedPrefix.EndsWith(Path.DirectorySeparatorChar)
+                ? normalizedPrefix
+                : normalizedPrefix + Path.DirectorySeparatorChar;
+            countCommand.Parameters.AddWithValue("@pathPrefix", normalizedPrefix);
+        }
+
+        var totalCount = Convert.ToInt32(
+            await countCommand.ExecuteScalarAsync().ConfigureAwait(false),
+            CultureInfo.InvariantCulture);
+
+        if (totalCount == 0)
+        {
+            return new ProjectOutline(repoId, [], 0, false);
+        }
+
+        // Step 2: Fetch symbols with limit, ordered by file then line
+        using var command = _connection.CreateCommand();
+        var sql = new StringBuilder();
+        sql.Append(
+            """
+            SELECT s.id, s.file_id, s.name, s.kind, s.signature, s.parent_symbol,
+                   s.byte_offset, s.byte_length, s.line_start, s.line_end, s.visibility, s.doc_comment,
+                   f.relative_path
+            FROM symbols_fts
+            JOIN symbols s ON s.id = symbols_fts.rowid
+            JOIN files f ON f.id = s.file_id
+            WHERE symbols_fts MATCH @query AND f.repo_id = @repoId
+            """);
+
+        if (pathFilter is not null)
+        {
+            sql.Append(@" AND f.relative_path LIKE @pathPrefix || '%' ESCAPE '!'");
+        }
+
+        sql.Append(" ORDER BY f.relative_path, s.line_start LIMIT @limit");
+
+#pragma warning disable CA2100 // SQL is built from static literals and parameterized placeholders only
+        command.CommandText = sql.ToString();
+#pragma warning restore CA2100
+
+        command.Parameters.AddWithValue("@query", query);
+        command.Parameters.AddWithValue("@repoId", repoId);
+        command.Parameters.AddWithValue("@limit", clampedLimit);
+
+        if (pathFilter is not null)
+        {
+            command.Parameters.AddWithValue("@pathPrefix", normalizedPrefix!);
+        }
+
+        using var reader = await command.ExecuteReaderAsync().ConfigureAwait(false);
+
+        var symbolsByFile = new Dictionary<string, List<Symbol>>(StringComparer.Ordinal);
+
+        while (await reader.ReadAsync().ConfigureAwait(false))
+        {
+            var symbol = new Symbol(
+                reader.GetInt64(0),
+                reader.GetInt64(1),
+                reader.GetString(2),
+                reader.GetString(3),
+                reader.GetString(4),
+                await reader.IsDBNullAsync(5).ConfigureAwait(false) ? null : reader.GetString(5),
+                reader.GetInt32(6),
+                reader.GetInt32(7),
+                reader.GetInt32(8),
+                reader.GetInt32(9),
+                reader.GetString(10),
+                await reader.IsDBNullAsync(11).ConfigureAwait(false) ? null : reader.GetString(11));
+
+            var filePath = reader.GetString(12);
+
+            if (!symbolsByFile.TryGetValue(filePath, out var list))
+            {
+                list = [];
+                symbolsByFile[filePath] = list;
+            }
+
+            list.Add(symbol);
+        }
+
+        var groups = symbolsByFile
+            .OrderBy(kvp => kvp.Key, StringComparer.Ordinal)
+            .Select(kvp => new OutlineGroup(kvp.Key, kvp.Value, []))
+            .ToList();
+
+        var fetchedCount = symbolsByFile.Values.Sum(l => l.Count);
+        var isTruncated = fetchedCount < totalCount;
+
+        return new ProjectOutline(repoId, groups, totalCount, isTruncated);
+    }
 }

--- a/src/CodeCompress.Server/Tools/QueryTools.cs
+++ b/src/CodeCompress.Server/Tools/QueryTools.cs
@@ -529,6 +529,74 @@ internal sealed class QueryTools
         }
     }
 
+    [McpServerTool(Name = "topic_outline")]
+    [Description("Search for symbols related to a topic and return results in a structured outline format grouped by file. Combines the search power of search_symbols with the structured presentation of project_outline. Use for questions like 'show me all authentication-related types' or 'find all Kubernetes symbols'.")]
+    public async Task<string> TopicOutline(
+        [Description("ABSOLUTE path to the project root directory — the same root used with index_project (e.g., 'C:\\Projects\\MyGame' or '/home/user/my-project'). Must NOT be a subdirectory or relative path.")] string path,
+        [Description("Topic or keyword to search for (e.g., 'authentication', 'kubernetes', 'database'). Searches symbol names, signatures, and doc comments via FTS5.")] string topic,
+        [Description("Filter results to files under this relative directory path (e.g., 'src/Core/Models'). Optional.")] string? pathFilter = null,
+        [Description("Maximum number of symbols to return (1-200, default 50). Limits output to prevent token overflow.")] int maxResults = 50,
+        CancellationToken cancellationToken = default)
+    {
+        _activityTracker.RecordActivity();
+
+        string validatedPath;
+        try
+        {
+            validatedPath = _pathValidator.ValidatePath(path, path);
+        }
+        catch (ArgumentException)
+        {
+            return SerializeError("Path validation failed", "INVALID_PATH");
+        }
+
+        if (string.IsNullOrWhiteSpace(topic))
+        {
+            return SerializeError("Topic query cannot be empty", "EMPTY_QUERY");
+        }
+
+        string? validatedPathFilter = null;
+        if (pathFilter is not null)
+        {
+            try
+            {
+                validatedPathFilter = PathValidator.ValidatePathFilter(pathFilter);
+            }
+            catch (ArgumentException)
+            {
+                return SerializeError("Invalid path filter", "INVALID_PATH_FILTER");
+            }
+        }
+
+        var clampedLimit = Math.Clamp(maxResults, 1, 200);
+        var sanitizedQuery = Fts5QuerySanitizer.Sanitize(topic);
+
+        if (string.IsNullOrWhiteSpace(sanitizedQuery))
+        {
+            return SerializeError("Topic query cannot be empty", "EMPTY_QUERY");
+        }
+
+        var scope = await _scopeFactory.CreateAsync(validatedPath, cancellationToken).ConfigureAwait(false);
+        await using (scope.ConfigureAwait(false))
+        {
+            Core.Models.ProjectOutline outline;
+            try
+            {
+                outline = await scope.Store.SearchTopicOutlineAsync(
+                    scope.RepoId, sanitizedQuery, clampedLimit, validatedPathFilter).ConfigureAwait(false);
+            }
+            catch (System.Data.Common.DbException)
+            {
+                // FTS5 syntax error — retry with literal phrase
+                var literalQuery = $"\"{topic.Replace("\"", string.Empty, StringComparison.Ordinal)}\"";
+                outline = await scope.Store.SearchTopicOutlineAsync(
+                    scope.RepoId, literalQuery, clampedLimit, validatedPathFilter).ConfigureAwait(false);
+            }
+
+            return FormatTopicOutline(outline, sanitizedQuery, clampedLimit);
+        }
+    }
+
     [McpServerTool(Name = "search_text")]
     [Description("Search raw indexed file contents using FTS5 full-text search. Use for string literals, comments, or non-symbol patterns. Use pathFilter to scope results to a specific directory (e.g., pathFilter='src/' to exclude test files, pathFilter='src/Config' to target configuration).")]
     public async Task<string> SearchText(
@@ -615,6 +683,35 @@ internal sealed class QueryTools
 
             return JsonSerializer.Serialize(response, SerializerOptions);
         }
+    }
+
+    private static string FormatTopicOutline(Core.Models.ProjectOutline outline, string query, int maxResults)
+    {
+        var sb = new StringBuilder();
+        var pageSymbols = CountSymbols(outline.Groups);
+
+        if (outline.IsTruncated)
+        {
+            sb.AppendLine(CultureInfo.InvariantCulture, $"# Topic Outline: \"{query}\" (showing {pageSymbols} of {outline.TotalSymbolCount} matches)");
+        }
+        else
+        {
+            sb.AppendLine(CultureInfo.InvariantCulture, $"# Topic Outline: \"{query}\" ({pageSymbols} matches)");
+        }
+
+        foreach (var group in outline.Groups)
+        {
+            RenderGroup(sb, group, depth: 0);
+        }
+
+        if (outline.IsTruncated)
+        {
+            sb.AppendLine();
+            sb.AppendLine("---");
+            sb.AppendLine(CultureInfo.InvariantCulture, $"**Truncated:** {outline.TotalSymbolCount - pageSymbols} more matches. Refine your topic query or use `pathFilter` to narrow results. Max: `maxResults: {maxResults}`.");
+        }
+
+        return sb.ToString();
     }
 
     private static string FormatOutline(Core.Models.ProjectOutline outline, int offset, int maxSymbols)

--- a/tests/CodeCompress.Core.Tests/Storage/SymbolStoreQueryTests.cs
+++ b/tests/CodeCompress.Core.Tests/Storage/SymbolStoreQueryTests.cs
@@ -853,4 +853,142 @@ internal sealed class SymbolStoreQueryTests
 
         await Assert.That(results).Count().IsEqualTo(0);
     }
+
+    // ── SearchTopicOutlineAsync Tests ────────────────────────────────────
+
+    [Test]
+    public async Task SearchTopicOutlineAsyncReturnsMatchingSymbolsGroupedByFile()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var (store, _) = await SeedTestDataAsync(connection).ConfigureAwait(false);
+
+        var outline = await store.SearchTopicOutlineAsync("repo1", "Initialize", 50).ConfigureAwait(false);
+
+        await Assert.That(outline.Groups.Count).IsGreaterThan(0);
+        var allSymbols = outline.Groups.SelectMany(g => g.Symbols).ToList();
+        await Assert.That(allSymbols.Count).IsGreaterThan(0);
+        await Assert.That(allSymbols[0].Name).IsEqualTo("Initialize");
+    }
+
+    [Test]
+    public async Task SearchTopicOutlineAsyncGroupsByFilePath()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = await SeedMultiFileDataAsync(connection).ConfigureAwait(false);
+
+        var outline = await store.SearchTopicOutlineAsync("repo1", "function", 50).ConfigureAwait(false);
+
+        await Assert.That(outline.Groups.Count).IsGreaterThan(1);
+        var groupNames = outline.Groups.Select(g => g.Name).ToList();
+        foreach (var name in groupNames)
+        {
+            await Assert.That(name).Contains(".luau");
+        }
+    }
+
+    [Test]
+    public async Task SearchTopicOutlineAsyncRespectsLimit()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var (store, _) = await SeedTestDataAsync(connection).ConfigureAwait(false);
+
+        var outline = await store.SearchTopicOutlineAsync("repo1", "function", 1).ConfigureAwait(false);
+
+        var allSymbols = outline.Groups.SelectMany(g => g.Symbols).ToList();
+        await Assert.That(allSymbols.Count).IsLessThanOrEqualTo(1);
+    }
+
+    [Test]
+    public async Task SearchTopicOutlineAsyncReturnsTruncatedWhenLimitExceeded()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var (store, _) = await SeedTestDataAsync(connection).ConfigureAwait(false);
+
+        var outline = await store.SearchTopicOutlineAsync("repo1", "function", 1).ConfigureAwait(false);
+
+        await Assert.That(outline.IsTruncated).IsTrue();
+        await Assert.That(outline.TotalSymbolCount).IsGreaterThan(1);
+    }
+
+    [Test]
+    public async Task SearchTopicOutlineAsyncReturnsEmptyForNoMatches()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var (store, _) = await SeedTestDataAsync(connection).ConfigureAwait(false);
+
+        var outline = await store.SearchTopicOutlineAsync("repo1", "nonexistentxyz", 50).ConfigureAwait(false);
+
+        await Assert.That(outline.Groups).Count().IsEqualTo(0);
+        await Assert.That(outline.TotalSymbolCount).IsEqualTo(0);
+        await Assert.That(outline.IsTruncated).IsFalse();
+    }
+
+    [Test]
+    public async Task SearchTopicOutlineAsyncReturnsEmptyForEmptyQuery()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var (store, _) = await SeedTestDataAsync(connection).ConfigureAwait(false);
+
+        var outline = await store.SearchTopicOutlineAsync("repo1", "", 50).ConfigureAwait(false);
+
+        await Assert.That(outline.Groups).Count().IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task SearchTopicOutlineAsyncFiltersbyPathFilter()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = await SeedMultiFileDataAsync(connection).ConfigureAwait(false);
+
+        var outline = await store.SearchTopicOutlineAsync("repo1", "function", 50, "src/services").ConfigureAwait(false);
+
+        var allSymbols = outline.Groups.SelectMany(g => g.Symbols).ToList();
+        await Assert.That(allSymbols.Count).IsGreaterThan(0);
+        foreach (var group in outline.Groups)
+        {
+            await Assert.That(group.Name).StartsWith(OsPath("src/services/"));
+        }
+    }
+
+    [Test]
+    public async Task SearchTopicOutlineAsyncMatchesDocComments()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var (store, _) = await SeedTestDataAsync(connection).ConfigureAwait(false);
+
+        var outline = await store.SearchTopicOutlineAsync("repo1", "Initializes", 50).ConfigureAwait(false);
+
+        var allSymbols = outline.Groups.SelectMany(g => g.Symbols).ToList();
+        await Assert.That(allSymbols.Count).IsGreaterThan(0);
+        await Assert.That(allSymbols[0].Name).IsEqualTo("Initialize");
+    }
+
+    [Test]
+    public async Task SearchTopicOutlineAsyncReturnsEmptyForWrongRepo()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var (store, _) = await SeedTestDataAsync(connection).ConfigureAwait(false);
+
+        var outline = await store.SearchTopicOutlineAsync("nonexistent", "Initialize", 50).ConfigureAwait(false);
+
+        await Assert.That(outline.Groups).Count().IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task SearchTopicOutlineAsyncOrdersSymbolsByLineWithinFile()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var (store, _) = await SeedTestDataAsync(connection).ConfigureAwait(false);
+
+        // "function" matches multiple symbols in the same file via FTS5
+        var outline = await store.SearchTopicOutlineAsync("repo1", "function", 50).ConfigureAwait(false);
+
+        foreach (var group in outline.Groups)
+        {
+            for (var i = 1; i < group.Symbols.Count; i++)
+            {
+                await Assert.That(group.Symbols[i].LineStart).IsGreaterThanOrEqualTo(group.Symbols[i - 1].LineStart);
+            }
+        }
+    }
 }

--- a/tests/CodeCompress.Server.Tests/Tools/QueryToolsTests.cs
+++ b/tests/CodeCompress.Server.Tests/Tools/QueryToolsTests.cs
@@ -1558,6 +1558,150 @@ internal sealed class QueryToolsTests
             "test-repo-id", Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<int>(), "src/Config").ConfigureAwait(false);
     }
 
+    // ── TopicOutline Tests ────────────────────────────────────────────────
+
+    [Test]
+    public async Task TopicOutlineValidTopicReturnsStructuredOutline()
+    {
+        var outline = new Core.Models.ProjectOutline(
+            "test-repo-id",
+            [
+                new Core.Models.OutlineGroup(
+                    "src/services/Auth.cs",
+                    [CreateSymbol(1, 1, "AuthService", "Class", "public class AuthService")],
+                    []),
+            ],
+            1,
+            false);
+
+        _store.SearchTopicOutlineAsync("test-repo-id", Arg.Any<string>(), Arg.Any<int>(), Arg.Any<string?>())
+            .Returns(outline);
+
+        var result = await _tools.TopicOutline("/valid/path", "authentication").ConfigureAwait(false);
+
+        await Assert.That(result).Contains("AuthService");
+        await Assert.That(result).Contains("src/services/Auth.cs");
+    }
+
+    [Test]
+    public async Task TopicOutlineEmptyQueryReturnsError()
+    {
+        var result = await _tools.TopicOutline("/valid/path", "").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        await Assert.That(doc.RootElement.GetProperty("code").GetString()).IsEqualTo("EMPTY_QUERY");
+    }
+
+    [Test]
+    public async Task TopicOutlineWhitespaceQueryReturnsError()
+    {
+        var result = await _tools.TopicOutline("/valid/path", "   ").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        await Assert.That(doc.RootElement.GetProperty("code").GetString()).IsEqualTo("EMPTY_QUERY");
+    }
+
+    [Test]
+    public async Task TopicOutlineInvalidPathReturnsError()
+    {
+        _pathValidator.ValidatePath(Arg.Any<string>(), Arg.Any<string>()).Throws(new ArgumentException("bad path"));
+
+        var result = await _tools.TopicOutline("/bad/path", "auth").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        await Assert.That(doc.RootElement.GetProperty("code").GetString()).IsEqualTo("INVALID_PATH");
+    }
+
+    [Test]
+    public async Task TopicOutlineClampsLimitTo200Max()
+    {
+        var outline = new Core.Models.ProjectOutline("test-repo-id", [], 0, false);
+
+        _store.SearchTopicOutlineAsync("test-repo-id", Arg.Any<string>(), Arg.Any<int>(), Arg.Any<string?>())
+            .Returns(outline);
+
+        await _tools.TopicOutline("/valid/path", "test", maxResults: 999).ConfigureAwait(false);
+
+        await _store.Received(1).SearchTopicOutlineAsync(
+            "test-repo-id", Arg.Any<string>(), 200, Arg.Any<string?>()).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task TopicOutlineClampsLimitTo1Min()
+    {
+        var outline = new Core.Models.ProjectOutline("test-repo-id", [], 0, false);
+
+        _store.SearchTopicOutlineAsync("test-repo-id", Arg.Any<string>(), Arg.Any<int>(), Arg.Any<string?>())
+            .Returns(outline);
+
+        await _tools.TopicOutline("/valid/path", "test", maxResults: -5).ConfigureAwait(false);
+
+        await _store.Received(1).SearchTopicOutlineAsync(
+            "test-repo-id", Arg.Any<string>(), 1, Arg.Any<string?>()).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task TopicOutlinePassesPathFilterToStore()
+    {
+        var outline = new Core.Models.ProjectOutline("test-repo-id", [], 0, false);
+
+        _store.SearchTopicOutlineAsync("test-repo-id", Arg.Any<string>(), Arg.Any<int>(), "src/services")
+            .Returns(outline);
+
+        await _tools.TopicOutline("/valid/path", "auth", pathFilter: "src/services/").ConfigureAwait(false);
+
+        await _store.Received(1).SearchTopicOutlineAsync(
+            "test-repo-id", Arg.Any<string>(), Arg.Any<int>(), "src/services").ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task TopicOutlineInvalidPathFilterReturnsError()
+    {
+        var result = await _tools.TopicOutline("/valid/path", "auth", pathFilter: "../../../etc/passwd").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        await Assert.That(doc.RootElement.GetProperty("code").GetString()).IsEqualTo("INVALID_PATH_FILTER");
+    }
+
+    [Test]
+    public async Task TopicOutlineShowsTruncationMessage()
+    {
+        var outline = new Core.Models.ProjectOutline(
+            "test-repo-id",
+            [
+                new Core.Models.OutlineGroup(
+                    "src/Auth.cs",
+                    [CreateSymbol(1, 1, "Login", "Method", "public void Login()")],
+                    []),
+            ],
+            100,
+            true);
+
+        _store.SearchTopicOutlineAsync("test-repo-id", Arg.Any<string>(), Arg.Any<int>(), Arg.Any<string?>())
+            .Returns(outline);
+
+        var result = await _tools.TopicOutline("/valid/path", "auth").ConfigureAwait(false);
+
+        await Assert.That(result).Contains("Truncated");
+        await Assert.That(result).Contains("100");
+    }
+
+    [Test]
+    public async Task TopicOutlineFts5ErrorRetriesWithLiteralPhrase()
+    {
+        var outline = new Core.Models.ProjectOutline("test-repo-id", [], 0, false);
+
+        _store.SearchTopicOutlineAsync("test-repo-id", Arg.Any<string>(), Arg.Any<int>(), Arg.Any<string?>())
+            .Returns(
+                callInfo => throw new Microsoft.Data.Sqlite.SqliteException("fts5 error", 1),
+                callInfo => outline);
+
+        await _tools.TopicOutline("/valid/path", "auth:bad").ConfigureAwait(false);
+
+        await _store.Received(2).SearchTopicOutlineAsync(
+            "test-repo-id", Arg.Any<string>(), Arg.Any<int>(), Arg.Any<string?>()).ConfigureAwait(false);
+    }
+
     private static Symbol CreateSymbol(
         long id,
         long fileId,


### PR DESCRIPTION
## Summary
- Adds new `topic_outline` MCP tool that combines FTS5 full-text search with structured outline formatting (resolves #45)
- Searches symbol names, signatures, and doc comments via `symbols_fts`, returns results grouped by file in outline format
- New `SearchTopicOutlineAsync` method on `ISymbolStore`/`SqliteSymbolStore` with FTS5 count query for truncation detection, parameterized queries, path filter support, and configurable limits (default 50, max 200)
- 20 new tests: 10 Core layer (store method) + 10 Server layer (MCP tool) covering matching, grouping, limits, truncation, pathFilter, doc comment search, error handling, and FTS5 syntax error retry

## Test plan
- [x] All 657 tests pass (0 failures)
- [x] Core tests verify FTS5 search, file grouping, limit/truncation, pathFilter, doc comment matching, line ordering
- [x] Server tests verify input validation, limit clamping (1-200), pathFilter passthrough, error codes, truncation message, FTS5 error retry with literal phrase
- [ ] Manual testing with indexed codebase via MCP client

🤖 Generated with [Claude Code](https://claude.com/claude-code)