### PR TITLE
feat: add stale index hint to SYMBOL_NOT_FOUND error guidance

### DIFF
--- a/src/CodeCompress.Cli/Program.cs
+++ b/src/CodeCompress.Cli/Program.cs
@@ -222,7 +222,7 @@ getSymbolCommand.SetAction(async parseResult =>
             else
             {
                 await WriteErrorAsync("Symbol not found", "SYMBOL_NOT_FOUND", json, jsonSerializerOptions,
-                    "Use 'codecompress search --path <path> --query <name>' to discover symbol names.").ConfigureAwait(false);
+                    "Use 'codecompress search --path <path> --query <name>' to discover symbol names. If the symbol was recently added or changed, re-run 'codecompress index' to update the index.").ConfigureAwait(false);
                 return;
             }
         }
@@ -763,7 +763,7 @@ expandSymbolCommand.SetAction(async parseResult =>
             else
             {
                 await WriteErrorAsync("Symbol not found", "SYMBOL_NOT_FOUND", json, jsonSerializerOptions,
-                    "Use 'codecompress search --path <path> --query <name>' to discover symbol names.").ConfigureAwait(false);
+                    "Use 'codecompress search --path <path> --query <name>' to discover symbol names. If the symbol was recently added or changed, re-run 'codecompress index' to update the index.").ConfigureAwait(false);
                 return;
             }
         }

--- a/src/CodeCompress.Server/Tools/QueryTools.cs
+++ b/src/CodeCompress.Server/Tools/QueryTools.cs
@@ -29,6 +29,7 @@ internal sealed class QueryTools
     };
 
     private const int SymbolSizeThresholdBytes = 16_384;
+    private const string SymbolNotFoundGuidance = "Use search_symbols to find the correct qualified name. If the symbol was recently added or changed, re-run index_project to update the index.";
 
     private readonly IPathValidator _pathValidator;
     private readonly IProjectScopeFactory _scopeFactory;
@@ -212,7 +213,7 @@ internal sealed class QueryTools
                 else
                 {
                     return JsonSerializer.Serialize(
-                        new { Error = "Symbol not found", Code = "SYMBOL_NOT_FOUND", Retryable = false, Symbol = SanitizeSymbolName(symbolName) },
+                        new { Error = "Symbol not found", Code = "SYMBOL_NOT_FOUND", Retryable = false, Symbol = SanitizeSymbolName(symbolName), Guidance = SymbolNotFoundGuidance },
                         SerializerOptions);
                 }
             }
@@ -310,7 +311,7 @@ internal sealed class QueryTools
                 else
                 {
                     return JsonSerializer.Serialize(
-                        new { Error = "Symbol not found", Code = "SYMBOL_NOT_FOUND", Retryable = false, Symbol = SanitizeSymbolName(symbolName) },
+                        new { Error = "Symbol not found", Code = "SYMBOL_NOT_FOUND", Retryable = false, Symbol = SanitizeSymbolName(symbolName), Guidance = SymbolNotFoundGuidance },
                         SerializerOptions);
                 }
             }
@@ -479,6 +480,7 @@ internal sealed class QueryTools
                     Error = "Symbol not found",
                     Code = "SYMBOL_NOT_FOUND",
                     Retryable = false,
+                    Guidance = SymbolNotFoundGuidance,
                 })
                 .ToList();
 

--- a/tests/CodeCompress.Server.Tests/Tools/QueryToolsTests.cs
+++ b/tests/CodeCompress.Server.Tests/Tools/QueryToolsTests.cs
@@ -705,6 +705,8 @@ internal sealed class QueryToolsTests
         var root = doc.RootElement;
         await Assert.That(root.GetProperty("error").GetString()).IsEqualTo("Symbol not found");
         await Assert.That(root.GetProperty("code").GetString()).IsEqualTo("SYMBOL_NOT_FOUND");
+        await Assert.That(root.GetProperty("guidance").GetString())
+            .Contains("search_symbols").And.Contains("index_project");
     }
 
     [Test]
@@ -863,6 +865,8 @@ internal sealed class QueryToolsTests
         var root = doc.RootElement;
         await Assert.That(root.GetProperty("error").GetString()).IsEqualTo("Symbol not found");
         await Assert.That(root.GetProperty("code").GetString()).IsEqualTo("SYMBOL_NOT_FOUND");
+        await Assert.That(root.GetProperty("guidance").GetString())
+            .Contains("search_symbols").And.Contains("index_project");
     }
 
     [Test]
@@ -1021,6 +1025,8 @@ internal sealed class QueryToolsTests
             await Assert.That(errors[0].GetProperty("symbol").GetString()).IsEqualTo("Missing");
             await Assert.That(errors[0].GetProperty("error").GetString()).IsEqualTo("Symbol not found");
             await Assert.That(errors[0].GetProperty("code").GetString()).IsEqualTo("SYMBOL_NOT_FOUND");
+            await Assert.That(errors[0].GetProperty("guidance").GetString())
+                .Contains("search_symbols").And.Contains("index_project");
         }
         finally
         {


### PR DESCRIPTION
## Summary
- SYMBOL_NOT_FOUND errors now include guidance suggesting re-indexing when a symbol may exist but the index is stale
- MCP tools (`get_symbol`, `expand_symbol`, `get_symbols`) include `guidance` field with re-index hint
- CLI commands (`get-symbol`, `expand-symbol`) updated with same hint text

Closes #133

## Test plan
- [x] 3 existing tests updated to verify `guidance` field contains `search_symbols` and `index_project`
- [x] Full test suite passes (866 tests)
- [x] Zero build warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)