### PR TITLE
feat: Index C# record & class primary constructor parameters as child symbols (#96)

### DIFF
--- a/samples/csharp-sample-project/COVERAGE.md
+++ b/samples/csharp-sample-project/COVERAGE.md
@@ -21,6 +21,7 @@ Constructs exercised by this sample project against `CSharpParser`.
 - [x] Methods (public, private, async, expression-bodied, virtual, override)
 - [x] Constructors (regular, primary)
 - [x] Properties (auto-prop, expression-bodied, init-only)
+- [x] Primary constructor parameters (indexed as Constant children of record/class)
 - [x] Indexer (`this[]`)
 - [x] Finalizer (`~ClassName`)
 - [x] Operator overloads (single-line expression-bodied)

--- a/src/CodeCompress.Core/Parsers/CSharpParser.cs
+++ b/src/CodeCompress.Core/Parsers/CSharpParser.cs
@@ -962,6 +962,10 @@ public sealed partial class CSharpParser : ILanguageParser
         var visibility = DeriveVisibility(modifiers, isNested);
         var currentDepth = GetCurrentBraceDepth(parentStack);
 
+        // Extract primary constructor parameters as child symbols
+        ExtractPrimaryConstructorParameters(
+            rest, name, lineNumber, byteOffset, trimmed, symbols);
+
         var isSemicolonTerminated = trimmed.EndsWith(';');
 
         if (isSemicolonTerminated)
@@ -995,6 +999,162 @@ public sealed partial class CSharpParser : ILanguageParser
         }
 
         return true;
+    }
+
+    private static void ExtractPrimaryConstructorParameters(
+        string rest, string typeName, int lineNumber, int lineByteOffset,
+        string fullLine, List<SymbolInfo> symbols)
+    {
+        if (string.IsNullOrEmpty(rest) || rest[0] != '(')
+        {
+            return;
+        }
+
+        // Find matching close paren at depth 0
+        var closeIdx = FindMatchingCloseParenInParams(rest);
+        if (closeIdx < 0)
+        {
+            return;
+        }
+
+        var paramsText = rest[1..closeIdx]; // content between ( and )
+        if (string.IsNullOrWhiteSpace(paramsText))
+        {
+            return;
+        }
+
+        // Split on commas at depth 0 (respecting <>, [], ())
+        var parameters = SplitParametersAtDepthZero(paramsText);
+
+        foreach (var param in parameters)
+        {
+            var trimmedParam = param.Trim();
+            if (string.IsNullOrEmpty(trimmedParam))
+            {
+                continue;
+            }
+
+            var paramName = ExtractParameterName(trimmedParam);
+            if (string.IsNullOrEmpty(paramName))
+            {
+                continue;
+            }
+
+            // Calculate byte offset of this parameter within the line
+            var paramStartInLine = fullLine.IndexOf(trimmedParam, StringComparison.Ordinal);
+            var paramByteOffset = paramStartInLine >= 0
+                ? lineByteOffset + Encoding.UTF8.GetByteCount(fullLine[..paramStartInLine])
+                : lineByteOffset;
+
+            symbols.Add(new SymbolInfo(
+                Name: paramName,
+                Kind: SymbolKind.Constant,
+                Signature: trimmedParam,
+                ParentSymbol: typeName,
+                ByteOffset: paramByteOffset,
+                ByteLength: Encoding.UTF8.GetByteCount(trimmedParam),
+                LineStart: lineNumber,
+                LineEnd: lineNumber,
+                Visibility: Visibility.Public,
+                DocComment: null));
+        }
+    }
+
+    private static int FindMatchingCloseParenInParams(string text)
+    {
+        var depth = 0;
+        for (var i = 0; i < text.Length; i++)
+        {
+            switch (text[i])
+            {
+                case '(':
+                    depth++;
+                    break;
+                case ')':
+                    depth--;
+                    if (depth == 0)
+                    {
+                        return i;
+                    }
+
+                    break;
+            }
+        }
+
+        return -1;
+    }
+
+    private static List<string> SplitParametersAtDepthZero(string paramsText)
+    {
+        var result = new List<string>();
+        var depth = 0; // tracks <>, [], ()
+        var start = 0;
+
+        for (var i = 0; i < paramsText.Length; i++)
+        {
+            switch (paramsText[i])
+            {
+                case '<' or '[' or '(':
+                    depth++;
+                    break;
+                case '>' or ']' or ')':
+                    depth--;
+                    break;
+                case ',' when depth == 0:
+                    result.Add(paramsText[start..i]);
+                    start = i + 1;
+                    break;
+            }
+        }
+
+        // Add the last parameter
+        if (start < paramsText.Length)
+        {
+            result.Add(paramsText[start..]);
+        }
+
+        return result;
+    }
+
+    private static string ExtractParameterName(string paramText)
+    {
+        // Parameter name is the last word token before any `=` default value
+        // Handle: "string Name", "[Required] string Name", "int X = 5",
+        //         "ILogger<T> logger", "params string[] tags"
+
+        var text = paramText;
+
+        // Strip default value for name extraction
+        var equalsIdx = FindEqualsOutsideBrackets(text);
+        if (equalsIdx >= 0)
+        {
+            text = text[..equalsIdx].TrimEnd();
+        }
+
+        // The name is the last whitespace-delimited token
+        var lastSpace = text.LastIndexOf(' ');
+        return lastSpace >= 0 ? text[(lastSpace + 1)..] : text;
+    }
+
+    private static int FindEqualsOutsideBrackets(string text)
+    {
+        var depth = 0;
+        for (var i = 0; i < text.Length; i++)
+        {
+            switch (text[i])
+            {
+                case '<' or '[' or '(':
+                    depth++;
+                    break;
+                case '>' or ']' or ')':
+                    depth--;
+                    break;
+                case '=' when depth == 0:
+                    return i;
+            }
+        }
+
+        return -1;
     }
 
     private static void UpdateBraceDepth(

--- a/tests/CodeCompress.Core.Tests/Parsers/CSharpParserTests.cs
+++ b/tests/CodeCompress.Core.Tests/Parsers/CSharpParserTests.cs
@@ -644,6 +644,221 @@ internal sealed class CSharpParserTests
         await Assert.That(cls.ByteOffset).IsEqualTo(expectedOffset);
     }
 
