### PR TITLE
feat: centralize .code-compress database at git project root

### DIFF
--- a/src/CodeCompress.Cli/Program.cs
+++ b/src/CodeCompress.Cli/Program.cs
@@ -86,11 +86,12 @@ indexCommand.SetAction(async parseResult =>
         if (json)
         {
             Console.WriteLine(JsonSerializer.Serialize(
-                new { result.RepoId, result.FilesIndexed, result.FilesSkipped, result.SymbolsFound, result.DurationMs },
+                new { result.RepoId, ProjectRoot = scope.ProjectRoot, result.FilesIndexed, result.FilesSkipped, result.SymbolsFound, result.DurationMs },
                 jsonSerializerOptions));
         }
         else
         {
+            Console.WriteLine($"Project root: {scope.ProjectRoot}");
             Console.WriteLine($"Indexed {result.FilesIndexed} files ({result.FilesSkipped} skipped), {result.SymbolsFound} symbols in {result.DurationMs}ms");
         }
     }
@@ -1103,7 +1104,11 @@ return await rootCommand.Parse(args).InvokeAsync().ConfigureAwait(false);
 static async Task<CliProjectScope> CreateProjectScopeAsync(string path, ServiceProvider serviceProvider)
 {
     var pathValidator = serviceProvider.GetRequiredService<IPathValidator>();
-    var validatedPath = pathValidator.ValidatePath(path, path);
+    var rootResolver = serviceProvider.GetRequiredService<IProjectRootResolver>();
+
+    // Resolve to nearest git root (or fall back to given path)
+    var resolvedRoot = rootResolver.ResolveProjectRoot(path);
+    var validatedPath = pathValidator.ValidatePath(resolvedRoot, resolvedRoot);
 
     var connectionFactory = serviceProvider.GetRequiredService<IConnectionFactory>();
     var connection = await connectionFactory.CreateConnectionAsync(validatedPath).ConfigureAwait(false);

--- a/src/CodeCompress.Core/Indexing/IProjectRootResolver.cs
+++ b/src/CodeCompress.Core/Indexing/IProjectRootResolver.cs
@@ -1,0 +1,16 @@
+namespace CodeCompress.Core.Indexing;
+
+/// <summary>
+/// Resolves the project root directory by walking up the directory tree
+/// to find the nearest .git directory. Falls back to the given path if
+/// no .git directory is found.
+/// </summary>
+public interface IProjectRootResolver
+{
+    /// <summary>
+    /// Resolves the project root for the given path.
+    /// Walks up the directory tree looking for a .git directory.
+    /// Returns the directory containing .git, or the original path if not found.
+    /// </summary>
+    public string ResolveProjectRoot(string path);
+}

--- a/src/CodeCompress.Core/Indexing/ProjectRootResolver.cs
+++ b/src/CodeCompress.Core/Indexing/ProjectRootResolver.cs
@@ -1,0 +1,32 @@
+namespace CodeCompress.Core.Indexing;
+
+/// <summary>
+/// Resolves the project root by walking up the directory tree to find the nearest
+/// .git directory. Falls back to the given path if no .git directory is found.
+/// </summary>
+public sealed class ProjectRootResolver : IProjectRootResolver
+{
+    internal const string GitDirectoryName = ".git";
+
+    public string ResolveProjectRoot(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+        var fullPath = Path.GetFullPath(path);
+        var current = new DirectoryInfo(fullPath);
+
+        while (current is not null)
+        {
+            var gitDir = Path.Combine(current.FullName, GitDirectoryName);
+            if (Directory.Exists(gitDir))
+            {
+                return current.FullName;
+            }
+
+            current = current.Parent;
+        }
+
+        // No .git found — fall back to the original path
+        return fullPath;
+    }
+}

--- a/src/CodeCompress.Core/ServiceCollectionExtensions.cs
+++ b/src/CodeCompress.Core/ServiceCollectionExtensions.cs
@@ -26,6 +26,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IFileHasher, FileHasher>();
         services.AddSingleton<IChangeTracker, ChangeTracker>();
         services.AddSingleton<IIndexEngine, IndexEngine>();
+        services.AddSingleton<IProjectRootResolver, ProjectRootResolver>();
 
         return services;
     }

--- a/src/CodeCompress.Server/Scoping/IProjectScope.cs
+++ b/src/CodeCompress.Server/Scoping/IProjectScope.cs
@@ -6,6 +6,7 @@ namespace CodeCompress.Server.Scoping;
 internal interface IProjectScope : IAsyncDisposable
 {
     internal string RepoId { get; }
+    internal string ProjectRoot { get; }
     internal ISymbolStore Store { get; }
     internal IIndexEngine Engine { get; }
 }

--- a/src/CodeCompress.Server/Scoping/ProjectScope.cs
+++ b/src/CodeCompress.Server/Scoping/ProjectScope.cs
@@ -12,20 +12,24 @@ internal sealed class ProjectScope : IProjectScope
         SqliteConnection connection,
         ISymbolStore store,
         IIndexEngine engine,
