### PR TITLE
fix: handle unhandled DbException in assemble_context and CLI search

### DIFF
--- a/src/CodeCompress.Cli/Program.cs
+++ b/src/CodeCompress.Cli/Program.cs
@@ -277,7 +277,17 @@ searchCommand.SetAction(async parseResult =>
     var scope = await CreateProjectScopeAsync(path, provider).ConfigureAwait(false);
     await using (scope.ConfigureAwait(false))
     {
-        var results = await scope.Store.SearchSymbolsAsync(scope.RepoId, query, kind, limit, pathFilter).ConfigureAwait(false);
+        IReadOnlyList<SymbolSearchResult> results;
+        try
+        {
+            results = await scope.Store.SearchSymbolsAsync(scope.RepoId, query, kind, limit, pathFilter).ConfigureAwait(false);
+        }
+        catch (System.Data.Common.DbException)
+        {
+            // FTS5 syntax error — retry with literal phrase
+            var literalQuery = $"\"{query.Replace("\"", string.Empty, StringComparison.Ordinal)}\"";
+            results = await scope.Store.SearchSymbolsAsync(scope.RepoId, literalQuery, kind, limit, pathFilter).ConfigureAwait(false);
+        }
 
         // Auto contains-match fallback for plain terms with zero results
         var fallbackUsed = false;
@@ -1205,7 +1215,17 @@ assembleCommand.SetAction(async parseResult =>
             ? Fts5QuerySanitizer.Sanitize(query)
             : tokenizedQuery;
 
-        var searchResults = await scope.Store.SearchSymbolsAsync(scope.RepoId, searchQuery, null, 50).ConfigureAwait(false);
+        IReadOnlyList<SymbolSearchResult> searchResults;
+        try
+        {
+            searchResults = await scope.Store.SearchSymbolsAsync(scope.RepoId, searchQuery, null, 50).ConfigureAwait(false);
+        }
+        catch (System.Data.Common.DbException)
+        {
+            // FTS5 syntax error — retry with literal phrase
+            var literalQuery = $"\"{query.Replace("\"", string.Empty, StringComparison.Ordinal)}\"";
+            searchResults = await scope.Store.SearchSymbolsAsync(scope.RepoId, literalQuery, null, 50).ConfigureAwait(false);
+        }
 
         // Auto contains-match fallback: try each term as *term* individually
         if (searchResults.Count == 0)
@@ -1223,8 +1243,16 @@ assembleCommand.SetAction(async parseResult =>
                     continue;
                 }
 
-                searchResults = await scope.Store.SearchSymbolsAsync(
-                    scope.RepoId, containsGlob.Fts5Query, null, 50, null, containsGlob.SqlLikePattern).ConfigureAwait(false);
+                try
+                {
+                    searchResults = await scope.Store.SearchSymbolsAsync(
+                        scope.RepoId, containsGlob.Fts5Query, null, 50, null, containsGlob.SqlLikePattern).ConfigureAwait(false);
+                }
+                catch (System.Data.Common.DbException)
+                {
+                    // Skip this term and try the next one
+                    continue;
+                }
 
                 if (searchResults.Count > 0)
                 {

--- a/src/CodeCompress.Server/Tools/ContextTools.cs
+++ b/src/CodeCompress.Server/Tools/ContextTools.cs
@@ -35,7 +35,7 @@ internal sealed class ContextTools
     }
 
     [McpServerTool(Name = "assemble_context")]