+    // ── Record primary constructor parameters ─────────────────────
+
+    [Test]
+    public async Task RecordPrimaryConstructorParamsIndexedAsChildren()
+    {
+        var source = """
+            public record Order(string Id, decimal Total, DateTime CreatedAt);
+            """;
+
+        var result = Parse(source);
+
+        var rec = result.Symbols.First(s => s.Name == "Order");
+        await Assert.That(rec.Kind).IsEqualTo(SymbolKind.Record);
+
+        var children = result.Symbols.Where(s => s.ParentSymbol == "Order" && s.Kind == SymbolKind.Constant).ToList();
+        await Assert.That(children).Count().IsEqualTo(3);
+
+        var id = children.First(s => s.Name == "Id");
+        await Assert.That(id.Signature).IsEqualTo("string Id");
+        await Assert.That(id.Visibility).IsEqualTo(Visibility.Public);
+
+        var total = children.First(s => s.Name == "Total");
+        await Assert.That(total.Signature).IsEqualTo("decimal Total");
+
+        var createdAt = children.First(s => s.Name == "CreatedAt");
+        await Assert.That(createdAt.Signature).IsEqualTo("DateTime CreatedAt");
+    }
+
+    [Test]
+    public async Task RecordParamWithDefaultValuePreservesDefault()
+    {
+        var source = """
+            public record Config(string Name, int Retries = 3);
+            """;
+
+        var result = Parse(source);
+
+        var children = result.Symbols.Where(s => s.ParentSymbol == "Config" && s.Kind == SymbolKind.Constant).ToList();
+        await Assert.That(children).Count().IsEqualTo(2);
+
+        var retries = children.First(s => s.Name == "Retries");
+        await Assert.That(retries.Signature).IsEqualTo("int Retries = 3");
+    }
+
+    [Test]
+    public async Task RecordStructParamsIndexed()
+    {
+        var source = """
+            public record struct Point(double X, double Y);
+            """;
+
+        var result = Parse(source);
+
+        var children = result.Symbols.Where(s => s.ParentSymbol == "Point" && s.Kind == SymbolKind.Constant).ToList();
+        await Assert.That(children).Count().IsEqualTo(2);
+        await Assert.That(children[0].Name).IsEqualTo("X");
+        await Assert.That(children[1].Name).IsEqualTo("Y");
+    }
+
+    [Test]
+    public async Task ClassPrimaryConstructorParamsIndexed()
+    {
+        var source = """
+            public class OrderService(IOrderRepo repo, ILogger<OrderService> logger)
+            {
+            }
+            """;
+
+        var result = Parse(source);
+
+        var cls = result.Symbols.First(s => s.Name == "OrderService");
+        await Assert.That(cls.Kind).IsEqualTo(SymbolKind.Class);
+
+        var children = result.Symbols.Where(s => s.ParentSymbol == "OrderService" && s.Kind == SymbolKind.Constant).ToList();
+        await Assert.That(children).Count().IsEqualTo(2);
+
+        var repo = children.First(s => s.Name == "repo");
+        await Assert.That(repo.Signature).IsEqualTo("IOrderRepo repo");
+
+        var logger = children.First(s => s.Name == "logger");
+        await Assert.That(logger.Signature).IsEqualTo("ILogger<OrderService> logger");
+    }
+
+    [Test]
+    public async Task GenericRecordParamsHandled()
+    {
+        var source = """
+            public record Result<T>(T Value, string? Error) where T : notnull;
+            """;
+
+        var result = Parse(source);
+
+        var children = result.Symbols.Where(s => s.ParentSymbol == "Result" && s.Kind == SymbolKind.Constant).ToList();
+        await Assert.That(children).Count().IsEqualTo(2);
+        await Assert.That(children.First(s => s.Name == "Value").Signature).IsEqualTo("T Value");
+        await Assert.That(children.First(s => s.Name == "Error").Signature).IsEqualTo("string? Error");
+    }
+
+    [Test]
+    public async Task RecordWithNoParamsProducesNoChildren()
+    {
+        var source = """
+            public record EmptyMarker { }
+            """;
+
+        var result = Parse(source);
+
+        var rec = result.Symbols.First(s => s.Name == "EmptyMarker");
+        await Assert.That(rec.Kind).IsEqualTo(SymbolKind.Record);
+
+        var children = result.Symbols.Where(s => s.ParentSymbol == "EmptyMarker" && s.Kind == SymbolKind.Constant).ToList();
+        await Assert.That(children).Count().IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task RecordWithEmptyParensProducesNoChildren()
+    {
+        var source = """
+            public record Marker();
+            """;
+
+        var result = Parse(source);
+
+        var children = result.Symbols.Where(s => s.ParentSymbol == "Marker" && s.Kind == SymbolKind.Constant).ToList();
+        await Assert.That(children).Count().IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task RecordSingleParamProducesOneChild()
+    {
+        var source = """
+            public record Wrapper(string Value);
+            """;
+
+        var result = Parse(source);
+
+        var children = result.Symbols.Where(s => s.ParentSymbol == "Wrapper" && s.Kind == SymbolKind.Constant).ToList();
+        await Assert.That(children).Count().IsEqualTo(1);
+        await Assert.That(children[0].Name).IsEqualTo("Value");
+    }
+
+    [Test]
+    public async Task NestedRecordParamsUseCorrectParentChain()
+    {
+        var source = """
+            public class Outer
+            {
+                public record Inner(int X);
+            }
+            """;
+
+        var result = Parse(source);
+
+        var inner = result.Symbols.First(s => s.Name == "Inner");
+        await Assert.That(inner.ParentSymbol).IsEqualTo("Outer");
+
+        var x = result.Symbols.First(s => s.Name == "X" && s.Kind == SymbolKind.Constant);
+        await Assert.That(x.ParentSymbol).IsEqualTo("Inner");
+    }
+
+    [Test]
+    public async Task RecordParamsWithAttributesIncludeAttributes()
+    {
+        var source = """
+            public record Cmd([Required] string Name, [Range(1, 100)] int Count);
+            """;
+
+        var result = Parse(source);
+
+        var children = result.Symbols.Where(s => s.ParentSymbol == "Cmd" && s.Kind == SymbolKind.Constant).ToList();
+        await Assert.That(children).Count().IsEqualTo(2);
+
+        var name = children.First(s => s.Name == "Name");
+        await Assert.That(name.Signature).IsEqualTo("[Required] string Name");
+
+        var count = children.First(s => s.Name == "Count");
+        await Assert.That(count.Signature).IsEqualTo("[Range(1, 100)] int Count");
+    }
+
+    [Test]
+    public async Task RecordWithBodyParamsIndexed()
+    {
+        var source = """
+            public record Foo(int X, string Y)
+            {
+                public int Z { get; init; }
+            }
+            """;
+
+        var result = Parse(source);
+
+        var children = result.Symbols.Where(s => s.ParentSymbol == "Foo" && s.Kind == SymbolKind.Constant).ToList();
+        // X and Y from primary constructor + Z from body property
+        await Assert.That(children.Count).IsGreaterThanOrEqualTo(2);
+
+        var x = children.First(s => s.Name == "X");
+        await Assert.That(x.Signature).IsEqualTo("int X");
+    }
+
+    [Test]
+    public async Task RecordParamWithParamsKeyword()
+    {
+        var source = """
+            public record TaggedItem(string Name, params string[] Tags);
+            """;
+
+        var result = Parse(source);
+
+        var children = result.Symbols.Where(s => s.ParentSymbol == "TaggedItem" && s.Kind == SymbolKind.Constant).ToList();
+        await Assert.That(children).Count().IsEqualTo(2);
+
+        var tags = children.First(s => s.Name == "Tags");
+        await Assert.That(tags.Signature).IsEqualTo("params string[] Tags");
+    }
+
     // ── Record with body ─────────────────────────────────────────
 
     [Test]

--- a/tests/CodeCompress.Integration.Tests/CSharpEndToEndTests.cs
+++ b/tests/CodeCompress.Integration.Tests/CSharpEndToEndTests.cs
@@ -63,7 +63,7 @@ internal sealed class CSharpEndToEndTests : IDisposable
 
         await Assert.That(result.RepoId).IsEqualTo(_repoId);
         await Assert.That(result.FilesIndexed).IsEqualTo(15);
-        await Assert.That(result.SymbolsFound).IsEqualTo(92);
+        await Assert.That(result.SymbolsFound).IsEqualTo(99);
     }
 
     // ── Query Tests ──────────────────────────────────────────────────────
@@ -79,7 +79,7 @@ internal sealed class CSharpEndToEndTests : IDisposable
         await Assert.That(outline.Groups).Count().IsGreaterThanOrEqualTo(1);
 
         var totalSymbols = CountOutlineSymbols(outline.Groups);
-        await Assert.That(totalSymbols).IsEqualTo(92);
+        await Assert.That(totalSymbols).IsEqualTo(99);
 
         // Verify some specific symbol kinds appear
         var allSymbolKinds = CollectSymbolKinds(outline.Groups);
@@ -466,6 +466,53 @@ internal sealed class CSharpEndToEndTests : IDisposable
         var namespaceSymbol = symbols.FirstOrDefault(s => s.Kind == "Module");
         await Assert.That(namespaceSymbol).IsNotNull();
         await Assert.That(namespaceSymbol!.Name).IsEqualTo("GameProject.Models");
+    }
+
+    // ── Record Primary Constructor Parameter Tests ────────────────────
+
+    [Test]
+    public async Task RecordPrimaryConstructorParamsSearchable()
+    {
+        await IndexSampleProjectAsync().ConfigureAwait(false);
+
+        // Player record has params: Name, Level, Health
+        var results = await _store.SearchSymbolsAsync(
+            _repoId, "Name", kind: "Constant", limit: 20).ConfigureAwait(false);
+
+        var playerName = results.FirstOrDefault(r =>
+            r.Symbol.Name == "Name" && r.Symbol.ParentSymbol == "Player");
+
+        await Assert.That(playerName).IsNotNull();
+        await Assert.That(playerName!.Symbol.Kind).IsEqualTo("Constant");
+    }
+
+    [Test]
+    public async Task RecordPrimaryConstructorParamsExpandable()
+    {
+        await IndexSampleProjectAsync().ConfigureAwait(false);
+
+        // Point record struct has params: X, Y
+        var symbol = await _store.GetSymbolByNameAsync(
+            _repoId, "Point:X").ConfigureAwait(false);
+
+        await Assert.That(symbol).IsNotNull();
+        await Assert.That(symbol!.Kind).IsEqualTo("Constant");
+        await Assert.That(symbol.ParentSymbol).IsEqualTo("Point");
+    }
+
+    [Test]
+    public async Task ClassPrimaryConstructorParamsSearchableInSample()
+    {
+        await IndexSampleProjectAsync().ConfigureAwait(false);
+
+        // GameEngine has primary constructor params: combat, inventory
+        var results = await _store.SearchSymbolsAsync(
+            _repoId, "combat", kind: "Constant", limit: 20).ConfigureAwait(false);
+
+        var param = results.FirstOrDefault(r =>
+            r.Symbol.Name == "combat" && r.Symbol.ParentSymbol == "GameEngine");
+
+        await Assert.That(param).IsNotNull();
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Extract individual parameters from record and class primary constructors as `Constant` child symbols
- Parameters are now independently searchable via FTS5 and expandable via `expand_symbol("Order:Id")`
- Handles: default values, attributes, `params` keyword, generic types, nullable types, nested records, empty parens

## Before / After

**Before:** `search_symbols("DeliveryId")` → 0 results; `expand_symbol("Order:Id")` → `SYMBOL_NOT_FOUND`

**After:** Both work. Parameters appear as `Constant` children with `ParentSymbol` set to the containing type.

## Test plan
- [x] 866 tests pass (0 failures, 0 warnings)
- [x] 12 new unit tests covering all acceptance criteria
- [x] 3 new integration tests (FTS5 search, expand_symbol, class primary constructor)
- [x] Zero build warnings
- [x] No CLI changes needed (passes through symbols generically)
- [x] Security: no new user input surfaces; parameters flow through existing parameterized query pipeline

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)