### PR TITLE
Document output schemas in MCP tool descriptions

### DIFF
--- a/src/CodeCompress.Server/Tools/DeltaTools.cs
+++ b/src/CodeCompress.Server/Tools/DeltaTools.cs
@@ -36,7 +36,7 @@ internal sealed partial class DeltaTools
     }
 
     [McpServerTool(Name = "changes_since")]
-    [Description("Show what changed since a named snapshot: new, modified, and deleted files with symbol-level diffs. Use snapshot_create to set a baseline before making changes, then call this to see exactly what was added, modified, or removed. Requires index_project to have been called first. Errors return JSON {error, code}. Codes: INVALID_PATH, SNAPSHOT_NOT_FOUND (includes 'available_snapshots' array — check available labels or create a new snapshot with snapshot_create).")]
+    [Description("Show what changed since a named snapshot: new, modified, and deleted files with symbol-level diffs. Use snapshot_create to set a baseline before making changes, then call this to see exactly what was added, modified, or removed. Requires index_project to have been called first. Returns Markdown: sections for new files (with symbol counts), modified files (with +added/~changed/-removed symbol diffs), deleted files, and a summary line with total counts. Errors return JSON {error, code}. Codes: INVALID_PATH, SNAPSHOT_NOT_FOUND (includes 'available_snapshots' array — check available labels or create a new snapshot with snapshot_create).")]
     public async Task<string> ChangesSince(
         [Description("ABSOLUTE path to the project root directory — the same root used with index_project (e.g., 'C:\\Projects\\MyGame' or '/home/user/my-project'). Must NOT be a subdirectory or relative path.")] string path,
         [Description("Label of a previously created snapshot. Available labels are returned in the error if the snapshot is not found.")] string snapshotLabel,
@@ -194,7 +194,7 @@ internal sealed partial class DeltaTools
     }
 
     [McpServerTool(Name = "file_tree")]
-    [Description("Get an annotated directory tree with file counts and line counts per directory. Does NOT require index_project — reads the filesystem directly. Use to quickly understand project structure before indexing. Errors return JSON {error, code}. Codes: INVALID_PATH, DIRECTORY_NOT_FOUND.")]
+    [Description("Get an annotated directory tree with file counts and line counts per directory. Does NOT require index_project — reads the filesystem directly. Use to quickly understand project structure before indexing. Returns plain text: indented tree with 'dirname/ (N files, N lines)' per directory and 'filename (N lines)' per file. Errors return JSON {error, code}. Codes: INVALID_PATH, DIRECTORY_NOT_FOUND.")]
     public async Task<string> FileTree(
         [Description("ABSOLUTE path to the project root directory — the same root used with index_project (e.g., 'C:\\Projects\\MyGame' or '/home/user/my-project'). Must NOT be a subdirectory or relative path.")] string path,
         [Description("Maximum directory depth (1-20, default 5). Values outside this range are clamped.")] int maxDepth = 5,

--- a/src/CodeCompress.Server/Tools/DependencyTools.cs
+++ b/src/CodeCompress.Server/Tools/DependencyTools.cs
@@ -35,7 +35,7 @@ internal sealed class DependencyTools
     }
 
     [McpServerTool(Name = "dependency_graph")]
-    [Description("Get the import/require dependency graph for a project or specific file — shows which files depend on which others. Use to understand code relationships before making changes. Requires index_project to have been called first. Errors return JSON {error, code}. Codes: INVALID_PATH, INVALID_DIRECTION (see direction param for valid values), FILE_NOT_FOUND (rootFile not in index — verify path and run index_project).")]
+    [Description("Get the import/require dependency graph for a project or specific file — shows which files depend on which others. Use to understand code relationships before making changes. Requires index_project to have been called first. Returns plain text: each file node followed by 'requires -> file1, file2' and 'required by -> file3' edges, with a total summary line. Errors return JSON {error, code}. Codes: INVALID_PATH, INVALID_DIRECTION (see direction param for valid values), FILE_NOT_FOUND (rootFile not in index — verify path and run index_project).")]
     public async Task<string> DependencyGraph(
         [Description("ABSOLUTE path to the project root directory — the same root used with index_project (e.g., 'C:\\Projects\\MyGame' or '/home/user/my-project'). Must NOT be a subdirectory or relative path.")] string path,
         [Description("Start traversal from a specific file (relative path). Omit for full project graph.")] string? rootFile = null,
@@ -171,7 +171,7 @@ internal sealed class DependencyTools
     }
 
     [McpServerTool(Name = "project_dependencies")]
