### PR TITLE
feat: auto contains-match fallback for search_symbols

### DIFF
--- a/src/CodeCompress.Cli/Program.cs
+++ b/src/CodeCompress.Cli/Program.cs
@@ -279,6 +279,16 @@ searchCommand.SetAction(async parseResult =>
     {
         var results = await scope.Store.SearchSymbolsAsync(scope.RepoId, query, kind, limit, pathFilter).ConfigureAwait(false);
 
+        // Auto contains-match fallback for plain terms with zero results
+        var fallbackUsed = false;
+        if (results.Count == 0 && GlobPattern.IsPlainTerm(query))
+        {
+            var containsGlob = Fts5QuerySanitizer.SanitizeAsGlob($"*{query}*");
+            results = await scope.Store.SearchSymbolsAsync(
+                scope.RepoId, containsGlob.Fts5Query, kind, limit, pathFilter, containsGlob.SqlLikePattern).ConfigureAwait(false);
+            fallbackUsed = results.Count > 0;
+        }
+
         if (json)
         {
             Console.WriteLine(JsonSerializer.Serialize(results, jsonSerializerOptions));
@@ -291,7 +301,15 @@ searchCommand.SetAction(async parseResult =>
                 return;
             }
 
-            Console.WriteLine($"Found {results.Count} symbol(s):");
+            if (fallbackUsed)
+            {
+                Console.WriteLine($"Found {results.Count} symbol(s) via contains-match (no exact FTS5 match):");
+            }
+            else
+            {
+                Console.WriteLine($"Found {results.Count} symbol(s):");
+            }
+
             foreach (var r in results)
             {
                 Console.WriteLine($"  {r.Symbol.Kind,-12} {r.Symbol.Name,-30} {r.FilePath}:{r.Symbol.LineStart}");

--- a/src/CodeCompress.Core/Storage/GlobPattern.cs
+++ b/src/CodeCompress.Core/Storage/GlobPattern.cs
@@ -37,6 +37,37 @@ public sealed partial class GlobPattern
     public static GlobPattern CreateSqlLike(string fts5Query, string sqlLikePattern) =>
         new(GlobMatchStrategy.SqlLike, fts5Query, sqlLikePattern);
 
+    /// <summary>
+    /// Returns true if the query is a plain term with no wildcards, FTS5 operators, or quotes.
+    /// Plain terms are candidates for automatic contains-match fallback.
+    /// </summary>
+    public static bool IsPlainTerm(string query)
+    {
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            return false;
+        }
+
+        var trimmed = query.Trim();
+
+        if (trimmed.Contains('*', StringComparison.Ordinal) || trimmed.Contains('?', StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (trimmed.Contains('"', StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (ContainsFts5Operators(trimmed))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
     public static bool IsWildcardOnly(string query)
     {
         if (string.IsNullOrWhiteSpace(query))

--- a/src/CodeCompress.Server/Tools/QueryTools.cs
+++ b/src/CodeCompress.Server/Tools/QueryTools.cs
@@ -495,7 +495,7 @@ internal sealed class QueryTools
     }
 
     [McpServerTool(Name = "search_symbols")]
-    [Description("Search the symbol index using FTS5 full-text search — faster and more precise than grep-style file scanning. Supports prefix*, *suffix, *contains*, and I*Pattern glob matching. Returns symbol names, kinds, signatures, and locations. Use pathFilter to scope results to a specific directory. Use get_symbol or expand_symbol to retrieve full source code of matched symbols. Requires index_project to have been called first. Returns JSON: {query, total_matches, results: [{name, kind, parent, file, line, signature, snippet, rank}]}. Chain with get_symbol using the 'name' field (or 'parent:name' for nested symbols). Errors return JSON {error, code, retryable}. Codes: INVALID_PATH, EMPTY_QUERY, QUERY_TOO_BROAD (add a non-wildcard term or pathFilter), INVALID_KIND (see kind param for valid values), INVALID_PATH_FILTER, MIXED_PATTERN (includes 'suggestion' — split into separate queries).")]
+    [Description("Search the symbol index using FTS5 full-text search — faster and more precise than grep-style file scanning. Supports prefix*, *suffix, *contains*, and I*Pattern glob matching. Auto-retries with contains-match (*query*) when a plain term returns zero FTS5 results (e.g., searching 'Validator' automatically finds 'PathValidator', 'IPathValidator'). When this fallback triggers, the response includes fallback_used: true. Returns symbol names, kinds, signatures, and locations. Use pathFilter to scope results to a specific directory. Use get_symbol or expand_symbol to retrieve full source code of matched symbols. Requires index_project to have been called first. Returns JSON: {query, total_matches, [fallback_used], results: [{name, kind, parent, file, line, signature, snippet, rank}]}. Chain with get_symbol using the 'name' field (or 'parent:name' for nested symbols). Errors return JSON {error, code, retryable}. Codes: INVALID_PATH, EMPTY_QUERY, QUERY_TOO_BROAD (add a non-wildcard term or pathFilter), INVALID_KIND (see kind param for valid values), INVALID_PATH_FILTER, MIXED_PATTERN (includes 'suggestion' — split into separate queries).")]
     public async Task<string> SearchSymbols(
         [Description("ABSOLUTE path to the project root directory — the same root used with index_project (e.g., 'C:\\Projects\\MyGame' or '/home/user/my-project'). Must NOT be a subdirectory or relative path.")] string path,
         [Description("Search query — supports plain text, FTS5 operators (AND, OR, NOT), and glob patterns (prefix*, *suffix, *contains*)")] string query,
@@ -595,29 +595,23 @@ internal sealed class QueryTools
                     scope.RepoId, literalQuery, kind, clampedLimit, validatedPathFilter).ConfigureAwait(false);
             }
 
+            // Auto contains-match fallback: if FTS5 returned 0 results and query is a plain term,
+            // retry with *query* pattern to find substring matches (e.g., "Validator" → "*Validator*")
+            var fallbackUsed = false;
+            if (results.Count == 0 && GlobPattern.IsPlainTerm(query))
+            {
+                var containsGlob = Fts5QuerySanitizer.SanitizeAsGlob($"*{query}*");
+                results = await scope.Store.SearchSymbolsAsync(
+                    scope.RepoId, containsGlob.Fts5Query, kind, clampedLimit, validatedPathFilter, containsGlob.SqlLikePattern).ConfigureAwait(false);
+                fallbackUsed = results.Count > 0;
+            }
+
             var displayQuery = !string.IsNullOrEmpty(glob.Fts5Query) ? glob.Fts5Query : glob.SqlLikePattern ?? query;
             var hint = results.Count > 0
                 ? "Use get_symbol with a result's name (or parent:name for nested symbols) to retrieve full source code."
                 : (string?)null;
-            var response = new
-            {
-                Query = displayQuery,
-                TotalMatches = results.Count,
-                Results = results.Select((r, index) => new
-                {
-                    r.Symbol.Name,
-                    r.Symbol.Kind,
-                    Parent = r.Symbol.ParentSymbol,
-                    File = r.FilePath,
-                    Line = r.Symbol.LineStart,
-                    r.Symbol.Signature,
-                    Snippet = r.Symbol.DocComment ?? string.Empty,
-                    Rank = index + 1,
-                }),
-                Hint = hint,
-            };
 
-            return JsonSerializer.Serialize(response, SerializerOptions);
+            return SerializeSearchResults(displayQuery, results, hint, fallbackUsed);
         }
     }
 
@@ -1038,6 +1032,36 @@ internal sealed class QueryTools
         };
 
         return JsonSerializer.Serialize(response, SerializerOptions);
+    }
+
+    private static string SerializeSearchResults(
+        string displayQuery,
+        IReadOnlyList<Core.Models.SymbolSearchResult> results,
+        string? hint,
+        bool fallbackUsed)
+    {
+        var resultItems = results.Select((r, index) => new
+        {
+            r.Symbol.Name,
+            r.Symbol.Kind,
+            Parent = r.Symbol.ParentSymbol,
+            File = r.FilePath,
+            Line = r.Symbol.LineStart,
+            r.Symbol.Signature,
+            Snippet = r.Symbol.DocComment ?? string.Empty,
+            Rank = index + 1,
+        });
+
+        if (fallbackUsed)
+        {
+            return JsonSerializer.Serialize(
+                new { Query = displayQuery, TotalMatches = results.Count, FallbackUsed = true, Results = resultItems, Hint = hint },
+                SerializerOptions);
+        }
+
+        return JsonSerializer.Serialize(
+            new { Query = displayQuery, TotalMatches = results.Count, Results = resultItems, Hint = hint },
+            SerializerOptions);
     }
 
     private static string SerializeError(string error, string code, string? guidance = null) =>

--- a/tests/CodeCompress.Core.Tests/Storage/GlobPatternTests.cs
+++ b/tests/CodeCompress.Core.Tests/Storage/GlobPatternTests.cs
@@ -266,4 +266,25 @@ internal sealed class GlobPatternTests
         // ErrorDetail should contain a truncated version, not the full 200-char term
         await Assert.That(result.ErrorDetail!.Length).IsLessThan(300);
     }
+
+    [Test]
+    [Arguments("Validator", true)]
+    [Arguments("OrderService", true)]
+    [Arguments("a", true)]
+    [Arguments("*Validator*", false)]
+    [Arguments("Validator*", false)]
+    [Arguments("*Validator", false)]
+    [Arguments("I*Service", false)]
+    [Arguments("damage OR health", false)]
+    [Arguments("damage AND health", false)]
+    [Arguments("NOT damage", false)]
+    [Arguments("\"exact phrase\"", false)]
+    [Arguments("", false)]
+    [Arguments("   ", false)]
+    public async Task IsPlainTermDetectsCorrectly(string query, bool expected)
+    {
+        var result = GlobPattern.IsPlainTerm(query);
+
+        await Assert.That(result).IsEqualTo(expected);
+    }
 }

--- a/tests/CodeCompress.Server.Tests/Tools/QueryToolsTests.cs
+++ b/tests/CodeCompress.Server.Tests/Tools/QueryToolsTests.cs
@@ -1455,7 +1455,8 @@ internal sealed class QueryToolsTests
 
         await _tools.SearchSymbols("/valid/path", "Order", pathFilter: "src/Core/").ConfigureAwait(false);
 
-        await _store.Received(1).SearchSymbolsAsync(
+        // First call is FTS5, second is auto contains-match fallback (both with same pathFilter)
+        await _store.Received(2).SearchSymbolsAsync(
             "test-repo-id", Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<int>(), "src/Core", Arg.Any<string?>()).ConfigureAwait(false);
     }
 
@@ -1748,6 +1749,114 @@ internal sealed class QueryToolsTests
 
         await _store.Received(1).SearchSymbolsAsync(
             "test-repo-id", "Claude* OR Agent*", Arg.Any<string?>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>()).ConfigureAwait(false);
+    }
+
+    // ── Contains-match fallback tests ──────────────────────────────────
+
+    [Test]
+    public async Task SearchSymbolsPlainTermFallsBackToContainsOnZeroResults()
+    {
+        // First FTS5 call returns empty, fallback with *Validator* returns results
+        var fallbackResults = new List<SymbolSearchResult>
+        {
+            new(CreateSymbol(1, 1, "PathValidator", "Class", "public class PathValidator"), "src/Validation/PathValidator.cs", 1.0),
+            new(CreateSymbol(2, 1, "IPathValidator", "Interface", "public interface IPathValidator"), "src/Validation/IPathValidator.cs", 0.9),
+        };
+
+        _store.SearchSymbolsAsync("test-repo-id", "Validator", Arg.Any<string?>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>())
+            .Returns(new List<SymbolSearchResult>());
+        _store.SearchSymbolsAsync("test-repo-id", Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<int>(), Arg.Any<string?>(), "%Validator%")
+            .Returns(fallbackResults);
+
+        var result = await _tools.SearchSymbols("/valid/path", "Validator").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        var root = doc.RootElement;
+        await Assert.That(root.GetProperty("total_matches").GetInt32()).IsEqualTo(2);
+        await Assert.That(root.GetProperty("fallback_used").GetBoolean()).IsTrue();
+    }
+
+    [Test]
+    public async Task SearchSymbolsExactMatchDoesNotTriggerFallback()
+    {
+        var directResults = new List<SymbolSearchResult>
+        {
+            new(CreateSymbol(1, 1, "PathValidator", "Class", "public class PathValidator"), "src/Validation/PathValidator.cs", 1.0),
+        };
+
+        _store.SearchSymbolsAsync("test-repo-id", "PathValidator", Arg.Any<string?>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>())
+            .Returns(directResults);
+
+        var result = await _tools.SearchSymbols("/valid/path", "PathValidator").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        var root = doc.RootElement;
+        await Assert.That(root.GetProperty("total_matches").GetInt32()).IsEqualTo(1);
+        await Assert.That(root.TryGetProperty("fallback_used", out _)).IsFalse();
+    }
+
+    [Test]
+    public async Task SearchSymbolsFallbackPreservesKindAndPathFilter()
+    {
+        _store.SearchSymbolsAsync("test-repo-id", "Validator", "Class", 20, "src", Arg.Any<string?>())
+            .Returns(new List<SymbolSearchResult>());
+        _store.SearchSymbolsAsync("test-repo-id", Arg.Any<string>(), "Class", 20, "src", "%Validator%")
+            .Returns(new List<SymbolSearchResult>
+            {
+                new(CreateSymbol(1, 1, "PathValidator", "Class", "public class PathValidator"), "src/Validation/PathValidator.cs", 1.0),
+            });
+
+        var result = await _tools.SearchSymbols("/valid/path", "Validator", kind: "class", pathFilter: "src/").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        var root = doc.RootElement;
+        await Assert.That(root.GetProperty("total_matches").GetInt32()).IsEqualTo(1);
+        await Assert.That(root.GetProperty("fallback_used").GetBoolean()).IsTrue();
+    }
+
+    [Test]
+    public async Task SearchSymbolsNoResultsAfterFallbackReturnsEmpty()
+    {
+        _store.SearchSymbolsAsync("test-repo-id", "NonExistent", Arg.Any<string?>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>())
+            .Returns(new List<SymbolSearchResult>());
+        _store.SearchSymbolsAsync("test-repo-id", Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<int>(), Arg.Any<string?>(), "%NonExistent%")
+            .Returns(new List<SymbolSearchResult>());
+
+        var result = await _tools.SearchSymbols("/valid/path", "NonExistent").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        var root = doc.RootElement;
+        await Assert.That(root.GetProperty("total_matches").GetInt32()).IsEqualTo(0);
+        await Assert.That(root.TryGetProperty("fallback_used", out _)).IsFalse();
+    }
+
+    [Test]
+    public async Task SearchSymbolsWildcardQueryDoesNotTriggerFallback()
+    {
+        // *Handler already has wildcards — should NOT trigger fallback
+        _store.SearchSymbolsAsync("test-repo-id", Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<int>(), Arg.Any<string?>(), "%Handler")
+            .Returns(new List<SymbolSearchResult>());
+
+        var result = await _tools.SearchSymbols("/valid/path", "*Handler").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        var root = doc.RootElement;
+        await Assert.That(root.GetProperty("total_matches").GetInt32()).IsEqualTo(0);
+        await Assert.That(root.TryGetProperty("fallback_used", out _)).IsFalse();
+    }
+
+    [Test]
+    public async Task SearchSymbolsFts5OperatorQueryDoesNotTriggerFallback()
+    {
+        _store.SearchSymbolsAsync("test-repo-id", "damage OR health", Arg.Any<string?>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>())
+            .Returns(new List<SymbolSearchResult>());
+
+        var result = await _tools.SearchSymbols("/valid/path", "damage OR health").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        var root = doc.RootElement;
+        await Assert.That(root.GetProperty("total_matches").GetInt32()).IsEqualTo(0);
+        await Assert.That(root.TryGetProperty("fallback_used", out _)).IsFalse();
     }
 
     // ── Size guard tests ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- When `search_symbols` FTS5 query returns 0 results for a plain term (no wildcards/operators), automatically retries with `*query*` contains-match pattern
- E.g., searching "Validator" now finds "PathValidator", "IPathValidator", "PathValidatorService" without manual wildcards
- Response includes `fallback_used: true` when contains-matching was used
- Same fallback behavior added to CLI `search` command
- Added `GlobPattern.IsPlainTerm()` helper to detect fallback-eligible queries

Closes #132

## Test plan
- [x] `IsPlainTerm` parameterized tests (13 cases: plain terms, wildcards, operators, quotes, empty)
- [x] Fallback triggers on plain term with 0 FTS5 results (returns results + `fallback_used: true`)
- [x] Exact FTS5 match does NOT trigger fallback
- [x] Fallback preserves `kind` and `pathFilter` parameters
- [x] No results after fallback returns 0 normally (no infinite retry)
- [x] Wildcard queries do NOT trigger fallback
- [x] FTS5 operator queries do NOT trigger fallback
- [x] Full test suite passes (885 tests)
- [x] Zero build warnings
- [x] Security review passed (no injection vectors, parameterized queries throughout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)