-        string repoId)
+        string repoId,
+        string projectRoot)
     {
         ArgumentNullException.ThrowIfNull(connection);
         ArgumentNullException.ThrowIfNull(store);
         ArgumentNullException.ThrowIfNull(engine);
         ArgumentException.ThrowIfNullOrWhiteSpace(repoId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectRoot);
 
         _connection = connection;
         Store = store;
         Engine = engine;
         RepoId = repoId;
+        ProjectRoot = projectRoot;
     }
 
     public string RepoId { get; }
+    public string ProjectRoot { get; }
     public ISymbolStore Store { get; }
     public IIndexEngine Engine { get; }
 

--- a/src/CodeCompress.Server/Scoping/ProjectScopeFactory.cs
+++ b/src/CodeCompress.Server/Scoping/ProjectScopeFactory.cs
@@ -13,6 +13,7 @@ internal sealed class ProjectScopeFactory : IProjectScopeFactory
     private readonly IChangeTracker _changeTracker;
     private readonly IEnumerable<ILanguageParser> _parsers;
     private readonly IPathValidator _pathValidator;
+    private readonly IProjectRootResolver _rootResolver;
     private readonly ILoggerFactory _loggerFactory;
 
     public ProjectScopeFactory(
@@ -21,6 +22,7 @@ internal sealed class ProjectScopeFactory : IProjectScopeFactory
         IChangeTracker changeTracker,
         IEnumerable<ILanguageParser> parsers,
         IPathValidator pathValidator,
+        IProjectRootResolver rootResolver,
         ILoggerFactory loggerFactory)
     {
         ArgumentNullException.ThrowIfNull(connectionFactory);
@@ -28,6 +30,7 @@ internal sealed class ProjectScopeFactory : IProjectScopeFactory
         ArgumentNullException.ThrowIfNull(changeTracker);
         ArgumentNullException.ThrowIfNull(parsers);
         ArgumentNullException.ThrowIfNull(pathValidator);
+        ArgumentNullException.ThrowIfNull(rootResolver);
         ArgumentNullException.ThrowIfNull(loggerFactory);
 
         _connectionFactory = connectionFactory;
@@ -35,6 +38,7 @@ internal sealed class ProjectScopeFactory : IProjectScopeFactory
         _changeTracker = changeTracker;
         _parsers = parsers;
         _pathValidator = pathValidator;
+        _rootResolver = rootResolver;
         _loggerFactory = loggerFactory;
     }
 
@@ -42,9 +46,12 @@ internal sealed class ProjectScopeFactory : IProjectScopeFactory
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(projectRoot);
 
-        var connection = await _connectionFactory.CreateConnectionAsync(projectRoot).ConfigureAwait(false);
+        // Resolve to the nearest git root (or fall back to given path)
+        var resolvedRoot = _rootResolver.ResolveProjectRoot(projectRoot);
+
+        var connection = await _connectionFactory.CreateConnectionAsync(resolvedRoot).ConfigureAwait(false);
         var store = new SqliteSymbolStore(connection);
-        var canonicalRoot = _pathValidator.ValidatePath(projectRoot, projectRoot);
+        var canonicalRoot = _pathValidator.ValidatePath(resolvedRoot, resolvedRoot);
         var repoId = IndexEngine.ComputeRepoId(canonicalRoot);
         var engine = new IndexEngine(
             _fileHasher,
@@ -54,6 +61,6 @@ internal sealed class ProjectScopeFactory : IProjectScopeFactory
             _pathValidator,
             _loggerFactory.CreateLogger<IndexEngine>());
 
-        return new ProjectScope(connection, store, engine, repoId);
+        return new ProjectScope(connection, store, engine, repoId, canonicalRoot);
     }
 }

