### PR TITLE
fix: tokenize multi-word queries with OR logic in assemble_context

### DIFF
--- a/src/CodeCompress.Cli/Program.cs
+++ b/src/CodeCompress.Cli/Program.cs
@@ -1174,14 +1174,38 @@ assembleCommand.SetAction(async parseResult =>
         const double charsPerToken = 3.5;
         var charBudget = (int)(budget * charsPerToken);
 
-        var searchResults = await scope.Store.SearchSymbolsAsync(scope.RepoId, query, null, 50).ConfigureAwait(false);
+        // Tokenize: strips stopwords, joins multi-word queries with OR
+        var tokenizedQuery = Fts5QuerySanitizer.TokenizeForSearch(query);
+        var searchQuery = string.IsNullOrWhiteSpace(tokenizedQuery)
+            ? Fts5QuerySanitizer.Sanitize(query)
+            : tokenizedQuery;
 
-        // Auto contains-match fallback
-        if (searchResults.Count == 0 && GlobPattern.IsPlainTerm(query))
+        var searchResults = await scope.Store.SearchSymbolsAsync(scope.RepoId, searchQuery, null, 50).ConfigureAwait(false);
+
+        // Auto contains-match fallback: try each term as *term* individually
+        if (searchResults.Count == 0)
         {
-            var containsGlob = Fts5QuerySanitizer.SanitizeAsGlob($"*{query}*");
-            searchResults = await scope.Store.SearchSymbolsAsync(
-                scope.RepoId, containsGlob.Fts5Query, null, 50, null, containsGlob.SqlLikePattern).ConfigureAwait(false);
+            var terms = searchQuery.Split([" OR "], StringSplitOptions.RemoveEmptyEntries)
+                .Select(t => t.Trim())
+                .Where(t => t.Length > 0)
+                .ToList();
+
+            foreach (var term in terms.Where(GlobPattern.IsPlainTerm))
+            {
+                var containsGlob = Fts5QuerySanitizer.SanitizeAsGlob($"*{term}*");
+                if (containsGlob.SqlLikePattern is null)
+                {
+                    continue;
+                }
+
+                searchResults = await scope.Store.SearchSymbolsAsync(
+                    scope.RepoId, containsGlob.Fts5Query, null, 50, null, containsGlob.SqlLikePattern).ConfigureAwait(false);
+
+                if (searchResults.Count > 0)
+                {
+                    break;
+                }
+            }
         }
 
         if (searchResults.Count == 0)

--- a/src/CodeCompress.Core/Storage/Fts5QuerySanitizer.cs
+++ b/src/CodeCompress.Core/Storage/Fts5QuerySanitizer.cs
@@ -50,6 +50,65 @@ public static partial class Fts5QuerySanitizer
         return result;
     }
 
+    private static readonly HashSet<string> Stopwords = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "a", "an", "and", "are", "as", "at", "be", "but", "by",
+        "for", "from", "has", "have", "how", "if", "in", "is", "it",
+        "its", "no", "not", "of", "on", "or", "so", "that", "the",
+        "then", "this", "to", "was", "what", "when", "where", "which",
+        "who", "will", "with",
+    };
+
+    /// <summary>
+    /// Tokenizes a natural-language search query for use with FTS5.
+    /// Splits on whitespace, strips stopwords, sanitizes each token,
+    /// and joins remaining terms with OR for broad matching.
+    /// Returns the original query unchanged if it already contains
+    /// FTS5 operators or wildcard patterns.
+    /// </summary>
+    public static string TokenizeForSearch(string query)
+    {
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            return string.Empty;
+        }
+
+        var trimmed = query.Trim();
+
+        // If the query already has wildcards or FTS5 operators, leave it alone
+        if (trimmed.Contains('*', StringComparison.Ordinal) ||
+            trimmed.Contains('?', StringComparison.Ordinal) ||
+            trimmed.Contains('"', StringComparison.Ordinal) ||
+            GlobPattern.ContainsFts5Operators(trimmed))
+        {
+            return Sanitize(trimmed);
+        }
+
+        var tokens = trimmed.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+
+        // Single word — return as-is after sanitization
+        if (tokens.Length <= 1)
+        {
+            return Sanitize(trimmed);
+        }
+
+        // Multi-word: strip stopwords, sanitize each, join with OR
+        var meaningful = tokens
+            .Where(t => !Stopwords.Contains(t))
+            .Select(t => Sanitize(t))
+            .Where(t => !string.IsNullOrWhiteSpace(t))
+            .ToList();
+
+        if (meaningful.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        return meaningful.Count == 1
+            ? meaningful[0]
+            : string.Join(" OR ", meaningful);
+    }
+
     /// <summary>
     /// Sanitizes a glob pattern for use in SQL GLOB/LIKE clauses.
     /// Allows only alphanumeric, *, ?, /, ., -, _

