### PR TITLE
fix: register missing parser DI registrations (Java, Go, Rust, Python, TS)

### DIFF
--- a/src/CodeCompress.Core/ServiceCollectionExtensions.cs
+++ b/src/CodeCompress.Core/ServiceCollectionExtensions.cs
@@ -21,6 +21,11 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<ILanguageParser, JsonConfigParser>();
         services.AddSingleton<ILanguageParser, BlazorRazorParser>();
         services.AddSingleton<ILanguageParser, TerraformParser>();
+        services.AddSingleton<ILanguageParser, JavaParser>();
+        services.AddSingleton<ILanguageParser, GoParser>();
+        services.AddSingleton<ILanguageParser, RustParser>();
+        services.AddSingleton<ILanguageParser, PythonParser>();
+        services.AddSingleton<ILanguageParser, TypeScriptJavaScriptParser>();
 
         // Indexing
         services.AddSingleton<IFileHasher, FileHasher>();


### PR DESCRIPTION
## Summary

- Five parsers (Java, Go, Rust, Python, TypeScript/JavaScript) were implemented and merged on 2026-03-24 but were never registered in `ServiceCollectionExtensions.AddCodeCompressCore()`
- Without DI registration, these parsers are unreachable at runtime — `index` silently skips all files for these languages
- This adds the 5 missing `AddSingleton<ILanguageParser, ...>()` calls

## Reproduction

```bash
# With v0.12.0, indexing a Java-heavy repo returns 0 Java files
codecompress index --path /path/to/java-project --json
# {"files_indexed": 0, "total_files": 39}  ← only JSON/HCL configs
```

## Fix

One-line registration per parser in `ServiceCollectionExtensions.cs`:

```csharp
services.AddSingleton<ILanguageParser, JavaParser>();
services.AddSingleton<ILanguageParser, GoParser>();
services.AddSingleton<ILanguageParser, RustParser>();
services.AddSingleton<ILanguageParser, PythonParser>();
services.AddSingleton<ILanguageParser, TypeScriptJavaScriptParser>();
```

## Test plan

- [ ] Existing unit tests for all 5 parsers continue to pass
- [ ] `codecompress index` on a Java project now indexes `.java` files
- [ ] `codecompress index` on Go/Rust/Python/TS projects indexes respective file types
- [ ] `codecompress search` returns symbols from newly indexed languages

🤖 Generated with [Claude Code](https://claude.com/claude-code)