-    [Description("Show inter-project dependency relationships in a .NET solution — parses ProjectReference entries from indexed .csproj files to build a project-level dependency graph with shared public types. Use to understand solution architecture. Requires index_project to have been called first. Errors return JSON {error, code}. Codes: INVALID_PATH, NO_PROJECTS (no .csproj/.fsproj/.vbproj files in index — run index_project first).")]
+    [Description("Show inter-project dependency relationships in a .NET solution — parses ProjectReference entries from indexed .csproj files to build a project-level dependency graph with shared public types. Use to understand solution architecture. Requires index_project to have been called first. Returns plain text: each project node with 'references -> project1, project2' (with shared types) and 'referenced by -> project3', plus a total summary line. Errors return JSON {error, code}. Codes: INVALID_PATH, NO_PROJECTS (no .csproj/.fsproj/.vbproj files in index — run index_project first).")]
     public async Task<string> ProjectDependencies(
         [Description("ABSOLUTE path to the project root directory — the same root used with index_project (e.g., 'C:\\Projects\\MySolution' or '/home/user/my-solution'). Must NOT be a subdirectory or relative path.")] string path,
         [Description("Filter to projects whose name contains this string (case-insensitive). Omit for all projects.")] string? projectFilter = null,

--- a/src/CodeCompress.Server/Tools/IndexingTools.cs
+++ b/src/CodeCompress.Server/Tools/IndexingTools.cs
@@ -28,7 +28,7 @@ internal sealed partial class IndexingTools
     }
 
     [McpServerTool(Name = "index_project")]
-    [Description("Index a codebase to build a searchable symbol database — MUST be called before any query tools. Scans source files, extracts symbols (classes, methods, functions, types), and stores them in a SQLite index. Re-running performs an incremental update (only changed files are re-parsed), so it's fast after the initial index. This enables all other CodeCompress tools to provide compressed, symbol-level code access. Errors return JSON {error, code}. Codes: INVALID_PATH (path outside project root — fix the path), DIRECTORY_NOT_FOUND (directory does not exist — verify the path).")]
+    [Description("Index a codebase to build a searchable symbol database — MUST be called before any query tools. Scans source files, extracts symbols (classes, methods, functions, types), and stores them in a SQLite index. Re-running performs an incremental update (only changed files are re-parsed), so it's fast after the initial index. This enables all other CodeCompress tools to provide compressed, symbol-level code access. Returns JSON: {repo_id, project_root, files_indexed, files_unchanged, files_errored, total_files, symbols_found, duration_ms, parse_errors: [{file_path, reason}] or null}. Errors return JSON {error, code}. Codes: INVALID_PATH (path outside project root — fix the path), DIRECTORY_NOT_FOUND (directory does not exist — verify the path).")]
     public async Task<string> IndexProject(
         [Description("ABSOLUTE path to the project root directory — the same root used with index_project (e.g., 'C:\\Projects\\MyGame' or '/home/user/my-project'). Must NOT be a subdirectory or relative path.")] string path,
         [Description("Filter to a specific language (e.g., 'luau')")] string? language = null,
@@ -81,7 +81,7 @@ internal sealed partial class IndexingTools
     }
 
     [McpServerTool(Name = "snapshot_create")]
-    [Description("Create a named snapshot of the current index state. Use before making code changes, then call changes_since with the snapshot label to see a precise symbol-level diff of what changed. Requires index_project to have been called first. Errors return JSON {error, code}. Codes: INVALID_PATH.")]
+    [Description("Create a named snapshot of the current index state. Use before making code changes, then call changes_since with the snapshot label to see a precise symbol-level diff of what changed. Requires index_project to have been called first. Returns JSON: {snapshot_id, label, file_count, symbol_count}. Errors return JSON {error, code}. Codes: INVALID_PATH.")]
     public async Task<string> SnapshotCreate(
         [Description("ABSOLUTE path to the project root directory — the same root used with index_project (e.g., 'C:\\Projects\\MyGame' or '/home/user/my-project'). Must NOT be a subdirectory or relative path.")] string path,
         [Description("Human-readable snapshot label")] string label,
@@ -128,7 +128,7 @@ internal sealed partial class IndexingTools
     }
 
     [McpServerTool(Name = "invalidate_cache")]