--- a/src/CodeCompress.Core/Storage/GlobPattern.cs
+++ b/src/CodeCompress.Core/Storage/GlobPattern.cs
@@ -119,7 +119,7 @@ public sealed partial class GlobPattern
         return new GlobPattern(GlobMatchStrategy.SqlLike, string.Empty, likePattern);
     }
 
-    private static bool ContainsFts5Operators(string query)
+    internal static bool ContainsFts5Operators(string query)
     {
         var tokens = query.Split(' ', StringSplitOptions.RemoveEmptyEntries);
         return tokens.Any(t => Fts5Operators.Contains(t, StringComparer.Ordinal));

--- a/src/CodeCompress.Server/Tools/ContextTools.cs
+++ b/src/CodeCompress.Server/Tools/ContextTools.cs
@@ -70,15 +70,39 @@ internal sealed class ContextTools
             var usedChars = 0;
 
             // ── 1. Search for relevant symbols ──────────────────────
-            var searchResults = await scope.Store.SearchSymbolsAsync(
-                scope.RepoId, query, null, MaxSearchResults).ConfigureAwait(false);
+            // Tokenize: strips stopwords, joins multi-word queries with OR
+            var tokenizedQuery = Fts5QuerySanitizer.TokenizeForSearch(query);
+            var searchQuery = string.IsNullOrWhiteSpace(tokenizedQuery)
+                ? Fts5QuerySanitizer.Sanitize(query)
+                : tokenizedQuery;
 
-            // Auto contains-match fallback for plain terms
-            if (searchResults.Count == 0 && GlobPattern.IsPlainTerm(query))
+            var searchResults = await scope.Store.SearchSymbolsAsync(
+                scope.RepoId, searchQuery, null, MaxSearchResults).ConfigureAwait(false);
+
+            // Auto contains-match fallback: try each term as *term* individually
+            if (searchResults.Count == 0)
             {
-                var containsGlob = Fts5QuerySanitizer.SanitizeAsGlob($"*{query}*");
-                searchResults = await scope.Store.SearchSymbolsAsync(
-                    scope.RepoId, containsGlob.Fts5Query, null, MaxSearchResults, null, containsGlob.SqlLikePattern).ConfigureAwait(false);
+                var terms = searchQuery.Split([" OR "], StringSplitOptions.RemoveEmptyEntries)
+                    .Select(t => t.Trim())
+                    .Where(t => t.Length > 0)
+                    .ToList();
+
+                foreach (var term in terms.Where(GlobPattern.IsPlainTerm))
+                {
+                    var containsGlob = Fts5QuerySanitizer.SanitizeAsGlob($"*{term}*");
+                    if (containsGlob.SqlLikePattern is null)
+                    {
+                        continue;
+                    }
+
+                    searchResults = await scope.Store.SearchSymbolsAsync(
+                        scope.RepoId, containsGlob.Fts5Query, null, MaxSearchResults, null, containsGlob.SqlLikePattern).ConfigureAwait(false);
+
+                    if (searchResults.Count > 0)
+                    {
+                        break;
+                    }
+                }
             }
 
             if (searchResults.Count == 0)

--- a/tests/CodeCompress.Core.Tests/Storage/Fts5QuerySanitizerTests.cs
+++ b/tests/CodeCompress.Core.Tests/Storage/Fts5QuerySanitizerTests.cs
@@ -291,4 +291,86 @@ internal sealed class Fts5QuerySanitizerTests
         await Assert.That(result.Strategy).IsEqualTo(GlobMatchStrategy.MixedStrategy);
         await Assert.That(result.ErrorDetail).IsNotNull();
     }
