### PR TITLE
feat: add prefix matching for qualified names in expand_symbol

### DIFF
--- a/src/CodeCompress.Cli/Program.cs
+++ b/src/CodeCompress.Cli/Program.cs
@@ -765,24 +765,49 @@ expandSymbolCommand.SetAction(async parseResult =>
         var symbol = await scope.Store.GetSymbolByNameAsync(scope.RepoId, name).ConfigureAwait(false);
         if (symbol is null)
         {
-            // Fuzzy resolution: try matching by unqualified name
-            var candidates = await scope.Store.GetSymbolCandidatesByNameAsync(scope.RepoId, name).ConfigureAwait(false);
-            if (candidates.Count == 1)
+            // Step 2: prefix match within parent scope for qualified names
+            var separatorIndex = name.IndexOfAny(['.', ':']);
+            if (separatorIndex > 0 && separatorIndex < name.Length - 1)
             {
-                symbol = candidates[0];
+                var parent = name[..separatorIndex];
+                var childPrefix = name[(separatorIndex + 1)..];
+                var prefixCandidates = await scope.Store.GetSymbolsByParentAndChildPrefixAsync(
+                    scope.RepoId, parent, childPrefix).ConfigureAwait(false);
+
+                if (prefixCandidates.Count == 1)
+                {
+                    symbol = prefixCandidates[0];
+                }
+                else if (prefixCandidates.Count > 1)
+                {
+                    var qualifiedNames = prefixCandidates.Select(c => $"{parent}:{c.Name}");
+                    await WriteErrorAsync("Multiple symbols match this prefix", "SYMBOL_NOT_FOUND", json, jsonSerializerOptions,
+                        $"Candidates: {string.Join(", ", qualifiedNames)}").ConfigureAwait(false);
+                    return;
+                }
             }
-            else if (candidates.Count > 1)
+
+            // Step 3: unscoped candidate search by unqualified name
+            if (symbol is null)
             {
-                var qualifiedNames = candidates.Select(c => c.ParentSymbol is not null ? $"{c.ParentSymbol}:{c.Name}" : c.Name);
-                await WriteErrorAsync("Multiple symbols match this name", "SYMBOL_NOT_FOUND", json, jsonSerializerOptions,
-                    $"Candidates: {string.Join(", ", qualifiedNames)}").ConfigureAwait(false);
-                return;
-            }
-            else
-            {
-                await WriteErrorAsync("Symbol not found", "SYMBOL_NOT_FOUND", json, jsonSerializerOptions,
-                    "Use 'codecompress search --path <path> --query <name>' to discover symbol names. If the symbol was recently added or changed, re-run 'codecompress index' to update the index.").ConfigureAwait(false);
-                return;
+                var candidates = await scope.Store.GetSymbolCandidatesByNameAsync(scope.RepoId, name).ConfigureAwait(false);
+                if (candidates.Count == 1)
+                {
+                    symbol = candidates[0];
+                }
+                else if (candidates.Count > 1)
+                {
+                    var qualifiedNames = candidates.Select(c => c.ParentSymbol is not null ? $"{c.ParentSymbol}:{c.Name}" : c.Name);
+                    await WriteErrorAsync("Multiple symbols match this name", "SYMBOL_NOT_FOUND", json, jsonSerializerOptions,
+                        $"Candidates: {string.Join(", ", qualifiedNames)}").ConfigureAwait(false);
+                    return;
+                }
+                else
+                {
+                    await WriteErrorAsync("Symbol not found", "SYMBOL_NOT_FOUND", json, jsonSerializerOptions,
+                        "Use 'codecompress search --path <path> --query <name>' to discover symbol names. If the symbol was recently added or changed, re-run 'codecompress index' to update the index.").ConfigureAwait(false);
+                    return;
+                }
             }
         }
 

--- a/src/CodeCompress.Core/Storage/ISymbolStore.cs
+++ b/src/CodeCompress.Core/Storage/ISymbolStore.cs
@@ -44,6 +44,7 @@ public interface ISymbolStore
     // Lookups
     public Task<Symbol?> GetSymbolByNameAsync(string repoId, string symbolName);
     public Task<IReadOnlyList<Symbol>> GetSymbolCandidatesByNameAsync(string repoId, string unqualifiedName, int limit = 10);
+    public Task<IReadOnlyList<Symbol>> GetSymbolsByParentAndChildPrefixAsync(string repoId, string parent, string childPrefix, int limit = 10);
     public Task<IReadOnlyList<Symbol>> GetSymbolsByNamesAsync(string repoId, IReadOnlyList<string> symbolNames);
     public Task<IReadOnlyList<Symbol>> GetChildSymbolsAsync(string repoId, string parentSymbolName);
 

--- a/src/CodeCompress.Core/Storage/SqliteSymbolStore.cs
+++ b/src/CodeCompress.Core/Storage/SqliteSymbolStore.cs
@@ -1134,6 +1134,62 @@ public sealed class SqliteSymbolStore : ISymbolStore
         return results;
     }
 