-    [Description("Delete ALL indexed data for a project — removes every symbol, dependency, file record, and repository metadata from the database. The next index_project call will perform a full re-index from scratch, which can be slow for large codebases. Only use when the index appears corrupted or out of sync. For normal updates, prefer index_project which performs fast incremental re-indexing of only changed files. Errors return JSON {error, code}. Codes: INVALID_PATH.")]
+    [Description("Delete ALL indexed data for a project — removes every symbol, dependency, file record, and repository metadata from the database. The next index_project call will perform a full re-index from scratch, which can be slow for large codebases. Only use when the index appears corrupted or out of sync. For normal updates, prefer index_project which performs fast incremental re-indexing of only changed files. Returns JSON: {success: true, message}. Errors return JSON {error, code}. Codes: INVALID_PATH.")]
     public async Task<string> InvalidateCache(
         [Description("ABSOLUTE path to the project root directory — the same root used with index_project (e.g., 'C:\\Projects\\MyGame' or '/home/user/my-project'). Must NOT be a subdirectory or relative path.")] string path,
         CancellationToken cancellationToken = default)

--- a/src/CodeCompress.Server/Tools/QueryTools.cs
+++ b/src/CodeCompress.Server/Tools/QueryTools.cs
@@ -43,7 +43,7 @@ internal sealed class QueryTools
     }
 
     [McpServerTool(Name = "project_outline")]
-    [Description("Get a compressed overview of the entire indexed codebase — all symbol signatures grouped by file, kind, or directory in a single response. Far more efficient than reading files individually (saves 90%+ tokens). Supports pagination via offset/maxSymbols for large codebases. Use pathFilter to scope to a subdirectory. Requires index_project to have been called first. Errors return JSON {error, code}. Codes: INVALID_PATH, INVALID_GROUP_BY (use 'file', 'kind', or 'directory'), INVALID_PATH_FILTER.")]
+    [Description("Get a compressed overview of the entire indexed codebase — all symbol signatures grouped by file, kind, or directory in a single response. Far more efficient than reading files individually (saves 90%+ tokens). Supports pagination via offset/maxSymbols for large codebases. Use pathFilter to scope to a subdirectory. Requires index_project to have been called first. Returns Markdown: heading hierarchy with symbol signatures (visibility, kind, signature per line). When truncated, includes a footer with the next offset/maxSymbols values to continue pagination. Errors return JSON {error, code}. Codes: INVALID_PATH, INVALID_GROUP_BY (use 'file', 'kind', or 'directory'), INVALID_PATH_FILTER.")]
     public async Task<string> ProjectOutline(
         [Description("ABSOLUTE path to the project root directory — the same root used with index_project (e.g., 'C:\\Projects\\MyGame' or '/home/user/my-project'). Must NOT be a subdirectory or relative path.")] string path,
         [Description("Include private/local symbols")] bool includePrivate = false,
@@ -102,7 +102,7 @@ internal sealed class QueryTools
     }
 
     [McpServerTool(Name = "get_module_api")]
-    [Description("Get the full public API surface of a single module file — all exported symbols, signatures, and import dependencies in one call. Use instead of reading the file to see only the public interface without implementation details. Requires index_project to have been called first. Errors return JSON {error, code}. Codes: INVALID_PATH, MODULE_NOT_FOUND (file not in index — verify modulePath and run index_project).")]
+    [Description("Get the full public API surface of a single module file — all exported symbols, signatures, and import dependencies in one call. Use instead of reading the file to see only the public interface without implementation details. Requires index_project to have been called first. Returns JSON: {module, symbols: [{name, kind, parent, signature, line, doc_comment}], dependencies: [{requires_path, alias}]}. Errors return JSON {error, code}. Codes: INVALID_PATH, MODULE_NOT_FOUND (file not in index — verify modulePath and run index_project).")]
     public async Task<string> GetModuleApi(
         [Description("ABSOLUTE path to the project root directory — the same root used with index_project (e.g., 'C:\\Projects\\MyGame' or '/home/user/my-project'). Must NOT be a subdirectory or relative path.")] string path,
         [Description("Relative path from the project root to the module file (e.g., 'src/services/CombatService.luau'). Forward slashes only, NOT an absolute path.")] string modulePath,
@@ -163,7 +163,7 @@ internal sealed class QueryTools
     }
 
     [McpServerTool(Name = "get_symbol")]