+
+    // ── TokenizeForSearch tests ────────────────────────────────────────
+
+    [Test]
+    public async Task TokenizeForSearchMultiWordReturnsOrJoinedTerms()
+    {
+        var result = Fts5QuerySanitizer.TokenizeForSearch("PromptInjectionGuard sanitize detect injection");
+
+        await Assert.That(result).IsEqualTo("PromptInjectionGuard OR sanitize OR detect OR injection");
+    }
+
+    [Test]
+    public async Task TokenizeForSearchStripsStopwords()
+    {
+        var result = Fts5QuerySanitizer.TokenizeForSearch("the authentication handler for tenants");
+
+        await Assert.That(result).IsEqualTo("authentication OR handler OR tenants");
+    }
+
+    [Test]
+    public async Task TokenizeForSearchSingleWordReturnsSameWord()
+    {
+        var result = Fts5QuerySanitizer.TokenizeForSearch("PathValidator");
+
+        await Assert.That(result).IsEqualTo("PathValidator");
+    }
+
+    [Test]
+    public async Task TokenizeForSearchAllStopwordsReturnsEmpty()
+    {
+        var result = Fts5QuerySanitizer.TokenizeForSearch("the a an in of");
+
+        await Assert.That(result).IsEqualTo(string.Empty);
+    }
+
+    [Test]
+    public async Task TokenizeForSearchEmptyReturnsEmpty()
+    {
+        var result = Fts5QuerySanitizer.TokenizeForSearch("");
+
+        await Assert.That(result).IsEqualTo(string.Empty);
+    }
+
+    [Test]
+    public async Task TokenizeForSearchWhitespaceReturnsEmpty()
+    {
+        var result = Fts5QuerySanitizer.TokenizeForSearch("   ");
+
+        await Assert.That(result).IsEqualTo(string.Empty);
+    }
+
+    [Test]
+    public async Task TokenizeForSearchPreservesExistingFts5Operators()
+    {
+        var result = Fts5QuerySanitizer.TokenizeForSearch("damage OR health");
+
+        await Assert.That(result).IsEqualTo("damage OR health");
+    }
+
+    [Test]
+    public async Task TokenizeForSearchPreservesWildcardPatterns()
+    {
+        var result = Fts5QuerySanitizer.TokenizeForSearch("*Guard*");
+
+        await Assert.That(result).IsEqualTo("*Guard*");
+    }
+
+    [Test]
+    public async Task TokenizeForSearchSanitizesEachToken()
+    {
+        var result = Fts5QuerySanitizer.TokenizeForSearch("name:foo bar");
+
+        await Assert.That(result).IsEqualTo("foo OR bar");
+    }
+
+    [Test]
+    public async Task TokenizeForSearchStopwordsCaseInsensitive()
+    {
+        var result = Fts5QuerySanitizer.TokenizeForSearch("The Authentication FOR Tenants");
+
+        await Assert.That(result).IsEqualTo("Authentication OR Tenants");
+    }
 }

--- a/tests/CodeCompress.Server.Tests/Tools/ContextToolsTests.cs
+++ b/tests/CodeCompress.Server.Tests/Tools/ContextToolsTests.cs
@@ -126,6 +126,106 @@ internal sealed class ContextToolsTests
         await Assert.That(doc.RootElement.GetProperty("budget").GetInt32()).IsEqualTo(40000);
     }
 
