### PR TITLE
fix: prefer class-level symbols over constructors in unqualified name resolution

### DIFF
--- a/src/CodeCompress.Core/Storage/SqliteSymbolStore.cs
+++ b/src/CodeCompress.Core/Storage/SqliteSymbolStore.cs
@@ -1047,6 +1047,11 @@ public sealed class SqliteSymbolStore : ISymbolStore
                 FROM symbols s
                 JOIN files f ON f.id = s.file_id
                 WHERE s.name = @name AND f.repo_id = @repoId
+                ORDER BY CASE s.kind
+                    WHEN 'Class' THEN 1 WHEN 'Interface' THEN 1 WHEN 'Record' THEN 1
+                    WHEN 'Enum' THEN 1 WHEN 'Type' THEN 1 WHEN 'Module' THEN 2
+                    WHEN 'Function' THEN 3 WHEN 'Method' THEN 4 WHEN 'Constant' THEN 5
+                    ELSE 6 END
                 LIMIT 1
                 """;
 #pragma warning restore CA2100
@@ -1093,6 +1098,11 @@ public sealed class SqliteSymbolStore : ISymbolStore
             FROM symbols s
             JOIN files f ON f.id = s.file_id
             WHERE s.name = @name AND f.repo_id = @repoId
+            ORDER BY CASE s.kind
+                WHEN 'Class' THEN 1 WHEN 'Interface' THEN 1 WHEN 'Record' THEN 1
+                WHEN 'Enum' THEN 1 WHEN 'Type' THEN 1 WHEN 'Module' THEN 2
+                WHEN 'Function' THEN 3 WHEN 'Method' THEN 4 WHEN 'Constant' THEN 5
+                ELSE 6 END
             LIMIT @limit
             """;
 #pragma warning restore CA2100

--- a/tests/CodeCompress.Core.Tests/Storage/SymbolStoreQueryTests.cs
+++ b/tests/CodeCompress.Core.Tests/Storage/SymbolStoreQueryTests.cs
@@ -174,6 +174,59 @@ internal sealed class SymbolStoreQueryTests
         await Assert.That(result).IsNull();
     }
 
+    [Test]
+    public async Task GetSymbolByNameAsyncPrefersClassOverConstructor()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(connection);
+        var repo = new Repository("repo1", "/test/path", "TestProject", "csharp", 1000, 0, 0);
+        await store.UpsertRepositoryAsync(repo).ConfigureAwait(false);
+
+        var file = new FileRecord(0, "repo1", "src/BaseEntity.cs", "hash1", 1024, 50, 1000, 1000);
+        await store.InsertFilesAsync([file]).ConfigureAwait(false);
+        var insertedFile = await store.GetFileByPathAsync("repo1", "src/BaseEntity.cs").ConfigureAwait(false);
+
+        // Insert constructor FIRST (lower rowid), then class — without ordering, constructor would win
+        var symbols = new List<Symbol>
+        {
+            new(0, insertedFile!.Id, "BaseEntity", "Method", "protected BaseEntity()", "BaseEntity", 100, 50, 10, 15, "Protected", null),
+            new(0, insertedFile.Id, "BaseEntity", "Class", "public abstract class BaseEntity", null, 0, 200, 1, 20, "Public", "Base entity class"),
+        };
+        await store.InsertSymbolsAsync(symbols).ConfigureAwait(false);
+
+        var result = await store.GetSymbolByNameAsync("repo1", "BaseEntity").ConfigureAwait(false);
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.Kind).IsEqualTo("Class");
+    }
+
+    [Test]
+    public async Task GetSymbolCandidatesByNameAsyncReturnsClassFirst()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(connection);
+        var repo = new Repository("repo1", "/test/path", "TestProject", "csharp", 1000, 0, 0);
+        await store.UpsertRepositoryAsync(repo).ConfigureAwait(false);
+
+        var file = new FileRecord(0, "repo1", "src/Tenant.cs", "hash1", 1024, 50, 1000, 1000);
+        await store.InsertFilesAsync([file]).ConfigureAwait(false);
+        var insertedFile = await store.GetFileByPathAsync("repo1", "src/Tenant.cs").ConfigureAwait(false);
+
+        // Insert method first, class second
+        var symbols = new List<Symbol>
+        {
+            new(0, insertedFile!.Id, "Tenant", "Method", "private Tenant()", "Tenant", 100, 50, 10, 15, "Private", null),
+            new(0, insertedFile.Id, "Tenant", "Class", "public sealed class Tenant", null, 0, 200, 1, 20, "Public", "Tenant entity"),
+        };
+        await store.InsertSymbolsAsync(symbols).ConfigureAwait(false);
+
+        var results = await store.GetSymbolCandidatesByNameAsync("repo1", "Tenant").ConfigureAwait(false);
+
+        await Assert.That(results.Count).IsEqualTo(2);
+        await Assert.That(results[0].Kind).IsEqualTo("Class");
+        await Assert.That(results[1].Kind).IsEqualTo("Method");
+    }
+
     // ── GetSymbolsByNamesAsync Tests ─────────────────────────────────────
 
     [Test]


### PR DESCRIPTION
## Summary
- `GetSymbolByNameAsync` and `GetSymbolCandidatesByNameAsync` now use kind-based `ORDER BY` to return structural types (Class, Interface, Record, Enum, Type) before their members (Method, Function, Constant)
- Fixes `get_symbol("BaseEntity")` returning the constructor instead of the class when both share the same name
- Qualified name resolution (`Parent:Child`) is unchanged — already precise

Closes #144

## Test plan
- [x] New test: `GetSymbolByNameAsyncPrefersClassOverConstructor` — inserts constructor first (lower rowid), verifies class is returned
- [x] New test: `GetSymbolCandidatesByNameAsyncReturnsClassFirst` — verifies candidates are ordered by kind preference
- [x] All existing tests pass (887 total)
- [x] Zero build warnings
- [x] Security review passed (static CASE expression, no user input in ORDER BY)

🤖 Generated with [Claude Code](https://claude.com/claude-code)