-    [Description("Retrieve the full source code of a specific symbol by qualified name — loads only the exact symbol, not the entire file (saves 80%+ tokens vs file reading). For large symbols (>16KB), returns a guided summary with child method signatures and instructions to use expand_symbol for individual methods. Use force=true to bypass the size guard. Requires index_project to have been called first. Errors return JSON {error, code}. Codes: INVALID_PATH, SYMBOL_NOT_FOUND (includes 'symbol' field — use search_symbols to find the correct name), FILE_NOT_FOUND.")]
+    [Description("Retrieve the full source code of a specific symbol by qualified name — loads only the exact symbol, not the entire file (saves 80%+ tokens vs file reading). For large symbols (>16KB), returns a guided summary with child method signatures and instructions to use expand_symbol for individual methods. Use force=true to bypass the size guard. Requires index_project to have been called first. Returns JSON: {name, kind, parent, file, line_start, line_end, signature, source_code}. For large symbols (>16KB): {name, kind, parent, file, line_start, line_end, signature, truncated: true, source_size_bytes, children: [{name, signature, expand_with}], guidance}. Errors return JSON {error, code}. Codes: INVALID_PATH, SYMBOL_NOT_FOUND (includes 'symbol' field — use search_symbols to find the correct name), FILE_NOT_FOUND.")]
     public async Task<string> GetSymbol(
         [Description("ABSOLUTE path to the project root directory — the same root used with index_project (e.g., 'C:\\Projects\\MyGame' or '/home/user/my-project'). Must NOT be a subdirectory or relative path.")] string path,
         [Description("Fully qualified symbol name — use 'Parent:Child' for nested symbols (e.g., 'CombatService:ProcessAttack') or just the name for top-level symbols. Use search_symbols to discover names.")] string symbolName,
@@ -240,7 +240,7 @@ internal sealed class QueryTools
     }
 
     [McpServerTool(Name = "expand_symbol")]
-    [Description("Retrieve only the body of a nested symbol (e.g., a single method) without loading the entire parent class — saves ~60% tokens vs get_symbol on the parent. Use 'Parent:Child' qualified names to extract exactly the method you need. Ideal for reading individual methods in large classes. Requires index_project to have been called first. Errors return JSON {error, code}. Codes: INVALID_PATH, SYMBOL_NOT_FOUND (includes 'symbol' field — use search_symbols to find the correct name), FILE_NOT_FOUND.")]
+    [Description("Retrieve only the body of a nested symbol (e.g., a single method) without loading the entire parent class — saves ~60% tokens vs get_symbol on the parent. Use 'Parent:Child' qualified names to extract exactly the method you need. Ideal for reading individual methods in large classes. Requires index_project to have been called first. Returns JSON: {name, kind, parent, file, line_start, line_end, signature, doc_comment, source_code}. Errors return JSON {error, code}. Codes: INVALID_PATH, SYMBOL_NOT_FOUND (includes 'symbol' field — use search_symbols to find the correct name), FILE_NOT_FOUND.")]
     public async Task<string> ExpandSymbol(
         [Description("ABSOLUTE path to the project root directory — the same root used with index_project (e.g., 'C:\\Projects\\MyGame' or '/home/user/my-project'). Must NOT be a subdirectory or relative path.")] string path,
         [Description("Fully qualified symbol name — use 'Parent:Child' for nested symbols (e.g., 'PlayerService:GetHealth'). Use search_symbols to discover names.")] string symbolName,
@@ -308,7 +308,7 @@ internal sealed class QueryTools
     }
 
     [McpServerTool(Name = "get_symbols")]
-    [Description("Batch retrieve source code for multiple symbols in one call — significantly more efficient than calling get_symbol repeatedly (single round-trip vs N). Maximum 50 names per call. Requires index_project to have been called first. Errors return JSON {error, code}. Codes: INVALID_PATH, EMPTY_SYMBOL_NAMES, SYMBOL_LIMIT_EXCEEDED (max 50). Per-symbol errors in 'errors' array: SYMBOL_NOT_FOUND (includes 'symbol' field).")]
+    [Description("Batch retrieve source code for multiple symbols in one call — significantly more efficient than calling get_symbol repeatedly (single round-trip vs N). Maximum 50 names per call. Requires index_project to have been called first. Returns JSON: {results: [{name, kind, parent, file, line_start, line_end, signature, source_code}], errors: [{symbol, error, code}]}. Large symbols return truncated format with children array (same as get_symbol). Errors return JSON {error, code}. Codes: INVALID_PATH, EMPTY_SYMBOL_NAMES, SYMBOL_LIMIT_EXCEEDED (max 50). Per-symbol errors in 'errors' array: SYMBOL_NOT_FOUND (includes 'symbol' field).")]
     public async Task<string> GetSymbols(
         [Description("ABSOLUTE path to the project root directory — the same root used with index_project (e.g., 'C:\\Projects\\MyGame' or '/home/user/my-project'). Must NOT be a subdirectory or relative path.")] string path,
         [Description("Array of fully qualified symbol names (same format as get_symbol). Maximum 50 per call.")] string[] symbolNames,
@@ -445,7 +445,7 @@ internal sealed class QueryTools
     }
 
     [McpServerTool(Name = "search_symbols")]
