### PR TITLE
Improve MCP tool descriptions with examples and cross-references

### DIFF
--- a/src/CodeCompress.Server/Tools/IndexingTools.cs
+++ b/src/CodeCompress.Server/Tools/IndexingTools.cs
@@ -32,8 +32,8 @@ internal sealed partial class IndexingTools
     public async Task<string> IndexProject(
         [Description("ABSOLUTE path to the project root directory — the same root used with index_project (e.g., 'C:\\Projects\\MyGame' or '/home/user/my-project'). Must NOT be a subdirectory or relative path.")] string path,
         [Description("Filter to a specific language (e.g., 'luau')")] string? language = null,
-        [Description("Glob patterns for files to include")] string[]? includePatterns = null,
-        [Description("Glob patterns for files to exclude")] string[]? excludePatterns = null,
+        [Description("Microsoft glob patterns for files to include (e.g., 'src/**/*.cs', '**/*.py', 'tests/**'). Omit to index all supported file types.")] string[]? includePatterns = null,
+        [Description("Microsoft glob patterns for files to exclude (e.g., 'bin/**', 'obj/**', 'node_modules/**', '**/generated/**'). Common build output directories are excluded by default.")] string[]? excludePatterns = null,
         CancellationToken cancellationToken = default)
     {
         string validatedPath;
@@ -128,7 +128,7 @@ internal sealed partial class IndexingTools
     }
 
     [McpServerTool(Name = "invalidate_cache")]
-    [Description("Delete the entire index for a project, forcing a full re-index on the next index_project call. Use when the index appears corrupted or out of sync.")]
+    [Description("Delete ALL indexed data for a project — removes every symbol, dependency, file record, and repository metadata from the database. The next index_project call will perform a full re-index from scratch, which can be slow for large codebases. Only use when the index appears corrupted or out of sync. For normal updates, prefer index_project which performs fast incremental re-indexing of only changed files.")]
     public async Task<string> InvalidateCache(
         [Description("ABSOLUTE path to the project root directory — the same root used with index_project (e.g., 'C:\\Projects\\MyGame' or '/home/user/my-project'). Must NOT be a subdirectory or relative path.")] string path,
         CancellationToken cancellationToken = default)

--- a/src/CodeCompress.Server/Tools/QueryTools.cs
+++ b/src/CodeCompress.Server/Tools/QueryTools.cs
@@ -445,7 +445,7 @@ internal sealed class QueryTools
     }
 
     [McpServerTool(Name = "search_symbols")]
-    [Description("Search the symbol index using FTS5 full-text search — faster and more precise than grep-style file scanning. Supports prefix*, *suffix, *contains*, and I*Pattern glob matching. Returns symbol names, kinds, signatures, and locations. Use pathFilter to scope results to a specific directory. Requires index_project to have been called first.")]
+    [Description("Search the symbol index using FTS5 full-text search — faster and more precise than grep-style file scanning. Supports prefix*, *suffix, *contains*, and I*Pattern glob matching. Returns symbol names, kinds, signatures, and locations. Use pathFilter to scope results to a specific directory. Use get_symbol or expand_symbol to retrieve full source code of matched symbols. Requires index_project to have been called first.")]
     public async Task<string> SearchSymbols(
         [Description("ABSOLUTE path to the project root directory — the same root used with index_project (e.g., 'C:\\Projects\\MyGame' or '/home/user/my-project'). Must NOT be a subdirectory or relative path.")] string path,
         [Description("Search query — supports plain text, FTS5 operators (AND, OR, NOT), and glob patterns (prefix*, *suffix, *contains*)")] string query,
@@ -633,7 +633,7 @@ internal sealed class QueryTools
     }
 
     [McpServerTool(Name = "search_text")]
-    [Description("Search raw indexed file contents using FTS5 full-text search — faster than grep for large codebases since content is pre-indexed. Use for string literals, comments, TODOs, or non-symbol patterns that search_symbols wouldn't find. Use pathFilter to scope results. Requires index_project to have been called first.")]
+    [Description("Search raw indexed file contents using FTS5 full-text search — faster than grep for large codebases since content is pre-indexed. Use for string literals, comments, TODOs, or non-symbol patterns that search_symbols wouldn't find. For symbol-specific searches (classes, functions, types), prefer search_symbols which returns structured metadata. Use pathFilter to scope results. Requires index_project to have been called first.")]
     public async Task<string> SearchText(
         [Description("ABSOLUTE path to the project root directory — the same root used with index_project (e.g., 'C:\\Projects\\MyGame' or '/home/user/my-project'). Must NOT be a subdirectory or relative path.")] string path,
         [Description("FTS5 search query (supports AND, OR, NOT, quoted phrases, prefix*)")] string query,


### PR DESCRIPTION
## Summary
- Add Microsoft glob pattern format and examples to `includePatterns`/`excludePatterns` parameters on `index_project`
- Rewrite `invalidate_cache` description to accurately reflect full data wipe behavior and recommend `index_project` for incremental updates
- Add cross-tool references: `search_symbols` → `get_symbol`/`expand_symbol`, `search_text` → `search_symbols`

Closes #104

## Test plan
- [x] All 576 core tests pass
- [x] Build compiles with zero code warnings (server binary locked by running MCP process — file copy errors only)
- [x] Changes are description-only (`[Description]` attributes) — no logic changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)