### PR TITLE
feat: add size guard to get_symbol with guided expand_symbol fallback (#86)

### DIFF
--- a/src/CodeCompress.Core/Storage/ISymbolStore.cs
+++ b/src/CodeCompress.Core/Storage/ISymbolStore.cs
@@ -44,6 +44,7 @@ public interface ISymbolStore
     // Lookups
     public Task<Symbol?> GetSymbolByNameAsync(string repoId, string symbolName);
     public Task<IReadOnlyList<Symbol>> GetSymbolsByNamesAsync(string repoId, IReadOnlyList<string> symbolNames);
+    public Task<IReadOnlyList<Symbol>> GetChildSymbolsAsync(string repoId, string parentSymbolName);
 
     // Aggregation
     public Task<ProjectOutline> GetProjectOutlineAsync(string repoId, bool includePrivate, string groupBy, int maxDepth, string? pathFilter = null, int offset = 0, int limit = 0);

--- a/src/CodeCompress.Core/Storage/SqliteSymbolStore.cs
+++ b/src/CodeCompress.Core/Storage/SqliteSymbolStore.cs
@@ -1157,6 +1157,48 @@ public sealed class SqliteSymbolStore : ISymbolStore
         return results;
     }
 
+    public async Task<IReadOnlyList<Symbol>> GetChildSymbolsAsync(string repoId, string parentSymbolName)
+    {
+        ArgumentNullException.ThrowIfNull(repoId);
+        ArgumentNullException.ThrowIfNull(parentSymbolName);
+
+        using var command = _connection.CreateCommand();
+        command.CommandText =
+            """
+            SELECT s.id, s.file_id, s.name, s.kind, s.signature, s.parent_symbol,
+                   s.byte_offset, s.byte_length, s.line_start, s.line_end, s.visibility, s.doc_comment
+            FROM symbols s
+            JOIN files f ON f.id = s.file_id
+            WHERE s.parent_symbol = @parent AND f.repo_id = @repoId
+            ORDER BY s.line_start
+            """;
+
+        command.Parameters.AddWithValue("@parent", parentSymbolName);
+        command.Parameters.AddWithValue("@repoId", repoId);
+
+        using var reader = await command.ExecuteReaderAsync().ConfigureAwait(false);
+        var results = new List<Symbol>();
+
+        while (await reader.ReadAsync().ConfigureAwait(false))
+        {
+            results.Add(new Symbol(
+                reader.GetInt64(0),
+                reader.GetInt64(1),
+                reader.GetString(2),
+                reader.GetString(3),
+                reader.GetString(4),
+                await reader.IsDBNullAsync(5).ConfigureAwait(false) ? null : reader.GetString(5),
+                reader.GetInt32(6),
+                reader.GetInt32(7),
+                reader.GetInt32(8),
+                reader.GetInt32(9),
+                reader.GetString(10),
+                await reader.IsDBNullAsync(11).ConfigureAwait(false) ? null : reader.GetString(11)));
+        }
+
+        return results;
+    }
+
     // ── Aggregation ─────────────────────────────────────────────────────
 
     public async Task<ProjectOutline> GetProjectOutlineAsync(string repoId, bool includePrivate, string groupBy, int maxDepth, string? pathFilter = null, int offset = 0, int limit = 0)

--- a/src/CodeCompress.Server/Tools/QueryTools.cs
+++ b/src/CodeCompress.Server/Tools/QueryTools.cs
@@ -28,6 +28,8 @@ internal sealed class QueryTools
         "function", "method", "type", "class", "interface", "export", "constant", "module", "record", "enum",
     };
 
+    private const int SymbolSizeThresholdBytes = 16_384;
+
     private readonly IPathValidator _pathValidator;
     private readonly IProjectScopeFactory _scopeFactory;
 
@@ -161,11 +163,12 @@ internal sealed class QueryTools
     }
 
     [McpServerTool(Name = "get_symbol")]