--- a/src/CodeCompress.Server/Tools/IndexingTools.cs
+++ b/src/CodeCompress.Server/Tools/IndexingTools.cs
@@ -52,7 +52,7 @@ internal sealed partial class IndexingTools
             await using (scope.ConfigureAwait(false))
             {
                 var result = await scope.Engine.IndexProjectAsync(
-                    validatedPath,
+                    scope.ProjectRoot,
                     language,
                     includePatterns,
                     excludePatterns,
@@ -62,6 +62,7 @@ internal sealed partial class IndexingTools
                     new
                     {
                         result.RepoId,
+                        ProjectRoot = scope.ProjectRoot,
                         result.FilesIndexed,
                         result.FilesSkipped,
                         result.SymbolsFound,

--- a/tests/CodeCompress.Core.Tests/Indexing/ProjectRootResolverTests.cs
+++ b/tests/CodeCompress.Core.Tests/Indexing/ProjectRootResolverTests.cs
@@ -1,0 +1,104 @@
+using CodeCompress.Core.Indexing;
+
+namespace CodeCompress.Core.Tests.Indexing;
+
+internal sealed class ProjectRootResolverTests
+{
+    private ProjectRootResolver _resolver = null!;
+
+    [Before(Test)]
+    public void SetUp()
+    {
+        _resolver = new ProjectRootResolver();
+    }
+
+    [Test]
+    public async Task ResolveProjectRootReturnsGitRootWhenGitExists()
+    {
+        // The test project itself is inside a git repo
+        var thisDir = AppContext.BaseDirectory;
+        var result = _resolver.ResolveProjectRoot(thisDir);
+
+        // Should walk up and find the .git directory
+        await Assert.That(Directory.Exists(Path.Combine(result, ".git"))).IsTrue();
+    }
+
+    [Test]
+    public async Task ResolveProjectRootReturnsExactRootWhenPathIsRoot()
+    {
+        // Find the actual git root for this repo
+        var thisDir = AppContext.BaseDirectory;
+        var gitRoot = _resolver.ResolveProjectRoot(thisDir);
+
+        // Passing the root itself should return the same root
+        var result = _resolver.ResolveProjectRoot(gitRoot);
+
+        await Assert.That(result).IsEqualTo(gitRoot);
+    }
+
+    [Test]
+    public async Task ResolveProjectRootFallsBackToGivenPathWhenNoGit()
+    {
+        // Use a temp directory with no .git anywhere above it
+        // The filesystem root won't have .git, so we go deep enough
+        var tempDir = Path.Combine(Path.GetTempPath(), $"codecompress-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var result = _resolver.ResolveProjectRoot(tempDir);
+
+            // Should fall back to the given path since no .git exists
+            await Assert.That(result).IsEqualTo(Path.GetFullPath(tempDir));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task ResolveProjectRootFindsNearestGitInNestedRepos()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"codecompress-test-{Guid.NewGuid():N}");
+        var outerGit = Path.Combine(tempDir, ".git");
+        var innerDir = Path.Combine(tempDir, "packages", "sub-repo");
+        var innerGit = Path.Combine(innerDir, ".git");
+        var deepDir = Path.Combine(innerDir, "src", "lib");
+
+        Directory.CreateDirectory(outerGit);
+        Directory.CreateDirectory(innerGit);
+        Directory.CreateDirectory(deepDir);
+
+        try
+        {
+            var result = _resolver.ResolveProjectRoot(deepDir);
+
+            // Should resolve to the inner repo (nearest .git), not the outer
+            await Assert.That(result).IsEqualTo(Path.GetFullPath(innerDir));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task ResolveProjectRootReturnsCanonicalPath()
+    {
+        var thisDir = AppContext.BaseDirectory;
+        var result = _resolver.ResolveProjectRoot(thisDir);
+
+        // Result should be a full, canonical path
+        await Assert.That(Path.IsPathRooted(result)).IsTrue();
+        await Assert.That(result).IsEqualTo(Path.GetFullPath(result));
+    }
+
+    [Test]
+    public async Task ResolveProjectRootThrowsForNullOrEmpty()
+    {
+        await Assert.That(() => _resolver.ResolveProjectRoot(null!)).ThrowsException();
+        await Assert.That(() => _resolver.ResolveProjectRoot("")).ThrowsException();
+        await Assert.That(() => _resolver.ResolveProjectRoot("  ")).ThrowsException();
+    }
+}


### PR DESCRIPTION
## Summary
- Add `IProjectRootResolver` / `ProjectRootResolver` — walks up the directory tree to find the nearest `.git` directory
- Subfolder paths auto-resolve to the git root, ensuring a single `.code-compress/index.db` per project
- Falls back to the given path if no `.git` is found (non-git directories still work)
- Wired into both MCP server (`ProjectScopeFactory`) and CLI (`CreateProjectScopeAsync`)
- `index_project` MCP tool and CLI `index` command now include `project_root` in response
- `IProjectScope` gains `ProjectRoot` property — tools use the resolved root for indexing
- Repo ID always based on resolved root (stable regardless of subfolder passed)

## How it works
```
Agent calls: index_project(path: "/project/src/subfolder")
Resolver walks: /project/src/subfolder → /project/src → /project (has .git!) → STOP
Result: DB at /project/.code-compress/index.db, indexes from /project/
```

## Security review
- `ProjectRootResolver` only uses `Directory.Exists()` — no user input in file operations
- Resolved root passes through `PathValidator.ValidatePath()` before any DB or file access
- No SQL changes, no FTS5 changes, no output changes beyond adding `project_root` field
- **PASS**

## Test plan
- [x] `dotnet build CodeCompress.slnx` — zero warnings
- [x] `dotnet test` — 783 tests passed (6 new for ProjectRootResolver)
- [x] CLI: `index --path $(pwd)/src` resolves to git root
- [x] CLI: `--json` output includes `project_root` field
- [x] Nested git repos resolve to nearest `.git`
- [x] Non-git directories fall back to given path

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)