-    [Description("Search the symbol index using FTS5 full-text search — faster and more precise than grep-style file scanning. Supports prefix*, *suffix, *contains*, and I*Pattern glob matching. Returns symbol names, kinds, signatures, and locations. Use pathFilter to scope results to a specific directory. Use get_symbol or expand_symbol to retrieve full source code of matched symbols. Requires index_project to have been called first. Errors return JSON {error, code}. Codes: INVALID_PATH, EMPTY_QUERY, QUERY_TOO_BROAD (add a non-wildcard term or pathFilter), INVALID_KIND (see kind param for valid values), INVALID_PATH_FILTER, MIXED_PATTERN (includes 'suggestion' — split into separate queries).")]
+    [Description("Search the symbol index using FTS5 full-text search — faster and more precise than grep-style file scanning. Supports prefix*, *suffix, *contains*, and I*Pattern glob matching. Returns symbol names, kinds, signatures, and locations. Use pathFilter to scope results to a specific directory. Use get_symbol or expand_symbol to retrieve full source code of matched symbols. Requires index_project to have been called first. Returns JSON: {query, total_matches, results: [{name, kind, parent, file, line, signature, snippet, rank}]}. Chain with get_symbol using the 'name' field (or 'parent:name' for nested symbols). Errors return JSON {error, code}. Codes: INVALID_PATH, EMPTY_QUERY, QUERY_TOO_BROAD (add a non-wildcard term or pathFilter), INVALID_KIND (see kind param for valid values), INVALID_PATH_FILTER, MIXED_PATTERN (includes 'suggestion' — split into separate queries).")]
     public async Task<string> SearchSymbols(
         [Description("ABSOLUTE path to the project root directory — the same root used with index_project (e.g., 'C:\\Projects\\MyGame' or '/home/user/my-project'). Must NOT be a subdirectory or relative path.")] string path,
         [Description("Search query — supports plain text, FTS5 operators (AND, OR, NOT), and glob patterns (prefix*, *suffix, *contains*)")] string query,
@@ -567,7 +567,7 @@ internal sealed class QueryTools
     }
 
     [McpServerTool(Name = "topic_outline")]
-    [Description("Search for symbols related to a topic and return results in a structured outline format grouped by file. Combines search_symbols with project_outline presentation — ideal for exploring a concept across the codebase (e.g., 'show me all authentication-related types'). Requires index_project to have been called first. Errors return JSON {error, code}. Codes: INVALID_PATH, EMPTY_QUERY, INVALID_PATH_FILTER.")]
+    [Description("Search for symbols related to a topic and return results in a structured outline format grouped by file. Combines search_symbols with project_outline presentation — ideal for exploring a concept across the codebase (e.g., 'show me all authentication-related types'). Requires index_project to have been called first. Returns Markdown: heading hierarchy with matching symbol signatures grouped by file. When truncated, includes a footer with remaining match count. Errors return JSON {error, code}. Codes: INVALID_PATH, EMPTY_QUERY, INVALID_PATH_FILTER.")]
     public async Task<string> TopicOutline(
         [Description("ABSOLUTE path to the project root directory — the same root used with index_project (e.g., 'C:\\Projects\\MyGame' or '/home/user/my-project'). Must NOT be a subdirectory or relative path.")] string path,
         [Description("Topic or keyword to search for (e.g., 'authentication', 'kubernetes', 'database'). Searches symbol names, signatures, and doc comments via FTS5.")] string topic,
@@ -633,7 +633,7 @@ internal sealed class QueryTools
     }
 
     [McpServerTool(Name = "search_text")]
