### PR TITLE
feat: include parent_symbol in FTS5 index for cross-field search

### DIFF
--- a/src/CodeCompress.Core/Storage/Migrations.cs
+++ b/src/CodeCompress.Core/Storage/Migrations.cs
@@ -73,26 +73,26 @@ public static class Migrations
         "CREATE INDEX IF NOT EXISTS ix_dependencies_file_id ON dependencies(file_id)",
         "CREATE INDEX IF NOT EXISTS ix_dependencies_resolved ON dependencies(resolved_file_id)",
         "CREATE INDEX IF NOT EXISTS ix_snapshots_repo_id ON index_snapshots(repo_id)",
-        "CREATE VIRTUAL TABLE IF NOT EXISTS symbols_fts USING fts5(name, signature, doc_comment, content=symbols, content_rowid=id)",
+        "CREATE VIRTUAL TABLE IF NOT EXISTS symbols_fts USING fts5(name, parent_symbol, signature, doc_comment, content=symbols, content_rowid=id)",
         "CREATE VIRTUAL TABLE IF NOT EXISTS file_content_fts USING fts5(relative_path, content)",
         """
         CREATE TRIGGER IF NOT EXISTS symbols_ai AFTER INSERT ON symbols BEGIN
-            INSERT INTO symbols_fts(rowid, name, signature, doc_comment)
-            VALUES (new.id, new.name, new.signature, new.doc_comment);
+            INSERT INTO symbols_fts(rowid, name, parent_symbol, signature, doc_comment)
+            VALUES (new.id, new.name, new.parent_symbol, new.signature, new.doc_comment);
         END
         """,
         """
         CREATE TRIGGER IF NOT EXISTS symbols_ad AFTER DELETE ON symbols BEGIN
-            INSERT INTO symbols_fts(symbols_fts, rowid, name, signature, doc_comment)
-            VALUES ('delete', old.id, old.name, old.signature, old.doc_comment);
+            INSERT INTO symbols_fts(symbols_fts, rowid, name, parent_symbol, signature, doc_comment)
+            VALUES ('delete', old.id, old.name, old.parent_symbol, old.signature, old.doc_comment);
         END
         """,
         """
         CREATE TRIGGER IF NOT EXISTS symbols_au AFTER UPDATE ON symbols BEGIN
-            INSERT INTO symbols_fts(symbols_fts, rowid, name, signature, doc_comment)
-            VALUES ('delete', old.id, old.name, old.signature, old.doc_comment);
-            INSERT INTO symbols_fts(rowid, name, signature, doc_comment)
-            VALUES (new.id, new.name, new.signature, new.doc_comment);
+            INSERT INTO symbols_fts(symbols_fts, rowid, name, parent_symbol, signature, doc_comment)
+            VALUES ('delete', old.id, old.name, old.parent_symbol, old.signature, old.doc_comment);
+            INSERT INTO symbols_fts(rowid, name, parent_symbol, signature, doc_comment)
+            VALUES (new.id, new.name, new.parent_symbol, new.signature, new.doc_comment);
         END
         """,
     ];
@@ -105,6 +105,67 @@ public static class Migrations
         await using var _ = transaction.ConfigureAwait(false);
 
         foreach (var ddl in DdlStatements)