+    public async Task<IReadOnlyList<Symbol>> GetSymbolsByParentAndChildPrefixAsync(string repoId, string parent, string childPrefix, int limit = 10)
+    {
+        ArgumentNullException.ThrowIfNull(repoId);
+        ArgumentNullException.ThrowIfNull(parent);
+        ArgumentNullException.ThrowIfNull(childPrefix);
+
+        if (string.IsNullOrWhiteSpace(parent) || string.IsNullOrWhiteSpace(childPrefix))
+        {
+            return [];
+        }
+
+        var clampedLimit = Math.Min(Math.Max(limit, 1), 50);
+
+        using var command = _connection.CreateCommand();
+
+#pragma warning disable CA2100
+        command.CommandText =
+            """
+            SELECT s.id, s.file_id, s.name, s.kind, s.signature, s.parent_symbol,
+                   s.byte_offset, s.byte_length, s.line_start, s.line_end, s.visibility, s.doc_comment
+            FROM symbols s
+            JOIN files f ON f.id = s.file_id
+            WHERE s.parent_symbol = @parent AND s.name LIKE @childPrefix ESCAPE '!' AND f.repo_id = @repoId
+            ORDER BY s.name
+            LIMIT @limit
+            """;
+#pragma warning restore CA2100
+
+        command.Parameters.AddWithValue("@parent", parent);
+        command.Parameters.AddWithValue("@childPrefix", EscapeLikePattern(childPrefix) + "%");
+        command.Parameters.AddWithValue("@repoId", repoId);
+        command.Parameters.AddWithValue("@limit", clampedLimit);
+
+        using var reader = await command.ExecuteReaderAsync().ConfigureAwait(false);
+        var results = new List<Symbol>();
+
+        while (await reader.ReadAsync().ConfigureAwait(false))
+        {
+            results.Add(new Symbol(
+                reader.GetInt64(0),
+                reader.GetInt64(1),
+                reader.GetString(2),
+                reader.GetString(3),
+                reader.GetString(4),
+                await reader.IsDBNullAsync(5).ConfigureAwait(false) ? null : reader.GetString(5),
+                reader.GetInt32(6),
+                reader.GetInt32(7),
+                reader.GetInt32(8),
+                reader.GetInt32(9),
+                reader.GetString(10),
+                await reader.IsDBNullAsync(11).ConfigureAwait(false) ? null : reader.GetString(11)));
+        }
+
+        return results;
+    }
+
     public async Task<IReadOnlyList<Symbol>> GetSymbolsByNamesAsync(string repoId, IReadOnlyList<string> symbolNames)
     {
         ArgumentNullException.ThrowIfNull(repoId);
@@ -1888,4 +1944,12 @@ public sealed class SqliteSymbolStore : ISymbolStore
 
         return new ProjectOutline(repoId, groups, totalCount, isTruncated);
     }
+
+    /// <summary>
+    /// Escapes SQL LIKE special characters using '!' as the escape character.
+    /// </summary>
+    private static string EscapeLikePattern(string input) =>
+        input.Replace("!", "!!", StringComparison.Ordinal)
+             .Replace("%", "!%", StringComparison.Ordinal)
+             .Replace("_", "!_", StringComparison.Ordinal);
 }