-    [Description("Search raw indexed file contents using FTS5 full-text search — faster than grep for large codebases since content is pre-indexed. Use for string literals, comments, TODOs, or non-symbol patterns that search_symbols wouldn't find. For symbol-specific searches (classes, functions, types), prefer search_symbols which returns structured metadata. Use pathFilter to scope results. Requires index_project to have been called first. Errors return JSON {error, code}. Codes: INVALID_PATH, EMPTY_QUERY, INVALID_PATH_FILTER.")]
+    [Description("Search raw indexed file contents using FTS5 full-text search — faster than grep for large codebases since content is pre-indexed. Use for string literals, comments, TODOs, or non-symbol patterns that search_symbols wouldn't find. For symbol-specific searches (classes, functions, types), prefer search_symbols which returns structured metadata. Use pathFilter to scope results. Requires index_project to have been called first. Returns JSON: {query, total_matches, results: [{file_path, snippet, rank}]}. Errors return JSON {error, code}. Codes: INVALID_PATH, EMPTY_QUERY, INVALID_PATH_FILTER.")]
     public async Task<string> SearchText(
         [Description("ABSOLUTE path to the project root directory — the same root used with index_project (e.g., 'C:\\Projects\\MyGame' or '/home/user/my-project'). Must NOT be a subdirectory or relative path.")] string path,
         [Description("FTS5 search query (supports AND, OR, NOT, quoted phrases, prefix*)")] string query,

--- a/src/CodeCompress.Server/Tools/ReferenceTools.cs
+++ b/src/CodeCompress.Server/Tools/ReferenceTools.cs
@@ -29,7 +29,7 @@ internal sealed class ReferenceTools
     }
 
     [McpServerTool(Name = "find_references")]
-    [Description("Find all locations where a symbol is referenced across the indexed codebase — far faster than grep since content is pre-indexed. Returns file paths, line numbers, and 3-line context snippets. Works for functions, types, interfaces, DI registrations, and any text pattern. Use to trace usage before refactoring. Requires index_project to have been called first. Errors return JSON {error, code}. Codes: INVALID_PATH, EMPTY_SYMBOL_NAME, INVALID_PATH_FILTER.")]
+    [Description("Find all locations where a symbol is referenced across the indexed codebase — far faster than grep since content is pre-indexed. Returns file paths, line numbers, and 3-line context snippets. Works for functions, types, interfaces, DI registrations, and any text pattern. Use to trace usage before refactoring. Requires index_project to have been called first. Returns JSON: {symbol, total_matches, results: [{file, line, context_snippet, rank}]}. Errors return JSON {error, code}. Codes: INVALID_PATH, EMPTY_SYMBOL_NAME, INVALID_PATH_FILTER.")]
     public async Task<string> FindReferences(
         [Description("ABSOLUTE path to the project root directory — the same root used with index_project (e.g., 'C:\\Projects\\MyGame' or '/home/user/my-project'). Must NOT be a subdirectory or relative path.")] string path,
         [Description("Symbol name to search for references (e.g., 'ProcessAttack', 'ISymbolStore'). Does not need to exist in the symbol table — text search is used.")] string symbolName,

--- a/src/CodeCompress.Server/Tools/ServerControlTools.cs
+++ b/src/CodeCompress.Server/Tools/ServerControlTools.cs
@@ -23,7 +23,7 @@ internal sealed class ServerControlTools
     }
 
     [McpServerTool(Name = "stop_server")]
-    [Description("Gracefully shut down the CodeCompress MCP server. Claude Code will automatically restart it on the next tool call. Use this to release DLL locks during development or free resources.")]
+    [Description("Gracefully shut down the CodeCompress MCP server. Claude Code will automatically restart it on the next tool call. Use this to release DLL locks during development or free resources. Returns JSON: {success: true, message}.")]
     public async Task<string> StopServer()
     {
         // Schedule shutdown after a brief delay so the response can be sent first


### PR DESCRIPTION
## Summary
- Add `Returns:` section to all 16 MCP tool descriptions documenting response structure
- JSON tools: document field names, types, and nesting (all snake_case per JsonNamingPolicy)
- Markdown/text tools: document heading hierarchy, pagination footers, diff format, tree structure
- Document large symbol guard response (truncated + children array) on `get_symbol` and `get_symbols`
- Document tool chaining: `search_symbols` name/parent fields map to `get_symbol` symbolName param

Closes #102

## Test plan
- [x] All 866 tests pass
- [x] Build with zero warnings
- [x] Changes are description-only (`[Description]` attributes) — no logic changes
- [x] All 16 tools across 6 tool classes covered (including `stop_server`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)