+        {
+            using var command = connection.CreateCommand();
+            command.Transaction = (SqliteTransaction)transaction;
+#pragma warning disable CA2100 // DDL statements are static literals, not user input
+            command.CommandText = ddl;
+#pragma warning restore CA2100
+            await command.ExecuteNonQueryAsync().ConfigureAwait(false);
+        }
+
+        await transaction.CommitAsync().ConfigureAwait(false);
+
+        // Upgrade FTS5 table if it predates the parent_symbol column
+        await UpgradeFts5IfNeededAsync(connection).ConfigureAwait(false);
+    }
+
+    private static async Task UpgradeFts5IfNeededAsync(SqliteConnection connection)
+    {
+        // Check if parent_symbol is already a column in symbols_fts by attempting a column query
+        using var checkCmd = connection.CreateCommand();
+        checkCmd.CommandText = "SELECT sql FROM sqlite_master WHERE type='table' AND name='symbols_fts'";
+        if (await checkCmd.ExecuteScalarAsync().ConfigureAwait(false) is not string ftsSchema
+            || ftsSchema.Contains("parent_symbol", StringComparison.Ordinal))
+        {
+            return; // Either no FTS table or already upgraded
+        }
+
+        // Rebuild: drop old FTS table + triggers, then recreate with parent_symbol
+        var upgradeDdl = new[]
+        {
+            "DROP TRIGGER IF EXISTS symbols_ai",
+            "DROP TRIGGER IF EXISTS symbols_ad",
+            "DROP TRIGGER IF EXISTS symbols_au",
+            "DROP TABLE IF EXISTS symbols_fts",
+            "CREATE VIRTUAL TABLE symbols_fts USING fts5(name, parent_symbol, signature, doc_comment, content=symbols, content_rowid=id)",
+            """
+            CREATE TRIGGER symbols_ai AFTER INSERT ON symbols BEGIN
+                INSERT INTO symbols_fts(rowid, name, parent_symbol, signature, doc_comment)
+                VALUES (new.id, new.name, new.parent_symbol, new.signature, new.doc_comment);
+            END
+            """,
+            """
+            CREATE TRIGGER symbols_ad AFTER DELETE ON symbols BEGIN
+                INSERT INTO symbols_fts(symbols_fts, rowid, name, parent_symbol, signature, doc_comment)
+                VALUES ('delete', old.id, old.name, old.parent_symbol, old.signature, old.doc_comment);
+            END
+            """,
+            """
+            CREATE TRIGGER symbols_au AFTER UPDATE ON symbols BEGIN
+                INSERT INTO symbols_fts(symbols_fts, rowid, name, parent_symbol, signature, doc_comment)
+                VALUES ('delete', old.id, old.name, old.parent_symbol, old.signature, old.doc_comment);
+                INSERT INTO symbols_fts(rowid, name, parent_symbol, signature, doc_comment)
+                VALUES (new.id, new.name, new.parent_symbol, new.signature, new.doc_comment);
+            END
+            """,
+            "INSERT INTO symbols_fts(symbols_fts) VALUES('rebuild')",
+        };
+
+        var transaction = await connection.BeginTransactionAsync().ConfigureAwait(false);
+        await using var tx = transaction.ConfigureAwait(false);
+
+        foreach (var ddl in upgradeDdl)
         {
             using var command = connection.CreateCommand();
             command.Transaction = (SqliteTransaction)transaction;

--- a/tests/CodeCompress.Core.Tests/Storage/SymbolStoreQueryTests.cs
+++ b/tests/CodeCompress.Core.Tests/Storage/SymbolStoreQueryTests.cs
@@ -112,6 +112,36 @@ internal sealed class SymbolStoreQueryTests
         await Assert.That(results).Count().IsEqualTo(0);
     }
 
+    [Test]
+    public async Task SearchSymbolsAsyncFindsMethodByParentNameInFts5()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(connection);
+        var repo = new Repository("repo1", "/test/path", "TestProject", "csharp", 1000, 0, 0);
+        await store.UpsertRepositoryAsync(repo).ConfigureAwait(false);
+
+        var file = new FileRecord(0, "repo1", "src/VcsConnection.cs", "hash1", 1024, 50, 1000, 1000);
+        await store.InsertFilesAsync([file]).ConfigureAwait(false);
+        var insertedFile = await store.GetFileByPathAsync("repo1", "src/VcsConnection.cs").ConfigureAwait(false);
+
+        // Parent name "VcsConnection" does NOT appear in the method's name, signature, or doc_comment
+        // It only appears in parent_symbol — so this test proves parent_symbol is FTS5-indexed
+        var symbols = new List<Symbol>
+        {
+            new(0, insertedFile!.Id, "VcsConnection", "Class", "public class VcsConnection", null, 0, 500, 1, 50, "Public", "VCS connection manager"),
+            new(0, insertedFile.Id, "Activate", "Method", "public void Activate()", "VcsConnection", 100, 50, 10, 15, "Public", "Activates the connection"),
+            new(0, insertedFile.Id, "Deactivate", "Method", "public void Deactivate()", "VcsConnection", 200, 50, 20, 25, "Public", null),
+        };
+        await store.InsertSymbolsAsync(symbols).ConfigureAwait(false);
+
+        // Search "VcsConnection Activate" — "VcsConnection" must match via parent_symbol (not in Activate's name/signature/doc)
+        var results = await store.SearchSymbolsAsync("repo1", "VcsConnection Activate", null, 10).ConfigureAwait(false);
+
+        await Assert.That(results.Count).IsGreaterThan(0);
+        await Assert.That(results[0].Symbol.Name).IsEqualTo("Activate");
+        await Assert.That(results[0].Symbol.ParentSymbol).IsEqualTo("VcsConnection");
+    }
+
     // ── GetSymbolByNameAsync Tests ───────────────────────────────────────
 
     [Test]


### PR DESCRIPTION
## Summary
- `symbols_fts` FTS5 virtual table now indexes `parent_symbol` alongside `name`, `signature`, and `doc_comment`
- Enables searching "VcsConnection Activate" to find the `Activate` method on `VcsConnection` — previously returned 0 results because "VcsConnection" only existed in the `parent_symbol` column (not FTS5-indexed)
- Automatic upgrade migration detects old 3-column FTS5 schema and rebuilds with 4 columns + repopulates index
- All three triggers (INSERT/DELETE/UPDATE) updated to include `parent_symbol`

Closes #143

## Test plan
- [x] New test: `SearchSymbolsAsyncFindsMethodByParentNameInFts5` — verifies "VcsConnection Activate" finds the method when "VcsConnection" only appears in parent_symbol
- [x] Full test suite passes (888 tests)
- [x] Zero build warnings
- [x] Security review passed (static DDL, parameterized queries, no new injection vectors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)