--- a/src/CodeCompress.Server/Tools/QueryTools.cs
+++ b/src/CodeCompress.Server/Tools/QueryTools.cs
@@ -289,30 +289,61 @@ internal sealed class QueryTools
             var symbol = await scope.Store.GetSymbolByNameAsync(scope.RepoId, symbolName).ConfigureAwait(false);
             if (symbol is null)
             {
-                // Fuzzy resolution: try matching by unqualified name
-                var candidates = await scope.Store.GetSymbolCandidatesByNameAsync(scope.RepoId, symbolName).ConfigureAwait(false);
-                if (candidates.Count == 1)
+                // Step 2: prefix match within parent scope for qualified names (Parent:ChildPrefix*)
+                var separatorIndex = symbolName.IndexOfAny(['.', ':']);
+                if (separatorIndex > 0 && separatorIndex < symbolName.Length - 1)
                 {
-                    symbol = candidates[0];
+                    var parent = symbolName[..separatorIndex];
+                    var childPrefix = symbolName[(separatorIndex + 1)..];
+                    var prefixCandidates = await scope.Store.GetSymbolsByParentAndChildPrefixAsync(
+                        scope.RepoId, parent, childPrefix).ConfigureAwait(false);
+
+                    if (prefixCandidates.Count == 1)
+                    {
+                        symbol = prefixCandidates[0];
+                    }
+                    else if (prefixCandidates.Count > 1)
+                    {
+                        return JsonSerializer.Serialize(
+                            new
+                            {
+                                Error = "Multiple symbols match this prefix",
+                                Code = "SYMBOL_NOT_FOUND",
+                                Retryable = false,
+                                Symbol = SanitizeSymbolName(symbolName),
+                                Candidates = prefixCandidates.Select(c => $"{parent}:{c.Name}"),
+                            },
+                            SerializerOptions);
+                    }
                 }
-                else if (candidates.Count > 1)
+
+                // Step 3: unscoped candidate search by unqualified name
+                if (symbol is null)
                 {
-                    return JsonSerializer.Serialize(
-                        new
-                        {
-                            Error = "Multiple symbols match this name",
-                            Code = "SYMBOL_NOT_FOUND",
-                            Retryable = false,
-                            Symbol = SanitizeSymbolName(symbolName),
-                            Candidates = candidates.Select(c => c.ParentSymbol is not null ? $"{c.ParentSymbol}:{c.Name}" : c.Name),
-                        },
-                        SerializerOptions);
-                }
-                else
-                {
-                    return JsonSerializer.Serialize(
-                        new { Error = "Symbol not found", Code = "SYMBOL_NOT_FOUND", Retryable = false, Symbol = SanitizeSymbolName(symbolName), Guidance = SymbolNotFoundGuidance },
-                        SerializerOptions);
+                    var candidates = await scope.Store.GetSymbolCandidatesByNameAsync(scope.RepoId, symbolName).ConfigureAwait(false);
+                    if (candidates.Count == 1)
+                    {
+                        symbol = candidates[0];
+                    }
+                    else if (candidates.Count > 1)
+                    {
+                        return JsonSerializer.Serialize(
+                            new
+                            {
+                                Error = "Multiple symbols match this name",
+                                Code = "SYMBOL_NOT_FOUND",
+                                Retryable = false,
+                                Symbol = SanitizeSymbolName(symbolName),
+                                Candidates = candidates.Select(c => c.ParentSymbol is not null ? $"{c.ParentSymbol}:{c.Name}" : c.Name),
+                            },
+                            SerializerOptions);
+                    }
+                    else
+                    {
+                        return JsonSerializer.Serialize(
+                            new { Error = "Symbol not found", Code = "SYMBOL_NOT_FOUND", Retryable = false, Symbol = SanitizeSymbolName(symbolName), Guidance = SymbolNotFoundGuidance },
+                            SerializerOptions);
+                    }
                 }
             }
 

--- a/tests/CodeCompress.Core.Tests/Storage/SymbolStoreQueryTests.cs
+++ b/tests/CodeCompress.Core.Tests/Storage/SymbolStoreQueryTests.cs
@@ -257,6 +257,58 @@ internal sealed class SymbolStoreQueryTests
         await Assert.That(results[1].Kind).IsEqualTo("Method");
     }
 
