### PR TITLE
fix: improve MIXED_PATTERN error and search tool descriptions

### DIFF
--- a/src/CodeCompress.Server/Tools/QueryTools.cs
+++ b/src/CodeCompress.Server/Tools/QueryTools.cs
@@ -526,7 +526,7 @@ internal sealed class QueryTools
     }
 
     [McpServerTool(Name = "search_symbols")]
-    [Description("Search the symbol index using FTS5 full-text search — faster and more precise than grep-style file scanning. Supports prefix*, *suffix, *contains*, and I*Pattern glob matching. Auto-retries with contains-match (*query*) when a plain term returns zero FTS5 results (e.g., searching 'Validator' automatically finds 'PathValidator', 'IPathValidator'). When this fallback triggers, the response includes fallback_used: true. Returns symbol names, kinds, signatures, and locations. Use pathFilter to scope results to a specific directory. Use get_symbol or expand_symbol to retrieve full source code of matched symbols. Requires index_project to have been called first. Returns JSON: {query, total_matches, [fallback_used], results: [{name, kind, parent, file, line, signature, snippet, rank}]}. Chain with get_symbol using the 'name' field (or 'parent:name' for nested symbols). Errors return JSON {error, code, retryable}. Codes: INVALID_PATH, EMPTY_QUERY, QUERY_TOO_BROAD (add a non-wildcard term or pathFilter), INVALID_KIND (see kind param for valid values), INVALID_PATH_FILTER, MIXED_PATTERN (includes 'suggestion' — split into separate queries).")]
+    [Description("Search the symbol index for classes, methods, functions, types, interfaces, enums, and other code structure. Use this for navigating to named symbols — NOT for searching file contents, string literals, comments, or configuration values (use search_text for those). Supports prefix*, *suffix, *contains*, and I*Pattern glob matching. Auto-retries with contains-match (*query*) when a plain term returns zero FTS5 results (e.g., searching 'Validator' automatically finds 'PathValidator', 'IPathValidator'). When this fallback triggers, the response includes fallback_used: true. Returns symbol names, kinds, signatures, and locations. Use pathFilter to scope results to a specific directory. Use get_symbol or expand_symbol to retrieve full source code of matched symbols. Requires index_project to have been called first. Returns JSON: {query, total_matches, [fallback_used], results: [{name, kind, parent, file, line, signature, snippet, rank}]}. Chain with get_symbol using the 'name' field (or 'parent:name' for nested symbols). Errors return JSON {error, code, retryable}. Codes: INVALID_PATH, EMPTY_QUERY, QUERY_TOO_BROAD (add a non-wildcard term or pathFilter), INVALID_KIND (see kind param for valid values), INVALID_PATH_FILTER, MIXED_PATTERN (includes 'suggestions' array with ready-to-use queries — run each one separately).")]
     public async Task<string> SearchSymbols(
         [Description("ABSOLUTE path to the project root directory — the same root used with index_project (e.g., 'C:\\Projects\\MyGame' or '/home/user/my-project'). Must NOT be a subdirectory or relative path.")] string path,
         [Description("Search query — supports plain text, FTS5 operators (AND, OR, NOT), and glob patterns (prefix*, *suffix, *contains*)")] string query,
@@ -587,13 +587,17 @@ internal sealed class QueryTools
 
         if (glob.Strategy == GlobMatchStrategy.MixedStrategy)
         {
+            // Generate concrete ready-to-use query suggestions from the original terms
+            var suggestions = GenerateMixedPatternSuggestions(query);
+
             return JsonSerializer.Serialize(
                 new
                 {
                     Error = glob.ErrorDetail,
                     Code = "MIXED_PATTERN",
                     Retryable = false,
-                    Suggestion = "Split into separate queries: run one query for prefix patterns (e.g., 'Claude*') and another for suffix/contains patterns (e.g., '*Service').",
+                    Suggestion = "This query mixes incompatible pattern types. You MUST split it into separate search_symbols calls — one per pattern below.",
+                    Suggestions = suggestions,
                 },
                 SerializerOptions);
         }
@@ -713,7 +717,7 @@ internal sealed class QueryTools
     }
 
     [McpServerTool(Name = "search_text")]
