### PR TITLE
feat: add pathFilter parameter to assemble_context tool

### DIFF
--- a/src/CodeCompress.Cli/Program.cs
+++ b/src/CodeCompress.Cli/Program.cs
@@ -1184,6 +1184,7 @@ var assembleBudgetOption = new Option<int>("--budget")
     Description = "Maximum token budget (1000-200000, default 40000). Values outside range are clamped.",
     DefaultValueFactory = _ => 40000,
 };
+var assemblePathFilterOption = new Option<string?>("--path-filter") { Description = "Filter to files under this directory (e.g., 'src/')" };
 
 var assembleCommand = new Command("assemble",
     "Assemble relevant code context within a token budget. " +
@@ -1193,6 +1194,7 @@ var assembleCommand = new Command("assemble",
     assembleQueryOption,
     assembleActiveFileOption,
     assembleBudgetOption,
+    assemblePathFilterOption,
 };
 
 assembleCommand.SetAction(async parseResult =>
@@ -1201,6 +1203,7 @@ assembleCommand.SetAction(async parseResult =>
     var query = parseResult.GetValue(assembleQueryOption)!;
     _ = parseResult.GetValue(assembleActiveFileOption); // Reserved for future active-file priority
     var budget = Math.Clamp(parseResult.GetValue(assembleBudgetOption), 1000, 200000);
+    var pathFilter = parseResult.GetValue(assemblePathFilterOption);
     var json = parseResult.GetValue(jsonOption);
 
     var scope = await CreateProjectScopeAsync(path, provider).ConfigureAwait(false);
@@ -1218,13 +1221,13 @@ assembleCommand.SetAction(async parseResult =>
         IReadOnlyList<SymbolSearchResult> searchResults;
         try
         {
-            searchResults = await scope.Store.SearchSymbolsAsync(scope.RepoId, searchQuery, null, 50).ConfigureAwait(false);
+            searchResults = await scope.Store.SearchSymbolsAsync(scope.RepoId, searchQuery, null, 50, pathFilter).ConfigureAwait(false);
         }
         catch (System.Data.Common.DbException)
         {
             // FTS5 syntax error — retry with literal phrase
             var literalQuery = $"\"{query.Replace("\"", string.Empty, StringComparison.Ordinal)}\"";
-            searchResults = await scope.Store.SearchSymbolsAsync(scope.RepoId, literalQuery, null, 50).ConfigureAwait(false);
+            searchResults = await scope.Store.SearchSymbolsAsync(scope.RepoId, literalQuery, null, 50, pathFilter).ConfigureAwait(false);
         }
 
         // Auto contains-match fallback: try each term as *term* individually
@@ -1246,7 +1249,7 @@ assembleCommand.SetAction(async parseResult =>
                 try
                 {
                     searchResults = await scope.Store.SearchSymbolsAsync(
-                        scope.RepoId, containsGlob.Fts5Query, null, 50, null, containsGlob.SqlLikePattern).ConfigureAwait(false);
+                        scope.RepoId, containsGlob.Fts5Query, null, 50, pathFilter, containsGlob.SqlLikePattern).ConfigureAwait(false);
                 }
                 catch (System.Data.Common.DbException)
                 {

--- a/src/CodeCompress.Server/Tools/ContextTools.cs
+++ b/src/CodeCompress.Server/Tools/ContextTools.cs
@@ -35,11 +35,12 @@ internal sealed class ContextTools
     }
 
     [McpServerTool(Name = "assemble_context")]
-    [Description("One-shot context assembly — searches symbols, retrieves source code, and builds a structured overview within a token budget. Use INSTEAD of manually calling search_symbols + get_symbol + project_outline when starting a task. Reduces 5-10 tool round-trips to 1. Returns Markdown: file tree overview, source code sections grouped by file (with syntax-highlighted fenced blocks), and a metadata footer showing token usage. Large symbols (>16KB) are automatically summarized with signature + child list — use expand_symbol for individual methods. Set activeFile to prioritize the file you're editing. Requires index_project first. Zero-result response is JSON: {query, total_matches: 0, hint}. Errors return JSON {error, code, retryable}. Codes: INVALID_PATH, EMPTY_QUERY, FTS5_QUERY_ERROR.")]
+    [Description("One-shot context assembly — searches symbols, retrieves source code, and builds a structured overview within a token budget. Use INSTEAD of manually calling search_symbols + get_symbol + project_outline when starting a task. Reduces 5-10 tool round-trips to 1. Returns Markdown: file tree overview, source code sections grouped by file (with syntax-highlighted fenced blocks), and a metadata footer showing token usage. Large symbols (>16KB) are automatically summarized with signature + child list — use expand_symbol for individual methods. Set activeFile to prioritize the file you're editing. Requires index_project first. Zero-result response is JSON: {query, total_matches: 0, hint}. Errors return JSON {error, code, retryable}. Codes: INVALID_PATH, EMPTY_QUERY, FTS5_QUERY_ERROR, INVALID_PATH_FILTER.")]
     public async Task<string> AssembleContext(
         [Description("ABSOLUTE path to the project root directory — the same root used with index_project (e.g., 'C:\\Projects\\MyApp' or '/home/user/my-project'). Must NOT be a subdirectory or relative path.")] string path,
         [Description("Task description or search terms describing what you're working on (e.g., 'authentication middleware', 'database connection pooling', 'UserService'). Supports FTS5 full-text search — plain terms, prefix*, *contains*, and boolean operators (AND, OR, NOT).")] string query,
         [Description("Relative path to the file you're currently editing (e.g., 'src/services/UserService.ts'). Symbols from this file get highest priority in the assembled context. Optional — omit if you don't have a specific file focus.")] string? activeFile = null,
+        [Description("Filter results to files under this relative directory path. Scopes results to only files within the specified directory. Examples: 'src/' (exclude tests), 'src/Core/Models' (specific module), 'lib/' (library code only).")] string? pathFilter = null,
         [Description("Maximum token budget for the response (1000-200000, default 40000). The assembled context will not exceed this limit. Larger budgets include more symbols and source code. Values outside range are clamped.")] int budget = DefaultBudget,
         [Description("Maximum depth for dependency traversal (0-5, default 2). Higher values include more transitive dependencies but consume more budget.")] int maxDepth = 2,
         CancellationToken cancellationToken = default)
@@ -57,6 +58,19 @@ internal sealed class ContextTools
         if (string.IsNullOrWhiteSpace(query))
         {
             return SerializeError("Query cannot be empty", "EMPTY_QUERY");
+        }
+
+        string? validatedPathFilter = null;
+        if (pathFilter is not null)
+        {
+            try
+            {
+                validatedPathFilter = PathValidator.ValidatePathFilter(pathFilter);
+            }
+            catch (ArgumentException)
+            {
+                return SerializeError("Invalid path filter", "INVALID_PATH_FILTER");
+            }
         }
 
         var clampedBudget = Math.Clamp(budget, 1_000, 200_000);
@@ -80,7 +94,7 @@ internal sealed class ContextTools
             try
             {
                 searchResults = await scope.Store.SearchSymbolsAsync(
-                    scope.RepoId, searchQuery, null, MaxSearchResults).ConfigureAwait(false);
+                    scope.RepoId, searchQuery, null, MaxSearchResults, validatedPathFilter).ConfigureAwait(false);
             }
             catch (System.Data.Common.DbException)
             {
@@ -89,7 +103,7 @@ internal sealed class ContextTools
                 try
                 {
                     searchResults = await scope.Store.SearchSymbolsAsync(
-                        scope.RepoId, literalQuery, null, MaxSearchResults).ConfigureAwait(false);
+                        scope.RepoId, literalQuery, null, MaxSearchResults, validatedPathFilter).ConfigureAwait(false);
                 }
                 catch (System.Data.Common.DbException)
                 {
@@ -116,7 +130,7 @@ internal sealed class ContextTools
                     try
                     {
                         searchResults = await scope.Store.SearchSymbolsAsync(
-                            scope.RepoId, containsGlob.Fts5Query, null, MaxSearchResults, null, containsGlob.SqlLikePattern).ConfigureAwait(false);
+                            scope.RepoId, containsGlob.Fts5Query, null, MaxSearchResults, validatedPathFilter, containsGlob.SqlLikePattern).ConfigureAwait(false);
                     }
                     catch (System.Data.Common.DbException)
                     {

--- a/tests/CodeCompress.Server.Tests/Tools/ContextToolsTests.cs
+++ b/tests/CodeCompress.Server.Tests/Tools/ContextToolsTests.cs
@@ -311,6 +311,103 @@ internal sealed class ContextToolsTests
         await Assert.That(result).Contains("TenantFilter.cs");
     }
 
+    // ── pathFilter ────────────────────────────────────────────────────
+
+    [Test]
+    public async Task PathFilterScopesResultsToMatchingDirectory()
+    {
+        var srcSymbol = new SymbolSearchResult(
+            CreateSymbol(1, 1, "UserService", "Class", "public class UserService"), "src/Services/UserService.cs", 1.0);
+
+        // When pathFilter is provided, SearchSymbolsAsync receives the validated filter
+        _store.SearchSymbolsAsync("test-repo-id", Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<int>(), Arg.Is<string?>(p => p != null), Arg.Any<string?>())
+            .Returns(new List<SymbolSearchResult> { srcSymbol });
+        _store.GetFilesByRepoAsync("test-repo-id")
+            .Returns(new List<FileRecord>
+            {
+                new(1, "test-repo-id", "src/Services/UserService.cs", "hash1", 500, 20, 1000, 2000),
+                new(2, "test-repo-id", "tests/UserServiceTests.cs", "hash2", 300, 10, 1000, 2000),
+            });
+
+        var result = await _tools.AssembleContext("/valid/path", "UserService", pathFilter: "src/").ConfigureAwait(false);
+
+        await Assert.That(result).Contains("UserService.cs");
+        await Assert.That(result).DoesNotContain("UserServiceTests.cs");
+    }
+
+    [Test]
+    public async Task NullPathFilterPreservesExistingBehavior()
+    {
+        var searchResults = new List<SymbolSearchResult>
+        {
+            new(CreateSymbol(1, 1, "PathValidator", "Class", "public class PathValidator"), "src/Validation/PathValidator.cs", 1.0),
+        };
+
+        // When pathFilter is null, SearchSymbolsAsync receives null for pathFilter
+        _store.SearchSymbolsAsync("test-repo-id", Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<int>(), Arg.Is<string?>(p => p == null), Arg.Any<string?>())
+            .Returns(searchResults);
+        _store.GetFilesByRepoAsync("test-repo-id")
+            .Returns(new List<FileRecord>
+            {
+                new(1, "test-repo-id", "src/Validation/PathValidator.cs", "hash1", 500, 20, 1000, 2000),
+            });
+
+        var result = await _tools.AssembleContext("/valid/path", "PathValidator").ConfigureAwait(false);
+
+        await Assert.That(result).Contains("## File Overview");
+        await Assert.That(result).Contains("PathValidator.cs");
+    }
+
+    [Test]
+    [Arguments("../escape")]
+    [Arguments("/etc/passwd")]
+    [Arguments("src/../../etc")]
+    public async Task InvalidPathFilterReturnsStructuredError(string badFilter)
+    {
+        var result = await _tools.AssembleContext("/valid/path", "query", pathFilter: badFilter).ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        await Assert.That(doc.RootElement.GetProperty("code").GetString()).IsEqualTo("INVALID_PATH_FILTER");
+    }
+
+    [Test]
+    public async Task PathFilterAppliesToContainsMatchFallback()
+    {
+        var searchResults = new List<SymbolSearchResult>
+        {
+            new(CreateSymbol(1, 1, "TenantFilter", "Class", "public class TenantFilter"), "src/Data/TenantFilter.cs", 1.0),
+        };
+
+        // First call (OR query, with pathFilter) returns empty
+        _store.SearchSymbolsAsync("test-repo-id", Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<int>(), Arg.Is<string?>(p => p != null), Arg.Is<string?>(p => p == null))
+            .Returns(new List<SymbolSearchResult>());
+
+        // Contains-match fallback also receives pathFilter
+        _store.SearchSymbolsAsync("test-repo-id", Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<int>(), Arg.Is<string?>(p => p != null), Arg.Is<string?>(p => p != null))
+            .Returns(searchResults);
+        _store.GetFilesByRepoAsync("test-repo-id")
+            .Returns(new List<FileRecord>
+            {
+                new(1, "test-repo-id", "src/Data/TenantFilter.cs", "hash1", 500, 20, 1000, 2000),
+            });
+
+        var result = await _tools.AssembleContext("/valid/path", "filter tenant", pathFilter: "src/").ConfigureAwait(false);
+
+        await Assert.That(result).Contains("TenantFilter.cs");
+    }
+
+    [Test]
+    public async Task PathFilterWithNoMatchesReturnsZeroResultResponse()
+    {
+        _store.SearchSymbolsAsync("test-repo-id", Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>())
+            .Returns(new List<SymbolSearchResult>());
+
+        var result = await _tools.AssembleContext("/valid/path", "UserService", pathFilter: "nonexistent/").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        await Assert.That(doc.RootElement.GetProperty("total_matches").GetInt32()).IsEqualTo(0);
+    }
+
     // ── Helpers ────────────────────────────────────────────────────────
 
     private static Symbol CreateSymbol(


### PR DESCRIPTION
## Summary
- Adds `pathFilter` parameter to `assemble_context` MCP tool, matching the existing pattern from `search_symbols` and `project_outline`
- Validates via `PathValidator.ValidatePathFilter` on server side; returns structured `INVALID_PATH_FILTER` error on invalid input
- Threads `validatedPathFilter` through all 3 `SearchSymbolsAsync` call sites (primary, literal phrase retry, contains-match fallback)
- Adds `--path-filter` option to CLI `assemble` command for parity
- Updates tool description to document new error code

Closes #169

## Test plan
- [x] 7 new unit tests: pathFilter scopes results, null preserves behavior, 3 invalid inputs rejected, fallback respects filter, no matches returns zero-result
- [x] All 1,181 tests pass
- [x] Zero build warnings
- [x] Security review completed (no CRITICAL/HIGH findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)