+    // ── GetSymbolsByParentAndChildPrefixAsync Tests ────────────────────
+
+    [Test]
+    public async Task GetSymbolsByParentAndChildPrefixAsyncReturnsMatchingChildren()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(connection);
+        var repo = new Repository("repo1", "/test/path", "TestProject", "csharp", 1000, 0, 0);
+        await store.UpsertRepositoryAsync(repo).ConfigureAwait(false);
+
+        var file = new FileRecord(0, "repo1", "src/Endpoints.cs", "hash1", 2048, 80, 1000, 1000);
+        await store.InsertFilesAsync([file]).ConfigureAwait(false);
+        var insertedFile = await store.GetFileByPathAsync("repo1", "src/Endpoints.cs").ConfigureAwait(false);
+
+        var symbols = new List<Symbol>
+        {
+            new(0, insertedFile!.Id, "ProjectEndpoints", "Class", "public static class ProjectEndpoints", null, 0, 500, 1, 50, "Public", null),
+            new(0, insertedFile.Id, "MapMaestroProjectMemberEndpoints", "Method", "public static void MapMaestroProjectMemberEndpoints()", "ProjectEndpoints", 100, 100, 10, 20, "Public", null),
+            new(0, insertedFile.Id, "MapMaestroProjectCrudEndpoints", "Method", "public static void MapMaestroProjectCrudEndpoints()", "ProjectEndpoints", 200, 100, 21, 30, "Public", null),
+            new(0, insertedFile.Id, "MapOtherEndpoints", "Method", "public static void MapOtherEndpoints()", "ProjectEndpoints", 300, 100, 31, 40, "Public", null),
+        };
+        await store.InsertSymbolsAsync(symbols).ConfigureAwait(false);
+
+        var results = await store.GetSymbolsByParentAndChildPrefixAsync("repo1", "ProjectEndpoints", "MapMaestroProject").ConfigureAwait(false);
+
+        await Assert.That(results.Count).IsEqualTo(2);
+        await Assert.That(results[0].Name).IsEqualTo("MapMaestroProjectCrudEndpoints");
+        await Assert.That(results[1].Name).IsEqualTo("MapMaestroProjectMemberEndpoints");
+    }
+
+    [Test]
+    public async Task GetSymbolsByParentAndChildPrefixAsyncReturnsEmptyWhenNoMatch()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var (store, _) = await SeedTestDataAsync(connection).ConfigureAwait(false);
+
+        var results = await store.GetSymbolsByParentAndChildPrefixAsync("repo1", "MyClass", "NonExistent").ConfigureAwait(false);
+
+        await Assert.That(results.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task GetSymbolsByParentAndChildPrefixAsyncReturnsEmptyForEmptyPrefix()
+    {
+        using var connection = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var (store, _) = await SeedTestDataAsync(connection).ConfigureAwait(false);
+
+        var results = await store.GetSymbolsByParentAndChildPrefixAsync("repo1", "MyClass", "").ConfigureAwait(false);
+
+        await Assert.That(results.Count).IsEqualTo(0);
+    }
+
     // ── GetSymbolsByNamesAsync Tests ─────────────────────────────────────
 
     [Test]

--- a/tests/CodeCompress.Server.Tests/Tools/QueryToolsTests.cs
+++ b/tests/CodeCompress.Server.Tests/Tools/QueryToolsTests.cs
@@ -870,6 +870,77 @@ internal sealed class QueryToolsTests
     }
 
     [Test]
