### PR TITLE
fix: JsonConfigParser crashes on JSON with multi-byte UTF-8 characters (#84)

### DIFF
--- a/src/CodeCompress.Core/Parsers/JsonConfigParser.cs
+++ b/src/CodeCompress.Core/Parsers/JsonConfigParser.cs
@@ -60,15 +60,15 @@ public sealed class JsonConfigParser : ILanguageParser
                 ? property.Name
                 : $"{parentQualifiedName}:{property.Name}";
 
-            var keyByteOffset = FindPropertyKeyOffset(text, property.Name, searchStart);
+            var (keyByteOffset, keyCharIndex) = FindPropertyKeyOffset(text, property.Name, searchStart);
             var lineStart = FindLineForByteOffset(keyByteOffset, lineByteOffsets);
             var signature = BuildSignature(qualifiedName, property.Value);
             var byteLength = EstimateByteLength(property, contentLength, keyByteOffset);
 
-            // Advance searchStart past this property key so next search finds the next occurrence
-            if (keyByteOffset > searchStart)
+            // Advance searchStart (char index) past this property key so next search finds the next occurrence
+            if (keyCharIndex > searchStart)
             {
-                searchStart = keyByteOffset + Encoding.UTF8.GetByteCount(property.Name);
+                searchStart = keyCharIndex + property.Name.Length;
             }
 
             symbols.Add(new SymbolInfo(
@@ -90,11 +90,11 @@ public sealed class JsonConfigParser : ILanguageParser
         }
     }
 
-    private static int FindPropertyKeyOffset(string text, string propertyName, int searchStart)
+    private static (int ByteOffset, int CharIndex) FindPropertyKeyOffset(string text, string propertyName, int searchStartChar)
     {
-        // Search for "propertyName" pattern in the JSON text starting from searchStart
+        // Search for "propertyName" pattern in the JSON text starting from searchStartChar (char index)
         var needle = $"\"{propertyName}\"";
-        var charIndex = text.IndexOf(needle, searchStart, StringComparison.Ordinal);
+        var charIndex = text.IndexOf(needle, searchStartChar, StringComparison.Ordinal);
         if (charIndex < 0)
         {
             // Fallback: search from beginning
@@ -103,11 +103,12 @@ public sealed class JsonConfigParser : ILanguageParser
 
         if (charIndex < 0)
         {
-            return 0;
+            return (0, 0);
         }
 
-        // Convert char index to byte offset
-        return Encoding.UTF8.GetByteCount(text.AsSpan(0, charIndex));
+        // Convert char index to byte offset for symbol storage
+        var byteOffset = Encoding.UTF8.GetByteCount(text.AsSpan(0, charIndex));
+        return (byteOffset, charIndex);
     }
 
     private static int FindLineForByteOffset(int byteOffset, int[] lineByteOffsets)

--- a/tests/CodeCompress.Core.Tests/Parsers/JsonConfigParserTests.cs
+++ b/tests/CodeCompress.Core.Tests/Parsers/JsonConfigParserTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text;
 using CodeCompress.Core.Models;
 using CodeCompress.Core.Parsers;
@@ -366,5 +367,138 @@ internal sealed class JsonConfigParserTests
 
         var section = result.Symbols.First(s => s.Name == "Section");
         await Assert.That(section.Signature).IsEqualTo("Section: { ... } (3 keys)");
+    }
+
+    // ── Multi-byte UTF-8 character handling ──────────────────────
+
+    [Test]
+    public async Task JsonWithMultiByteValuesDoesNotCrash()
+    {
+        var source = """
+            {
+              "name": "José García",
+              "city": "München",
+              "greeting": "こんにちは"
+            }
+            """;
+
+        var result = Parse(source);
+
+        await Assert.That(result.Symbols).Count().IsEqualTo(3);
+        await Assert.That(result.Symbols[0].Name).IsEqualTo("name");
+        await Assert.That(result.Symbols[1].Name).IsEqualTo("city");
+        await Assert.That(result.Symbols[2].Name).IsEqualTo("greeting");
+    }
+
+    [Test]
+    public async Task JsonWithMultiBytePropertyKeysParses()
+    {
+        var source = """
+            {
+              "名前": "太郎",
+              "都市": "東京"
+            }
+            """;
+
+        var result = Parse(source);
+
+        await Assert.That(result.Symbols).Count().IsEqualTo(2);
+        await Assert.That(result.Symbols[0].Name).IsEqualTo("名前");
+        await Assert.That(result.Symbols[1].Name).IsEqualTo("都市");
+    }
+
+    [Test]
+    public async Task JsonWithEmojiValuesParses()
+    {
+        var source = """
+            {
+              "status": "✅ Active",
+              "icon": "🎮",
+              "label": "Player 1"
+            }
+            """;
+
+        var result = Parse(source);
+
+        await Assert.That(result.Symbols).Count().IsEqualTo(3);
+        await Assert.That(result.Symbols[2].Name).IsEqualTo("label");
+    }
+
+    [Test]
+    public async Task DeeplyNestedJsonWithMultiByteCharsParsesAllKeys()
+    {
+        var source = """
+            {
+              "config": {
+                "display": {
+                  "title": "Ölüm Vadisi",
+                  "subtitle": "Spëcîäl Çhàrs"
+                }
+              }
+            }
+            """;
+
+        var result = Parse(source);
+
+        var names = result.Symbols.Select(s => s.Name).ToList();
+        await Assert.That(names).Contains("config:display:title");
+        await Assert.That(names).Contains("config:display:subtitle");
+    }
+
+    [Test]
+    public async Task DuplicateKeyNamesWithMultiByteContentResolveCorrectly()
+    {
+        var source = """
+            {
+              "parent": {
+                "name": "José"
+              },
+              "child": {
+                "name": "María"
+              }
+            }
+            """;
+
+        var result = Parse(source);
+
+        var nameSymbols = result.Symbols.Where(s => s.Name.EndsWith("name", StringComparison.Ordinal)).ToList();
+        await Assert.That(nameSymbols).Count().IsEqualTo(2);
+        await Assert.That(nameSymbols[0].Name).IsEqualTo("parent:name");
+        await Assert.That(nameSymbols[1].Name).IsEqualTo("child:name");
+        // The two "name" keys should have different byte offsets
+        await Assert.That(nameSymbols[0].ByteOffset).IsNotEqualTo(nameSymbols[1].ByteOffset);
+    }
+
+    [Test]
+    public async Task ByteOffsetsAreCorrectForMultiByteContent()
+    {
+        var source = "{\"key\": \"café\", \"next\": \"value\"}";
+        var bytes = Encoding.UTF8.GetBytes(source);
+
+        var result = _parser.Parse("test.json", bytes);
+
+        await Assert.That(result.Symbols).Count().IsEqualTo(2);
+        // "next" key should have a byte offset that points to the right location
+        var nextSym = result.Symbols.First(s => s.Name == "next");
+        var byteSlice = Encoding.UTF8.GetString(bytes.AsSpan(nextSym.ByteOffset, 6));
+        await Assert.That(byteSlice).IsEqualTo("\"next\"");
+    }
+
+    [Test]
+    public async Task ManyPropertiesWithScatteredMultiByteCharsAllParse()
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("{");
+        for (var i = 0; i < 50; i++)
+        {
+            var comma = i < 49 ? "," : "";
+            sb.AppendLine(CultureInfo.InvariantCulture, $"  \"key{i}\": \"value{i} — entrée №{i}\"{comma}");
+        }
+
+        sb.AppendLine("}");
+
+        var result = Parse(sb.ToString());
+
+        await Assert.That(result.Symbols).Count().IsEqualTo(50);
     }
 }


### PR DESCRIPTION
## Summary

- Fixed `FindPropertyKeyOffset` to return both byte offset (for SymbolInfo storage) and char index (for search advancement)
- `searchStart` now tracked as char index throughout `TraverseObject`, preventing drift when multi-byte UTF-8 characters are present
- JSON files with accented names, emoji, CJK characters, and other non-ASCII content now index correctly

Closes #84

## Test plan

- [x] 809 tests pass (7 new multi-byte UTF-8 tests)
- [x] Zero build warnings
- [x] Accented chars (José, München), CJK (こんにちは), emoji (✅🎮) all parse correctly
- [x] Deeply nested JSON with multi-byte content works
- [x] Duplicate key names across nesting levels resolve to correct byte offsets
- [x] 50-property JSON with scattered multi-byte chars parses fully
- [x] Byte offset accuracy verified (slice at offset matches expected key)
- [x] All existing tests pass (no regression)
- [x] Security review passed — parser-internal fix, no new attack surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)