-    [Description("Search raw indexed file contents using FTS5 full-text search — faster than grep for large codebases since content is pre-indexed. Use for string literals, comments, TODOs, or non-symbol patterns that search_symbols wouldn't find. For symbol-specific searches (classes, functions, types), prefer search_symbols which is faster and returns structured metadata with direct chaining to get_symbol. Use pathFilter to scope results. Requires index_project to have been called first. Returns JSON: {query, total_matches, results: [{file_path, snippet, rank}]}. Errors return JSON {error, code, retryable}. Codes: INVALID_PATH, EMPTY_QUERY, INVALID_PATH_FILTER.")]
+    [Description("Search raw file contents for string literals, comments, TODOs, configuration values, SQL patterns, or any text that is NOT a symbol name. Use this instead of search_symbols when looking for: content patterns (e.g., 'FromSqlRaw', 'HasQueryFilter'), string literals or magic strings, comments and documentation text, configuration values, audit patterns (e.g., 'TODO', 'HACK', 'password'), or any non-symbol text in source files. Faster than grep — content is pre-indexed via FTS5. For navigating to named symbols (classes, methods, types), use search_symbols instead. Use pathFilter to scope results. Requires index_project to have been called first. Returns JSON: {query, total_matches, results: [{file_path, snippet, rank}]}. Errors return JSON {error, code, retryable}. Codes: INVALID_PATH, EMPTY_QUERY, INVALID_PATH_FILTER.")]
     public async Task<string> SearchText(
         [Description("ABSOLUTE path to the project root directory — the same root used with index_project (e.g., 'C:\\Projects\\MyGame' or '/home/user/my-project'). Must NOT be a subdirectory or relative path.")] string path,
         [Description("FTS5 search query (supports AND, OR, NOT, quoted phrases, prefix*)")] string query,
@@ -1037,6 +1041,37 @@ internal sealed class QueryTools
 
         var result = sb.ToString();
         return result.Length > 256 ? result[..256] : result;
+    }
+
+    private static List<string> GenerateMixedPatternSuggestions(string query)
+    {
+        var tokens = query.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        var suggestions = new List<string>();
+
+        foreach (var token in tokens)
+        {
+            if (string.Equals(token, "OR", StringComparison.Ordinal) ||
+                string.Equals(token, "AND", StringComparison.Ordinal) ||
+                string.Equals(token, "NOT", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var cleaned = token.Trim('(', ')');
+            if (string.IsNullOrEmpty(cleaned))
+            {
+                continue;
+            }
+
+            // Sanitize: allow only alphanumeric, *, _, ., -
+            var sanitized = string.Concat(cleaned.Where(c => char.IsLetterOrDigit(c) || c is '*' or '_' or '.' or '-'));
+            if (sanitized.Length > 0 && sanitized.Length <= 64)
+            {
+                suggestions.Add(sanitized);
+            }
+        }
+
+        return suggestions;
     }
 
     private static string FormatGuidedSummary(Symbol symbol, string filePath, IReadOnlyList<Symbol> children)

--- a/tests/CodeCompress.Server.Tests/Tools/QueryToolsTests.cs
+++ b/tests/CodeCompress.Server.Tests/Tools/QueryToolsTests.cs
@@ -1807,7 +1807,13 @@ internal sealed class QueryToolsTests
         using var doc = JsonDocument.Parse(result);
         var root = doc.RootElement;
         await Assert.That(root.GetProperty("code").GetString()).IsEqualTo("MIXED_PATTERN");
-        await Assert.That(root.GetProperty("suggestion").GetString()).Contains("separate queries");
+        await Assert.That(root.GetProperty("suggestion").GetString()).Contains("MUST split");
+
+        // Should include ready-to-use query suggestions
+        var suggestions = root.GetProperty("suggestions");
+        await Assert.That(suggestions.GetArrayLength()).IsGreaterThanOrEqualTo(2);
+        await Assert.That(suggestions[0].GetString()).IsEqualTo("Claude*");
+        await Assert.That(suggestions[1].GetString()).IsEqualTo("*Service");
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- Fixes #156 — MIXED_PATTERN error now includes `suggestions` array with ready-to-use query strings
- `search_symbols` description explicitly directs agents to `search_text` for content searches
- `search_text` description leads with concrete use cases (string literals, comments, audit patterns)

## Changes
- **MIXED_PATTERN response**: Added `suggestions` array with sanitized individual query terms extracted from the original mixed query. Added directive wording ("You MUST split it into separate search_symbols calls") that LLMs will follow more reliably.
- **search_symbols description**: Starts with "Search the symbol index for classes, methods, functions, types..." and adds cross-reference to search_text.
- **search_text description**: Starts with "Search raw file contents for string literals, comments, TODOs, configuration values..." with concrete examples like `FromSqlRaw`, `HasQueryFilter`.

## Test plan
- [x] Updated MIXED_PATTERN test to verify `suggestions` array with concrete query strings
- [x] All 1109 tests pass
- [x] Zero build warnings
- [x] No new security surface (description/error message changes only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)