### PR TITLE
Add next-action hints to tool responses

### DIFF
--- a/src/CodeCompress.Server/Tools/IndexingTools.cs
+++ b/src/CodeCompress.Server/Tools/IndexingTools.cs
@@ -69,6 +69,7 @@ internal sealed partial class IndexingTools
                     result.SymbolsFound,
                     result.DurationMs,
                     ParseErrors = result.ParseFailures?.Select(f => new { f.FilePath, f.Reason }),
+                    Hint = "Run project_outline to explore the indexed codebase, or search_symbols to find specific symbols.",
                 };
 
                 return JsonSerializer.Serialize(response, SerializerOptions);
@@ -122,6 +123,7 @@ internal sealed partial class IndexingTools
                     Label = sanitizedLabel,
                     FileCount = fileCount,
                     SymbolCount = symbolCount,
+                    Hint = $"After making changes, run changes_since with label '{sanitizedLabel}' to see symbol-level diffs.",
                 },
                 SerializerOptions);
         }

--- a/src/CodeCompress.Server/Tools/QueryTools.cs
+++ b/src/CodeCompress.Server/Tools/QueryTools.cs
@@ -151,6 +151,7 @@ internal sealed class QueryTools
                         d.RequiresPath,
                         d.Alias,
                     }),
+                    Hint = "Use get_symbol or expand_symbol with a symbol's name to retrieve its full source code.",
                 };
 
                 return JsonSerializer.Serialize(response, SerializerOptions);
@@ -547,6 +548,9 @@ internal sealed class QueryTools
             }
 
             var displayQuery = !string.IsNullOrEmpty(glob.Fts5Query) ? glob.Fts5Query : glob.SqlLikePattern ?? query;
+            var hint = results.Count > 0
+                ? "Use get_symbol with a result's name (or parent:name for nested symbols) to retrieve full source code."
+                : (string?)null;
             var response = new
             {
                 Query = displayQuery,
@@ -562,6 +566,7 @@ internal sealed class QueryTools
                     Snippet = r.Symbol.DocComment ?? string.Empty,
                     Rank = index + 1,
                 }),
+                Hint = hint,
             };
 
             return JsonSerializer.Serialize(response, SerializerOptions);
@@ -704,6 +709,9 @@ internal sealed class QueryTools
                     scope.RepoId, literalQuery, sanitizedGlob, clampedLimit, validatedPathFilter).ConfigureAwait(false);
             }
 
+            var hint = results.Count > 0
+                ? "Use search_symbols for structured symbol results, or get_symbol to retrieve source code for a specific symbol."
+                : (string?)null;
             var response = new
             {
                 Query = sanitizedQuery,
@@ -714,6 +722,7 @@ internal sealed class QueryTools
                     r.Snippet,
                     Rank = index + 1,
                 }),
+                Hint = hint,
             };
 
             return JsonSerializer.Serialize(response, SerializerOptions);

--- a/src/CodeCompress.Server/Tools/ReferenceTools.cs
+++ b/src/CodeCompress.Server/Tools/ReferenceTools.cs
@@ -82,6 +82,9 @@ internal sealed class ReferenceTools
                 results = [];
             }
 
+            var hint = results.Count > 0
+                ? "Use get_symbol to view the full source code of referenced symbols."
+                : (string?)null;
             var response = new
             {
                 Symbol = SanitizeSymbolName(symbolName),
@@ -93,6 +96,7 @@ internal sealed class ReferenceTools
                     ContextSnippet = r.ContextSnippet,
                     Rank = index + 1,
                 }),
+                Hint = hint,
             };
 
             return JsonSerializer.Serialize(response, SerializerOptions);


### PR DESCRIPTION
## Summary
- `index_project`: hint to run `project_outline` or `search_symbols`
- `snapshot_create`: hint to run `changes_since` with the snapshot label
- `search_symbols`: hint to use `get_symbol` with result names (when results > 0)
- `search_text`: hint to use `search_symbols` or `get_symbol` (when results > 0)
- `get_module_api`: hint to use `get_symbol`/`expand_symbol` for source code
- `find_references`: hint to use `get_symbol` for referenced symbols (when results > 0)
- Hints are null (omitted from JSON) when results are empty — no noise on zero-result responses

Closes #113

## Test plan
- [x] All 866 tests pass
- [x] Build with zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)