+    // ── Multi-word query support ──────────────────────────────────────
+
+    [Test]
+    public async Task MultiWordQueryUsesOrLogic()
+    {
+        var searchResults = new List<SymbolSearchResult>
+        {
+            new(CreateSymbol(1, 1, "PromptInjectionGuard", "Class", "public class PromptInjectionGuard"), "src/Security/PromptInjectionGuard.cs", 1.0),
+        };
+
+        // First call with tokenized OR query should return results
+        _store.SearchSymbolsAsync("test-repo-id", "PromptInjectionGuard OR sanitize OR detect OR injection", Arg.Any<string?>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>())
+            .Returns(searchResults);
+        _store.GetFilesByRepoAsync("test-repo-id")
+            .Returns(new List<FileRecord>
+            {
+                new(1, "test-repo-id", "src/Security/PromptInjectionGuard.cs", "hash1", 500, 20, 1000, 2000),
+            });
+
+        var result = await _tools.AssembleContext("/valid/path", "PromptInjectionGuard sanitize detect injection").ConfigureAwait(false);
+
+        await Assert.That(result).Contains("## File Overview");
+        await Assert.That(result).Contains("PromptInjectionGuard.cs");
+    }
+
+    [Test]
+    public async Task StopwordsStrippedFromMultiWordQuery()
+    {
+        var searchResults = new List<SymbolSearchResult>
+        {
+            new(CreateSymbol(1, 1, "AuthHandler", "Class", "public class AuthHandler"), "src/Auth/AuthHandler.cs", 1.0),
+        };
+
+        // Stopwords stripped: "the authentication handler for tenants" → "authentication OR handler OR tenants"
+        _store.SearchSymbolsAsync("test-repo-id", "authentication OR handler OR tenants", Arg.Any<string?>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>())
+            .Returns(searchResults);
+        _store.GetFilesByRepoAsync("test-repo-id")
+            .Returns(new List<FileRecord>
+            {
+                new(1, "test-repo-id", "src/Auth/AuthHandler.cs", "hash1", 500, 20, 1000, 2000),
+            });
+
+        var result = await _tools.AssembleContext("/valid/path", "the authentication handler for tenants").ConfigureAwait(false);
+
+        await Assert.That(result).Contains("## File Overview");
+        await Assert.That(result).Contains("AuthHandler.cs");
+    }
+
+    [Test]
+    public async Task MultiWordQueryFallsBackToContainsMatch()
+    {
+        var searchResults = new List<SymbolSearchResult>
+        {
+            new(CreateSymbol(1, 1, "TenantFilter", "Class", "public class TenantFilter"), "src/Data/TenantFilter.cs", 1.0),
+        };
+
+        // First call with OR query returns empty
+        _store.SearchSymbolsAsync("test-repo-id", Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Is<string?>(p => p == null))
+            .Returns(new List<SymbolSearchResult>());
+
+        // Contains-match fallback for individual terms returns results
+        _store.SearchSymbolsAsync("test-repo-id", Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Is<string?>(p => p != null))
+            .Returns(searchResults);
+        _store.GetFilesByRepoAsync("test-repo-id")
+            .Returns(new List<FileRecord>
+            {
+                new(1, "test-repo-id", "src/Data/TenantFilter.cs", "hash1", 500, 20, 1000, 2000),
+            });
+
+        var result = await _tools.AssembleContext("/valid/path", "query filter tenant").ConfigureAwait(false);
+
+        await Assert.That(result).Contains("TenantFilter.cs");
+    }
+
+    [Test]
+    public async Task SingleWordQueryStillUsesFallback()
+    {
+        var searchResults = new List<SymbolSearchResult>
+        {
+            new(CreateSymbol(1, 1, "PathValidator", "Class", "public class PathValidator"), "src/Validation/PathValidator.cs", 1.0),
+        };
+
+        // First call returns empty (single word, no OR needed)
+        _store.SearchSymbolsAsync("test-repo-id", "Validator", Arg.Any<string?>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Is<string?>(p => p == null))
+            .Returns(new List<SymbolSearchResult>());
+
+        // Contains-match fallback for single word
+        _store.SearchSymbolsAsync("test-repo-id", Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Is<string>(p => p != null))
+            .Returns(searchResults);
+        _store.GetFilesByRepoAsync("test-repo-id")
+            .Returns(new List<FileRecord>
+            {
+                new(1, "test-repo-id", "src/Validation/PathValidator.cs", "hash1", 500, 20, 1000, 2000),
+            });
+
+        var result = await _tools.AssembleContext("/valid/path", "Validator").ConfigureAwait(false);
+
+        await Assert.That(result).Contains("PathValidator.cs");
+    }
+
     // ── Helpers ────────────────────────────────────────────────────────
 
     private static Symbol CreateSymbol(


### PR DESCRIPTION
## Summary
- Fixes #154 — `assemble_context` returned 0 results for every multi-word natural-language query
- Adds `Fts5QuerySanitizer.TokenizeForSearch()` that splits multi-word queries, strips stopwords, sanitizes each token, and joins with FTS5 OR
- Updates both MCP server `assemble_context` and CLI `assemble` command (feature parity)
- Contains-match fallback now iterates individual terms when OR query also returns 0

## Root Cause
The contains-match fallback only triggered when `GlobPattern.IsPlainTerm(query)` was true — multi-word queries failed this check, so the raw string was passed as an implicit FTS5 AND. When no single symbol contained ALL words, 0 results.

## Test plan
- [x] 10 new unit tests for `TokenizeForSearch` (stopwords, multi-word, single-word, edge cases)
- [x] 4 new unit tests for `ContextTools` multi-word query behavior (OR logic, stopword stripping, fallback, single-word regression)
- [x] All 1104 existing tests pass
- [x] Zero build warnings
- [x] Security review: all 5 checks PASS (FTS5 injection, SQL injection, prompt injection, DoS, stopword bypass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)