### PR TITLE
Normalize relative path inputs in CLI commands

### DIFF
--- a/src/CodeCompress.Cli/Program.cs
+++ b/src/CodeCompress.Cli/Program.cs
@@ -560,7 +560,7 @@ var depsCommand = new Command("deps",
 depsCommand.SetAction(async parseResult =>
 {
     var path = parseResult.GetValue(depsPathOption)!;
-    var rootFile = parseResult.GetValue(depsFileOption);
+    var rootFile = parseResult.GetValue(depsFileOption) is { } rf ? PathValidator.NormalizeRelativePath(rf) : null;
     var direction = parseResult.GetValue(depsDirectionOption)!;
     var depth = Math.Clamp(parseResult.GetValue(depsDepthOption), 1, 50);
     var json = parseResult.GetValue(jsonOption);
@@ -651,7 +651,7 @@ var getModuleApiCommand = new Command("get-module-api",
 getModuleApiCommand.SetAction(async parseResult =>
 {
     var path = parseResult.GetValue(getModuleApiPathOption)!;
-    var modulePath = parseResult.GetValue(getModuleApiModuleOption)!;
+    var modulePath = PathValidator.NormalizeRelativePath(parseResult.GetValue(getModuleApiModuleOption)!);
     var json = parseResult.GetValue(jsonOption);
 
     var scope = await CreateProjectScopeAsync(path, provider).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- `get-module-api`: normalize `--module` path via `PathValidator.NormalizeRelativePath`
- `deps`: normalize `--file` path via `PathValidator.NormalizeRelativePath`
- Agents on Windows can now pass backslash paths (e.g., `src\services\Auth.cs`)

Closes #121

## Test plan
- [x] All 866 tests pass
- [x] Build with zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)