-    [Description("One-shot context assembly — searches symbols, retrieves source code, and builds a structured overview within a token budget. Use INSTEAD of manually calling search_symbols + get_symbol + project_outline when starting a task. Reduces 5-10 tool round-trips to 1. Returns Markdown: file tree overview, source code sections grouped by file (with syntax-highlighted fenced blocks), and a metadata footer showing token usage. Large symbols (>16KB) are automatically summarized with signature + child list — use expand_symbol for individual methods. Set activeFile to prioritize the file you're editing. Requires index_project first. Zero-result response is JSON: {query, total_matches: 0, hint}. Errors return JSON {error, code, retryable}. Codes: INVALID_PATH, EMPTY_QUERY.")]
+    [Description("One-shot context assembly — searches symbols, retrieves source code, and builds a structured overview within a token budget. Use INSTEAD of manually calling search_symbols + get_symbol + project_outline when starting a task. Reduces 5-10 tool round-trips to 1. Returns Markdown: file tree overview, source code sections grouped by file (with syntax-highlighted fenced blocks), and a metadata footer showing token usage. Large symbols (>16KB) are automatically summarized with signature + child list — use expand_symbol for individual methods. Set activeFile to prioritize the file you're editing. Requires index_project first. Zero-result response is JSON: {query, total_matches: 0, hint}. Errors return JSON {error, code, retryable}. Codes: INVALID_PATH, EMPTY_QUERY, FTS5_QUERY_ERROR.")]
     public async Task<string> AssembleContext(
         [Description("ABSOLUTE path to the project root directory — the same root used with index_project (e.g., 'C:\\Projects\\MyApp' or '/home/user/my-project'). Must NOT be a subdirectory or relative path.")] string path,
         [Description("Task description or search terms describing what you're working on (e.g., 'authentication middleware', 'database connection pooling', 'UserService'). Supports FTS5 full-text search — plain terms, prefix*, *contains*, and boolean operators (AND, OR, NOT).")] string query,
@@ -76,8 +76,26 @@ internal sealed class ContextTools
                 ? Fts5QuerySanitizer.Sanitize(query)
                 : tokenizedQuery;
 
-            var searchResults = await scope.Store.SearchSymbolsAsync(
-                scope.RepoId, searchQuery, null, MaxSearchResults).ConfigureAwait(false);
+            IReadOnlyList<SymbolSearchResult> searchResults;
+            try
+            {
+                searchResults = await scope.Store.SearchSymbolsAsync(
+                    scope.RepoId, searchQuery, null, MaxSearchResults).ConfigureAwait(false);
+            }
+            catch (System.Data.Common.DbException)
+            {
+                // FTS5 syntax error — retry with literal phrase
+                var literalQuery = $"\"{query.Replace("\"", string.Empty, StringComparison.Ordinal)}\"";
+                try
+                {
+                    searchResults = await scope.Store.SearchSymbolsAsync(
+                        scope.RepoId, literalQuery, null, MaxSearchResults).ConfigureAwait(false);
+                }
+                catch (System.Data.Common.DbException)
+                {
+                    return SerializeError("FTS5 query failed — try simpler search terms", "FTS5_QUERY_ERROR");
+                }
+            }
 
             // Auto contains-match fallback: try each term as *term* individually
             if (searchResults.Count == 0)
@@ -95,8 +113,16 @@ internal sealed class ContextTools
                         continue;
                     }
 