+    public async Task ExpandSymbolPrefixMatchReturnsCandidatesWithQualifiedNames()
+    {
+        // Exact match fails
+        _store.GetSymbolByNameAsync("test-repo-id", "ProjectEndpoints:MapMaestroProject")
+            .Returns((Symbol?)null);
+
+        // Prefix match returns multiple candidates
+        var candidates = new List<Symbol>
+        {
+            CreateSymbol(2, 1, "MapMaestroProjectCrudEndpoints", "Method", "public static void MapMaestroProjectCrudEndpoints()", parent: "ProjectEndpoints"),
+            CreateSymbol(3, 1, "MapMaestroProjectMemberEndpoints", "Method", "public static void MapMaestroProjectMemberEndpoints()", parent: "ProjectEndpoints"),
+        };
+        _store.GetSymbolsByParentAndChildPrefixAsync("test-repo-id", "ProjectEndpoints", "MapMaestroProject", Arg.Any<int>())
+            .Returns(candidates);
+
+        var result = await _tools.ExpandSymbol("/valid/path", "ProjectEndpoints:MapMaestroProject").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        var root = doc.RootElement;
+        await Assert.That(root.GetProperty("code").GetString()).IsEqualTo("SYMBOL_NOT_FOUND");
+        var candidateArray = root.GetProperty("candidates");
+        await Assert.That(candidateArray.GetArrayLength()).IsEqualTo(2);
+        await Assert.That(candidateArray[0].GetString()).IsEqualTo("ProjectEndpoints:MapMaestroProjectCrudEndpoints");
+        await Assert.That(candidateArray[1].GetString()).IsEqualTo("ProjectEndpoints:MapMaestroProjectMemberEndpoints");
+    }
+
+    [Test]
+    public async Task ExpandSymbolPrefixMatchSingleResultReturnsSymbol()
+    {
+        var content = "public static class ProjectEndpoints\n{\n    public static void MapMaestroProjectMemberEndpoints() { }\n}\n";
+        var tempFile = CreateTempFile(content);
+        try
+        {
+            var dir = Path.GetDirectoryName(tempFile)!;
+            var fileName = Path.GetFileName(tempFile);
+
+            var methodSource = "    public static void MapMaestroProjectMemberEndpoints() { }";
+            var byteOffset = Encoding.UTF8.GetByteCount("public static class ProjectEndpoints\n{\n");
+            var byteLength = Encoding.UTF8.GetByteCount(methodSource);
+
+            // Exact match fails
+            _store.GetSymbolByNameAsync("test-repo-id", "ProjectEndpoints:MapMaestroProjectMember")
+                .Returns((Symbol?)null);
+
+            // Prefix match returns single result — should auto-resolve
+            var symbol = CreateSymbol(2, 1, "MapMaestroProjectMemberEndpoints", "Method",
+                "public static void MapMaestroProjectMemberEndpoints()", parent: "ProjectEndpoints",
+                byteOffset: byteOffset, byteLength: byteLength);
+            _store.GetSymbolsByParentAndChildPrefixAsync("test-repo-id", "ProjectEndpoints", "MapMaestroProjectMember", Arg.Any<int>())
+                .Returns(new List<Symbol> { symbol });
+            _store.GetFilesByRepoAsync("test-repo-id")
+                .Returns(new List<FileRecord>
+                {
+                    new(1, "test-repo-id", fileName, "hash1", 500, 20, 1000, 2000),
+                });
+
+            _pathValidator.ValidatePath(dir, dir).Returns(dir);
+
+            var result = await _tools.ExpandSymbol(dir, "ProjectEndpoints:MapMaestroProjectMember").ConfigureAwait(false);
+
+            using var doc = JsonDocument.Parse(result);
+            var root = doc.RootElement;
+            await Assert.That(root.GetProperty("name").GetString()).IsEqualTo("MapMaestroProjectMemberEndpoints");
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Test]
     public async Task ExpandSymbolInvalidPathReturnsError()
     {
         _pathValidator.ValidatePath(Arg.Any<string>(), Arg.Any<string>())


### PR DESCRIPTION
## Summary
- Fixes #155 — `expand_symbol` now supports prefix matching for qualified names within a parent scope
- When `Parent:ChildPrefix` doesn't exactly match, tries `Parent:ChildPrefix*` before falling to unscoped search
- Single prefix match auto-resolves; multiple matches return candidate list with full `Parent:Child` qualified names
- New `GetSymbolsByParentAndChildPrefixAsync` store method with parameterized LIKE + proper escape handling
- CLI `expand-symbol` updated for feature parity

## Resolution Order
1. Exact `Parent:Child` match
2. Prefix `Parent:ChildPrefix*` within parent scope (new)
3. Unscoped child name search (existing)
4. SYMBOL_NOT_FOUND error

## Test plan
- [x] 3 new store tests for `GetSymbolsByParentAndChildPrefixAsync` (match, no match, empty prefix)
- [x] 2 new tool tests for prefix matching (multi-candidate list, single auto-resolve)
- [x] All 1109 existing tests pass (including 5 existing ExpandSymbol tests — no regressions)
- [x] Zero build warnings
- [x] Security review: all 5 checks PASS (SQL injection, output sanitization, prompt injection, DoS, path traversal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)