### PR TITLE
Normalize relative path inputs — backslashes to forward slashes

### DIFF
--- a/src/CodeCompress.Core/Validation/PathValidator.cs
+++ b/src/CodeCompress.Core/Validation/PathValidator.cs
@@ -76,6 +76,20 @@ public static class PathValidator
     }
 
     /// <summary>
+    /// Normalizes a relative path for consistent store lookups:
+    /// replaces backslashes with forward slashes and trims trailing separators.
+    /// </summary>
+    public static string NormalizeRelativePath(string relativePath)
+    {
+        if (string.IsNullOrEmpty(relativePath))
+        {
+            return relativePath;
+        }
+
+        return relativePath.Replace('\\', '/').TrimEnd('/');
+    }
+
+    /// <summary>
     /// Non-throwing variant that returns true if the candidate resolves within root.
     /// </summary>
     public static bool IsWithinRoot(string candidatePath, string projectRoot)

--- a/src/CodeCompress.Server/Tools/DependencyTools.cs
+++ b/src/CodeCompress.Server/Tools/DependencyTools.cs
@@ -60,11 +60,13 @@ internal sealed class DependencyTools
                 "INVALID_DIRECTION");
         }
 
-        if (rootFile is not null)
+        var normalizedRootFile = rootFile is not null ? PathValidator.NormalizeRelativePath(rootFile) : null;
+
+        if (normalizedRootFile is not null)
         {
             try
             {
-                _pathValidator.ValidateRelativePath(rootFile, validatedPath);
+                _pathValidator.ValidateRelativePath(normalizedRootFile, validatedPath);
             }
             catch (ArgumentException)
             {
@@ -78,15 +80,15 @@ internal sealed class DependencyTools
         await using (scope.ConfigureAwait(false))
         {
             var graph = await scope.Store.GetDependencyGraphAsync(
-                scope.RepoId, rootFile, direction, clampedDepth).ConfigureAwait(false);
+                scope.RepoId, normalizedRootFile, direction, clampedDepth).ConfigureAwait(false);
 
             // Non-existent root file returns empty graph
-            if (rootFile is not null && graph.Nodes.Count == 0)
+            if (normalizedRootFile is not null && graph.Nodes.Count == 0)
             {
                 return SerializeError("File not found in index", "FILE_NOT_FOUND");
             }
 
-            return FormatGraph(graph, rootFile, direction, clampedDepth);
+            return FormatGraph(graph, normalizedRootFile, direction, clampedDepth);
         }
     }
 

--- a/src/CodeCompress.Server/Tools/QueryTools.cs
+++ b/src/CodeCompress.Server/Tools/QueryTools.cs
@@ -118,9 +118,11 @@ internal sealed class QueryTools
             return SerializeError("Path validation failed", "INVALID_PATH");
         }
 
+        var normalizedModulePath = PathValidator.NormalizeRelativePath(modulePath);
+
         try
         {
-            _pathValidator.ValidateRelativePath(modulePath, validatedPath);
+            _pathValidator.ValidateRelativePath(normalizedModulePath, validatedPath);
         }
         catch (ArgumentException)
         {
@@ -132,7 +134,7 @@ internal sealed class QueryTools
             var scope = await _scopeFactory.CreateAsync(validatedPath, cancellationToken).ConfigureAwait(false);
             await using (scope.ConfigureAwait(false))
             {
-                var moduleApi = await scope.Store.GetModuleApiAsync(scope.RepoId, modulePath).ConfigureAwait(false);
+                var moduleApi = await scope.Store.GetModuleApiAsync(scope.RepoId, normalizedModulePath).ConfigureAwait(false);
 
                 var response = new
                 {


### PR DESCRIPTION
## Summary
- Add `PathValidator.NormalizeRelativePath()` — replaces backslashes with forward slashes and trims trailing separators
- `get_module_api`: normalize `modulePath` before validation and store lookup
- `dependency_graph`: normalize `rootFile` before validation and store lookup
- `pathFilter` already handled by `ValidatePathFilter` (existing behavior)
- Agents on Windows can now pass `src\services\Auth.cs` and it resolves correctly

Closes #112

## Test plan
- [x] All 866 tests pass
- [x] Build with zero warnings
- [x] Security: path traversal prevention preserved — normalization happens before validation
- [x] Parameterized SQL unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)