### PR TITLE
fix: NuGet README banner + create-release skill release notes step

### DIFF
--- a/.claude/skills/create-release/SKILL.md
+++ b/.claude/skills/create-release/SKILL.md
@@ -347,8 +347,12 @@ Use `AskUserQuestion` to ask:
 **If executing now:**
 1. Check if the PR is merged: `gh pr view {pr_number} --json state`
 2. If not merged, tell the user to merge the PR first and re-run
-3. If merged, execute steps 1-4 above
-4. **Skip GitHub Release creation** — CI/CD pipeline creates the release automatically when the tag is pushed
+3. If merged, execute steps 1-5 above (resolve merge conflicts if needed — take main's version for `Directory.Build.props` and `CHANGELOG.md`)
+4. **Update GitHub Release notes** — CI/CD creates the release but with minimal auto-generated notes. Replace them with the full changelog content:
+   ```bash
+   gh release edit v{new_version} --notes "{full_release_notes_with_changelog}" --repo MCrank/code-compress
+   ```
+   The release notes should include: a "What's New" header, the changelog entries rewritten for a release audience (grouped by theme, not just raw commit messages), and install instructions at the bottom.
 5. Execute step 5 (clean up release branch)
 
 ## Step 10: Exit Summary

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-<div align="center">
-
-<img src="https://raw.githubusercontent.com/MCrank/code-compress/develop/assets/banner.png" alt="CodeCompress — MCP Server & CLI" width="100%" />
+![CodeCompress — MCP Server & CLI](https://raw.githubusercontent.com/MCrank/code-compress/develop/assets/banner.png)
 
 **Persistent code index for AI agents. Ask for exactly what you need.**
 
@@ -10,8 +8,6 @@
 [![NuGet Downloads](https://img.shields.io/nuget/dt/CodeCompress.Server?label=downloads)](https://www.nuget.org/packages/CodeCompress.Server)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![.NET 10](https://img.shields.io/badge/.NET-10.0-purple.svg)](https://dotnet.microsoft.com/download/dotnet/10.0)
-
-</div>
 
 ---
 


### PR DESCRIPTION
## Summary
- Replace HTML `<div>`/`<img>` banner with standard markdown `![alt](url)` so the banner renders on NuGet.org (which strips raw HTML)
- Update `/create-release` skill Step 9 to include updating GitHub Release notes with full changelog after CI/CD creates the release

🤖 Generated with [Claude Code](https://claude.com/claude-code)