-    [Description("Retrieve the full source code of a specific symbol by qualified name — loads only the exact symbol, not the entire file (saves 80%+ tokens vs file reading). Uses byte-offset seeking for instant retrieval. Use search_symbols to discover symbol names first. Requires index_project to have been called first.")]
+    [Description("Retrieve the full source code of a specific symbol by qualified name — loads only the exact symbol, not the entire file (saves 80%+ tokens vs file reading). For large symbols (>16KB), returns a guided summary with child method signatures and instructions to use expand_symbol for individual methods. Use force=true to bypass the size guard. Requires index_project to have been called first.")]
     public async Task<string> GetSymbol(
         [Description("ABSOLUTE path to the project root directory — the same root used with index_project (e.g., 'C:\\Projects\\MyGame' or '/home/user/my-project'). Must NOT be a subdirectory or relative path.")] string path,
         [Description("Fully qualified symbol name — use 'Parent:Child' for nested symbols (e.g., 'CombatService:ProcessAttack') or just the name for top-level symbols. Use search_symbols to discover names.")] string symbolName,
         [Description("Include 5 lines of context before and after the symbol")] bool includeContext = false,
+        [Description("Bypass size guard and return full source code even for large symbols")] bool force = false,
         CancellationToken cancellationToken = default)
     {
         string validatedPath;
@@ -210,6 +213,15 @@ internal sealed class QueryTools
             var sourceCode = includeContext
                 ? await ReadSourceCodeWithContextAsync(resolvedPath, symbol.ByteOffset, symbol.ByteLength).ConfigureAwait(false)
                 : await ReadSourceCodeAsync(resolvedPath, symbol.ByteOffset, symbol.ByteLength).ConfigureAwait(false);
+
+            if (!force && Encoding.UTF8.GetByteCount(sourceCode) > SymbolSizeThresholdBytes)
+            {
+                var children = await scope.Store.GetChildSymbolsAsync(scope.RepoId, symbol.Name).ConfigureAwait(false);
+                if (children.Count > 0)
+                {
+                    return FormatGuidedSummary(symbol, file.RelativePath, children);
+                }
+            }
 
             var response = new
             {
@@ -367,6 +379,36 @@ internal sealed class QueryTools
                 foreach (var symbol in fileSymbols)
                 {
                     var sourceCode = await ReadSourceCodeAsync(resolvedPath, symbol.ByteOffset, symbol.ByteLength).ConfigureAwait(false);
+
+                    if (Encoding.UTF8.GetByteCount(sourceCode) > SymbolSizeThresholdBytes)
+                    {
+                        var children = await scope.Store.GetChildSymbolsAsync(scope.RepoId, symbol.Name).ConfigureAwait(false);
+                        if (children.Count > 0)
+                        {
+                            var parentName = symbol.ParentSymbol is not null ? $"{symbol.ParentSymbol}:{symbol.Name}" : symbol.Name;
+                            results.Add(new
+                            {
+                                symbol.Name,
+                                symbol.Kind,
+                                Parent = symbol.ParentSymbol,
+                                File = file.RelativePath,
+                                symbol.LineStart,
+                                symbol.LineEnd,
+                                symbol.Signature,
+                                Truncated = true,
+                                SourceSizeBytes = symbol.ByteLength,
+                                Children = children.Select(c => new
+                                {
+                                    c.Name,
+                                    c.Signature,
+                                    ExpandWith = $"{parentName}:{c.Name}",
+                                }),
+                                Guidance = $"This symbol is large ({symbol.ByteLength:N0} bytes). Use expand_symbol to retrieve individual methods.",
+                            });
+                            continue;
+                        }
+                    }
+
                     results.Add(new
                     {
                         symbol.Name,
@@ -911,6 +953,32 @@ internal sealed class QueryTools
 
         var result = sb.ToString();
         return result.Length > 256 ? result[..256] : result;
+    }
+
+    private static string FormatGuidedSummary(Symbol symbol, string filePath, IReadOnlyList<Symbol> children)
+    {
+        var parentName = symbol.ParentSymbol is not null ? $"{symbol.ParentSymbol}:{symbol.Name}" : symbol.Name;
+        var response = new
+        {
+            symbol.Name,
+            symbol.Kind,
+            Parent = symbol.ParentSymbol,
+            File = filePath,
+            symbol.LineStart,
+            symbol.LineEnd,
+            symbol.Signature,
+            Truncated = true,
+            SourceSizeBytes = symbol.ByteLength,
+            Children = children.Select(c => new
+            {
+                c.Name,
+                c.Signature,
+                ExpandWith = $"{parentName}:{c.Name}",
+            }),
+            Guidance = $"This symbol is large ({symbol.ByteLength:N0} bytes). Use expand_symbol with '{parentName}:<method_name>' to retrieve individual methods. Use force=true to bypass this guard.",
+        };
+
+        return JsonSerializer.Serialize(response, SerializerOptions);
     }
 
     private static string SerializeError(string error, string code) =>

--- a/tests/CodeCompress.Server.Tests/Tools/QueryToolsTests.cs
+++ b/tests/CodeCompress.Server.Tests/Tools/QueryToolsTests.cs
@@ -1743,4 +1743,146 @@ internal sealed class QueryToolsTests
         await _store.Received(1).SearchSymbolsAsync(
             "test-repo-id", "Claude* OR Agent*", Arg.Any<string?>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>()).ConfigureAwait(false);
     }
+
+    // ── Size guard tests ────────────────────────────────────────────────
+
+    [Test]
+    public async Task GetSymbolLargeSymbolWithChildrenReturnsGuidedSummary()
+    {
+        // Create a large source file (>16KB)
+        var largeContent = new string('x', 20_000);
+        var tempFile = CreateTempFile(largeContent);
+        try
+        {
+            var dir = Path.GetDirectoryName(tempFile)!;
+            var fileName = Path.GetFileName(tempFile);
+
+            var symbol = CreateSymbol(1, 1, "BigClass", "Class",
+                "public class BigClass", lineStart: 1, byteOffset: 0, byteLength: 20_000);
+
+            _store.GetSymbolByNameAsync("test-repo-id", "BigClass").Returns(symbol);
+            _store.GetFilesByRepoAsync("test-repo-id")
+                .Returns(new List<FileRecord> { new(1, "test-repo-id", fileName, "hash1", 20_000, 100, 1000, 2000) });
+            _store.GetChildSymbolsAsync("test-repo-id", "BigClass")
+                .Returns(new List<Symbol>
+                {
+                    CreateSymbol(2, 1, "MethodA", "Method", "void MethodA()", parent: "BigClass", lineStart: 5),
+                    CreateSymbol(3, 1, "MethodB", "Method", "void MethodB()", parent: "BigClass", lineStart: 15),
+                });
+
+            _pathValidator.ValidatePath(dir, dir).Returns(dir);
+
+            var result = await _tools.GetSymbol(dir, "BigClass").ConfigureAwait(false);
+
+            using var doc = JsonDocument.Parse(result);
+            var root = doc.RootElement;
+            await Assert.That(root.GetProperty("truncated").GetBoolean()).IsTrue();
+            await Assert.That(root.GetProperty("name").GetString()).IsEqualTo("BigClass");
+            await Assert.That(root.GetProperty("guidance").GetString()).Contains("expand_symbol");
+            await Assert.That(root.GetProperty("children").GetArrayLength()).IsEqualTo(2);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Test]
+    public async Task GetSymbolLargeSymbolWithForceReturnsFullSource()
+    {
+        var largeContent = new string('y', 20_000);
+        var tempFile = CreateTempFile(largeContent);
+        try
+        {
+            var dir = Path.GetDirectoryName(tempFile)!;
+            var fileName = Path.GetFileName(tempFile);
+
+            var symbol = CreateSymbol(1, 1, "BigClass", "Class",
+                "public class BigClass", lineStart: 1, byteOffset: 0, byteLength: 20_000);
+
+            _store.GetSymbolByNameAsync("test-repo-id", "BigClass").Returns(symbol);
+            _store.GetFilesByRepoAsync("test-repo-id")
+                .Returns(new List<FileRecord> { new(1, "test-repo-id", fileName, "hash1", 20_000, 100, 1000, 2000) });
+
+            _pathValidator.ValidatePath(dir, dir).Returns(dir);
+
+            var result = await _tools.GetSymbol(dir, "BigClass", force: true).ConfigureAwait(false);
+
+            using var doc = JsonDocument.Parse(result);
+            var root = doc.RootElement;
+            await Assert.That(root.TryGetProperty("truncated", out _)).IsFalse();
+            await Assert.That(root.GetProperty("source_code").GetString()).IsEqualTo(largeContent);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Test]
+    public async Task GetSymbolLargeSymbolWithNoChildrenReturnsFullSource()
+    {
+        var largeContent = new string('z', 20_000);
+        var tempFile = CreateTempFile(largeContent);
+        try
+        {
+            var dir = Path.GetDirectoryName(tempFile)!;
+            var fileName = Path.GetFileName(tempFile);
+
+            var symbol = CreateSymbol(1, 1, "BigFunction", "Function",
+                "function BigFunction()", lineStart: 1, byteOffset: 0, byteLength: 20_000);
+
+            _store.GetSymbolByNameAsync("test-repo-id", "BigFunction").Returns(symbol);
+            _store.GetFilesByRepoAsync("test-repo-id")
+                .Returns(new List<FileRecord> { new(1, "test-repo-id", fileName, "hash1", 20_000, 100, 1000, 2000) });
+            _store.GetChildSymbolsAsync("test-repo-id", "BigFunction")
+                .Returns(new List<Symbol>());
+
+            _pathValidator.ValidatePath(dir, dir).Returns(dir);
+
+            var result = await _tools.GetSymbol(dir, "BigFunction").ConfigureAwait(false);
+
+            using var doc = JsonDocument.Parse(result);
+            var root = doc.RootElement;
+            await Assert.That(root.TryGetProperty("truncated", out _)).IsFalse();
+            await Assert.That(root.GetProperty("source_code").GetString()).IsEqualTo(largeContent);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Test]
+    public async Task GetSymbolSmallSymbolReturnsFullSource()
+    {
+        var smallContent = "public class SmallClass { }";
+        var tempFile = CreateTempFile(smallContent);
+        try
+        {
+            var dir = Path.GetDirectoryName(tempFile)!;
+            var fileName = Path.GetFileName(tempFile);
+
+            var symbol = CreateSymbol(1, 1, "SmallClass", "Class",
+                "public class SmallClass", lineStart: 1, byteOffset: 0,
+                byteLength: Encoding.UTF8.GetByteCount(smallContent));
+
+            _store.GetSymbolByNameAsync("test-repo-id", "SmallClass").Returns(symbol);
+            _store.GetFilesByRepoAsync("test-repo-id")
+                .Returns(new List<FileRecord> { new(1, "test-repo-id", fileName, "hash1", 100, 1, 1000, 2000) });
+
+            _pathValidator.ValidatePath(dir, dir).Returns(dir);
+
+            var result = await _tools.GetSymbol(dir, "SmallClass").ConfigureAwait(false);
+
+            using var doc = JsonDocument.Parse(result);
+            var root = doc.RootElement;
+            await Assert.That(root.TryGetProperty("truncated", out _)).IsFalse();
+            await Assert.That(root.GetProperty("source_code").GetString()).IsEqualTo(smallContent);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Large symbols (>16KB) with child symbols return a **guided summary** instead of full source: metadata + child method signatures + expand_symbol instructions
- Added `GetChildSymbolsAsync` to `ISymbolStore`/`SqliteSymbolStore` for parent→child lookups
- `force=true` parameter bypasses the size guard
- `get_symbols` batch applies the same guard independently per-symbol
- Symbols with no children always return full source (nothing to drill into)
- Tool description updated to document the behavior

Closes #86

## Test plan

- [x] 816 tests pass (4 new: guided summary, force bypass, no-children fallback, small symbol)
- [x] Zero build warnings
- [x] Large symbol with children → truncated response with children array and guidance
- [x] Large symbol with force=true → full source code
- [x] Large symbol with no children → full source code (no drill-down target)
- [x] Small symbol → unchanged behavior (full source)
- [x] Security review passed — parameterized SQL, no user input in guidance text

🤖 Generated with [Claude Code](https://claude.com/claude-code)