-                    searchResults = await scope.Store.SearchSymbolsAsync(
-                        scope.RepoId, containsGlob.Fts5Query, null, MaxSearchResults, null, containsGlob.SqlLikePattern).ConfigureAwait(false);
+                    try
+                    {
+                        searchResults = await scope.Store.SearchSymbolsAsync(
+                            scope.RepoId, containsGlob.Fts5Query, null, MaxSearchResults, null, containsGlob.SqlLikePattern).ConfigureAwait(false);
+                    }
+                    catch (System.Data.Common.DbException)
+                    {
+                        // Skip this term and try the next one
+                        continue;
+                    }
 
                     if (searchResults.Count > 0)
                     {
@@ -109,7 +135,7 @@ internal sealed class ContextTools
             {
                 return JsonSerializer.Serialize(new
                 {
-                    Query = query,
+                    Query = SanitizeForDisplay(query),
                     TotalMatches = 0,
                     TokensUsed = 0,
                     Budget = clampedBudget,

--- a/tests/CodeCompress.Server.Tests/Tools/ContextToolsTests.cs
+++ b/tests/CodeCompress.Server.Tests/Tools/ContextToolsTests.cs
@@ -226,6 +226,91 @@ internal sealed class ContextToolsTests
         await Assert.That(result).Contains("PathValidator.cs");
     }
 
+    // ── FTS5 error handling ─────────────────────────────────────────────
+
+    [Test]
+    public async Task PrimarySearchDbExceptionRetriesWithLiteralPhrase()
+    {
+        var callCount = 0;
+        var searchResults = new List<SymbolSearchResult>
+        {
+            new(CreateSymbol(1, 1, "PathValidator", "Class", "public class PathValidator"), "src/Validation/PathValidator.cs", 1.0),
+        };
+
+        _store.SearchSymbolsAsync("test-repo-id", Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>())
+            .Returns(callInfo =>
+            {
+                callCount++;
+                if (callCount == 1)
+                {
+                    throw new Microsoft.Data.Sqlite.SqliteException("fts5: syntax error", 1);
+                }
+
+                return searchResults;
+            });
+        _store.GetFilesByRepoAsync("test-repo-id")
+            .Returns(new List<FileRecord>
+            {
+                new(1, "test-repo-id", "src/Validation/PathValidator.cs", "hash1", 500, 20, 1000, 2000),
+            });
+
+        var result = await _tools.AssembleContext("/valid/path", "Program.cs host config").ConfigureAwait(false);
+
+        // Should succeed via literal phrase retry, not throw
+        await Assert.That(result).Contains("## File Overview");
+        await Assert.That(result).Contains("PathValidator.cs");
+    }
+
+    [Test]
+    public async Task PrimarySearchDbExceptionBothAttemptsFailReturnsStructuredError()
+    {
+        _store.SearchSymbolsAsync("test-repo-id", Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>())
+            .Throws(new Microsoft.Data.Sqlite.SqliteException("fts5: syntax error", 1));
+
+        var result = await _tools.AssembleContext("/valid/path", "broken OR query").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        await Assert.That(doc.RootElement.GetProperty("error").GetString()).Contains("FTS5");
+        await Assert.That(doc.RootElement.GetProperty("code").GetString()).IsEqualTo("FTS5_QUERY_ERROR");
+    }
+
+    [Test]
+    public async Task ContainsMatchFallbackDbExceptionSkipsTermAndContinues()
+    {
+        var callCount = 0;
+        var searchResults = new List<SymbolSearchResult>
+        {
+            new(CreateSymbol(1, 1, "TenantFilter", "Class", "public class TenantFilter"), "src/Data/TenantFilter.cs", 1.0),
+        };
+
+        _store.SearchSymbolsAsync("test-repo-id", Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Is<string?>(p => p == null))
+            .Returns(new List<SymbolSearchResult>());
+
+        _store.SearchSymbolsAsync("test-repo-id", Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Is<string?>(p => p != null))
+            .Returns(callInfo =>
+            {
+                callCount++;
+                if (callCount == 1)
+                {
+                    // First contains-match term fails
+                    throw new Microsoft.Data.Sqlite.SqliteException("fts5: syntax error", 1);
+                }
+
+                // Second term succeeds
+                return searchResults;
+            });
+        _store.GetFilesByRepoAsync("test-repo-id")
+            .Returns(new List<FileRecord>
+            {
+                new(1, "test-repo-id", "src/Data/TenantFilter.cs", "hash1", 500, 20, 1000, 2000),
+            });
+
+        var result = await _tools.AssembleContext("/valid/path", "broken filter tenant").ConfigureAwait(false);
+
+        // Should succeed — skipped the broken term, found results on the next term
+        await Assert.That(result).Contains("TenantFilter.cs");
+    }
+
     // ── Helpers ────────────────────────────────────────────────────────
 
     private static Symbol CreateSymbol(


### PR DESCRIPTION
## Summary
- Wraps `SearchSymbolsAsync` calls in `try-catch (DbException)` with literal phrase retry in both MCP Server (`assemble_context`) and CLI (`search-symbols`, `assemble-context`)
- Returns structured `FTS5_QUERY_ERROR` JSON when both attempts fail, instead of letting exceptions bubble to the MCP SDK's generic error handler
- Adds `try-catch` per term in the contains-match fallback loop so one bad term doesn't abort the entire search
- Sanitizes raw query echo in zero-results JSON response to prevent prompt injection via crafted search terms
- Applies the same fix to CLI for parity

Closes #168

## Test plan
- [x] 3 new unit tests: retry success, double-failure structured error, fallback skip-and-continue
- [x] All 1,174 existing tests pass
- [x] Zero build warnings
- [x] Security review completed (no CRITICAL/HIGH findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)