### PR TITLE
fix: CLI search-text crashes on FTS5 special characters (#85)

### DIFF
--- a/src/CodeCompress.Cli/Program.cs
+++ b/src/CodeCompress.Cli/Program.cs
@@ -307,10 +307,34 @@ searchTextCommand.SetAction(async parseResult =>
     var limit = Math.Clamp(parseResult.GetValue(searchTextLimitOption), 1, 100);
     var json = parseResult.GetValue(jsonOption);
 
+    var sanitizedQuery = Fts5QuerySanitizer.Sanitize(query);
+    var sanitizedGlob = glob is not null ? Fts5QuerySanitizer.SanitizeGlob(glob) : null;
+
+    if (string.IsNullOrWhiteSpace(sanitizedQuery))
+    {
+        await Console.Error.WriteLineAsync("Error: search query is empty after sanitization.").ConfigureAwait(false);
+        return;
+    }
+
+    if (string.IsNullOrWhiteSpace(sanitizedGlob))
+    {
+        sanitizedGlob = null;
+    }
+
     var scope = await CreateProjectScopeAsync(path, provider).ConfigureAwait(false);
     await using (scope.ConfigureAwait(false))
     {
-        var results = await scope.Store.SearchTextAsync(scope.RepoId, query, glob, limit, pathFilter).ConfigureAwait(false);
+        IReadOnlyList<TextSearchResult> results;
+        try
+        {
+            results = await scope.Store.SearchTextAsync(scope.RepoId, sanitizedQuery, sanitizedGlob, limit, pathFilter).ConfigureAwait(false);
+        }
+        catch (System.Data.Common.DbException)
+        {
+            // FTS5 syntax error — retry with query as a quoted literal phrase
+            var literalQuery = $"\"{sanitizedQuery.Replace("\"", string.Empty, StringComparison.Ordinal)}\"";
+            results = await scope.Store.SearchTextAsync(scope.RepoId, literalQuery, sanitizedGlob, limit, pathFilter).ConfigureAwait(false);
+        }
 
         if (json)
         {

--- a/src/CodeCompress.Core/Storage/Fts5QuerySanitizer.cs
+++ b/src/CodeCompress.Core/Storage/Fts5QuerySanitizer.cs
@@ -1,16 +1,15 @@
 using System.Text;
 using System.Text.RegularExpressions;
-using CodeCompress.Core.Storage;
 
-namespace CodeCompress.Server.Sanitization;
+namespace CodeCompress.Core.Storage;
 
-internal static partial class Fts5QuerySanitizer
+public static partial class Fts5QuerySanitizer
 {
     /// <summary>
     /// Sanitizes an FTS5 query string. Returns the sanitized query.
     /// If the result is empty after sanitization, wraps the original input as a literal phrase.
     /// </summary>
-    internal static string Sanitize(string query)
+    public static string Sanitize(string query)
     {
         if (string.IsNullOrWhiteSpace(query))
         {
@@ -55,7 +54,7 @@ internal static partial class Fts5QuerySanitizer
     /// Sanitizes a glob pattern for use in SQL GLOB/LIKE clauses.
     /// Allows only alphanumeric, *, ?, /, ., -, _
     /// </summary>
-    internal static string SanitizeGlob(string glob)
+    public static string SanitizeGlob(string glob)
     {
         if (string.IsNullOrWhiteSpace(glob))
         {
@@ -72,7 +71,7 @@ internal static partial class Fts5QuerySanitizer
     /// Analyzes a raw search query and returns a sanitized GlobPattern
     /// that indicates how to execute the search (FTS5, prefix, or SQL LIKE).
     /// </summary>
-    internal static GlobPattern SanitizeAsGlob(string query)
+    public static GlobPattern SanitizeAsGlob(string query)
     {
         if (string.IsNullOrWhiteSpace(query))
         {

--- a/src/CodeCompress.Server/Tools/QueryTools.cs
+++ b/src/CodeCompress.Server/Tools/QueryTools.cs
@@ -5,7 +5,6 @@ using System.Text.Json;
 using CodeCompress.Core.Models;
 using CodeCompress.Core.Storage;
 using CodeCompress.Core.Validation;
-using CodeCompress.Server.Sanitization;
 using CodeCompress.Server.Scoping;
 using ModelContextProtocol.Server;
 

--- a/src/CodeCompress.Server/Tools/ReferenceTools.cs
+++ b/src/CodeCompress.Server/Tools/ReferenceTools.cs
@@ -1,8 +1,8 @@
 using System.ComponentModel;
 using System.Text.Json;
 using CodeCompress.Core.Models;
+using CodeCompress.Core.Storage;
 using CodeCompress.Core.Validation;
-using CodeCompress.Server.Sanitization;
 using CodeCompress.Server.Scoping;
 using ModelContextProtocol.Server;
 

--- a/tests/CodeCompress.Core.Tests/Storage/Fts5QuerySanitizerTests.cs
+++ b/tests/CodeCompress.Core.Tests/Storage/Fts5QuerySanitizerTests.cs
@@ -1,7 +1,6 @@
 using CodeCompress.Core.Storage;
-using CodeCompress.Server.Sanitization;
 
-namespace CodeCompress.Server.Tests.Sanitization;
+namespace CodeCompress.Core.Tests.Storage;
 
 internal sealed class Fts5QuerySanitizerTests
 {


### PR DESCRIPTION
## Summary

- Moved `Fts5QuerySanitizer` from `CodeCompress.Server.Sanitization` to `CodeCompress.Core.Storage` (`internal` → `public`) so both MCP server and CLI share the same sanitization logic
- Applied `Fts5QuerySanitizer.Sanitize()` + `SanitizeGlob()` + `DbException` try/catch fallback to the CLI `search-text` command, matching the MCP server's existing pattern
- Queries like `EnemyService.initialize`, `config:value`, `foo(bar)` now return results instead of crashing

Closes #85

## Test plan

- [x] 802 tests pass (sanitizer tests moved from Server.Tests to Core.Tests — no test count change)
- [x] Zero build warnings
- [x] Git detected file move as rename (94% similarity)
- [x] Server references updated (QueryTools.cs, ReferenceTools.cs)
- [x] Security review completed — fallback uses `sanitizedQuery` (not raw `query`) per reviewer recommendation
- [x] FTS5 operators (OR, AND, NOT) still work when used intentionally

🤖 Generated with [Claude Code](https://claude.com/claude-code)