### PR TITLE
feat: respect .gitignore during file discovery

### DIFF
--- a/src/CodeCompress.Cli/Program.cs
+++ b/src/CodeCompress.Cli/Program.cs
@@ -1495,6 +1495,7 @@ static async Task<CliProjectScope> CreateProjectScopeAsync(string path, ServiceP
         serviceProvider.GetRequiredService<IEnumerable<CodeCompress.Core.Parsers.ILanguageParser>>(),
         store,
         pathValidator,
+        serviceProvider.GetRequiredService<IGitIgnoreFilter>(),
         serviceProvider.GetRequiredService<ILoggerFactory>().CreateLogger<IndexEngine>());
 
     return new CliProjectScope(connection, store, engine, repoId, validatedPath);

--- a/src/CodeCompress.Core/Indexing/GitIgnoreFilter.cs
+++ b/src/CodeCompress.Core/Indexing/GitIgnoreFilter.cs
@@ -1,0 +1,153 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace CodeCompress.Core.Indexing;
+
+public sealed partial class GitIgnoreFilter : IGitIgnoreFilter
+{
+    private static readonly TimeSpan ProcessTimeout = TimeSpan.FromSeconds(30);
+
+    private readonly ILogger<GitIgnoreFilter> _logger;
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "No .git directory found in {ProjectRoot} — skipping gitignore filtering")]
+    private partial void LogNoGitDirectory(string projectRoot);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "git binary not found — skipping gitignore filtering")]
+    private partial void LogGitNotFound();
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "git check-ignore timed out after {Timeout}s — skipping gitignore filtering")]
+    private partial void LogGitTimeout(double timeout);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "git check-ignore identified {Count} ignored files")]
+    private partial void LogIgnoredCount(int count);
+
+    public GitIgnoreFilter(ILogger<GitIgnoreFilter> logger)
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+        _logger = logger;
+    }
+
+    public async Task<HashSet<string>> GetIgnoredPathsAsync(
+        string projectRoot,
+        IReadOnlyList<string> relativePaths,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(projectRoot);
+        ArgumentNullException.ThrowIfNull(relativePaths);
+
+        if (relativePaths.Count == 0)
+        {
+            return [];
+        }
+
+        // Check if this is a git repository
+        var gitDir = Path.Combine(projectRoot, ".git");
+        if (!Directory.Exists(gitDir) && !File.Exists(gitDir))
+        {
+            LogNoGitDirectory(projectRoot);
+            return [];
+        }
+
+        try
+        {
+            return await RunGitCheckIgnoreAsync(projectRoot, relativePaths, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            // Timeout from our internal CTS — not caller cancellation
+            LogGitTimeout(ProcessTimeout.TotalSeconds);
+            return [];
+        }
+        catch (OperationCanceledException)
+        {
+            // Caller cancelled — propagate
+            throw;
+        }
+#pragma warning disable CA1031 // Catch general exception for graceful fallback
+        catch (Exception ex) when (ex is System.ComponentModel.Win32Exception or IOException)
+#pragma warning restore CA1031
+        {
+            // git not found on PATH, or I/O error
+            LogGitNotFound();
+            return [];
+        }
+    }
+
+    private async Task<HashSet<string>> RunGitCheckIgnoreAsync(
+        string projectRoot,
+        IReadOnlyList<string> relativePaths,
+        CancellationToken cancellationToken)
+    {
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(ProcessTimeout);
+        var linkedToken = timeoutCts.Token;
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "git",
+            Arguments = "check-ignore --stdin -z",
+            WorkingDirectory = projectRoot,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+
+        using var process = new Process { StartInfo = psi };
+        process.Start();
+
+        try
+        {
+            // Write all paths to stdin, null-separated
+            var stdin = process.StandardInput;
+            foreach (var path in relativePaths)
+            {
+                // Normalize to forward slashes for git
+                var normalized = path.Replace('\\', '/');
+                await stdin.WriteAsync(normalized).ConfigureAwait(false);
+                await stdin.WriteAsync('\0').ConfigureAwait(false);
+            }
+
+            stdin.Close(); // Signal EOF to git
+
+            // Read stdout — git returns ignored paths, null-separated
+            var stdout = await process.StandardOutput.ReadToEndAsync(linkedToken).ConfigureAwait(false);
+
+            await process.WaitForExitAsync(linkedToken).ConfigureAwait(false);
+
+            // Parse null-separated output
+            var ignoredPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            if (stdout.Length > 0)
+            {
+                var parts = stdout.Split('\0', StringSplitOptions.RemoveEmptyEntries);
+                foreach (var part in parts)
+                {
+                    // Normalize back to OS-native separator for matching
+                    var normalized = part.Replace('/', Path.DirectorySeparatorChar);
+                    ignoredPaths.Add(normalized);
+                }
+            }
+
+            LogIgnoredCount(ignoredPaths.Count);
+            return ignoredPaths;
+        }
+        finally
+        {
+            // Ensure the git process is killed on timeout or cancellation
+            // Process.Dispose() only releases the handle — it does not kill the child process
+            if (!process.HasExited)
+            {
+                try
+                {
+                    process.Kill(entireProcessTree: true);
+                }
+                catch (InvalidOperationException)
+                {
+                    // Process already exited between HasExited check and Kill — safe to ignore
+                }
+            }
+        }
+    }
+}

--- a/src/CodeCompress.Core/Indexing/IGitIgnoreFilter.cs
+++ b/src/CodeCompress.Core/Indexing/IGitIgnoreFilter.cs
@@ -1,0 +1,16 @@
+namespace CodeCompress.Core.Indexing;
+
+/// <summary>
+/// Filters file paths by querying git for .gitignore rules.
+/// Returns an empty set on graceful fallback (non-git directory, git not installed, timeout).
+/// </summary>
+public interface IGitIgnoreFilter
+{
+    /// <summary>
+    /// Returns the subset of <paramref name="relativePaths"/> that git would ignore.
+    /// </summary>
+    public Task<HashSet<string>> GetIgnoredPathsAsync(
+        string projectRoot,
+        IReadOnlyList<string> relativePaths,
+        CancellationToken cancellationToken = default);
+}

--- a/src/CodeCompress.Core/Indexing/IndexEngine.cs
+++ b/src/CodeCompress.Core/Indexing/IndexEngine.cs
@@ -29,6 +29,7 @@ public sealed partial class IndexEngine : IIndexEngine
     private readonly IChangeTracker _changeTracker;
     private readonly ISymbolStore _symbolStore;
     private readonly IPathValidator _pathValidator;
+    private readonly IGitIgnoreFilter _gitIgnoreFilter;
     private readonly ILogger<IndexEngine> _logger;
     private readonly Dictionary<string, ILanguageParser> _parsersByExtension;
     private readonly Dictionary<string, ILanguageParser> _parsersByLanguageId;
@@ -42,6 +43,7 @@ public sealed partial class IndexEngine : IIndexEngine
         IEnumerable<ILanguageParser> parsers,
         ISymbolStore symbolStore,
         IPathValidator pathValidator,
+        IGitIgnoreFilter gitIgnoreFilter,
         ILogger<IndexEngine> logger)
     {
         ArgumentNullException.ThrowIfNull(fileHasher);
@@ -49,12 +51,14 @@ public sealed partial class IndexEngine : IIndexEngine
         ArgumentNullException.ThrowIfNull(parsers);
         ArgumentNullException.ThrowIfNull(symbolStore);
         ArgumentNullException.ThrowIfNull(pathValidator);
+        ArgumentNullException.ThrowIfNull(gitIgnoreFilter);
         ArgumentNullException.ThrowIfNull(logger);
 
         _fileHasher = fileHasher;
         _changeTracker = changeTracker;
         _symbolStore = symbolStore;
         _pathValidator = pathValidator;
+        _gitIgnoreFilter = gitIgnoreFilter;
         _logger = logger;
 
         _parsersByExtension = new Dictionary<string, ILanguageParser>(StringComparer.OrdinalIgnoreCase);
@@ -91,7 +95,7 @@ public sealed partial class IndexEngine : IIndexEngine
         var repoId = ComputeRepoId(canonicalRoot);
 
         // 3. Discover source files
-        var discoveredFiles = DiscoverFiles(canonicalRoot, language, includePatterns, excludePatterns);
+        var discoveredFiles = await DiscoverFilesAsync(canonicalRoot, language, includePatterns, excludePatterns, cancellationToken).ConfigureAwait(false);
 
         if (discoveredFiles.Count == 0)
         {
@@ -303,11 +307,12 @@ public sealed partial class IndexEngine : IIndexEngine
             parseFailures.IsEmpty ? null : [.. parseFailures]);
     }
 
-    private List<string> DiscoverFiles(
+    private async Task<List<string>> DiscoverFilesAsync(
         string canonicalRoot,
         string? language,
         string[]? includePatterns,
-        string[]? excludePatterns)
+        string[]? excludePatterns,
+        CancellationToken cancellationToken)
     {
         // Determine which extensions to consider
         HashSet<string>? allowedExtensions = null;
@@ -341,8 +346,10 @@ public sealed partial class IndexEngine : IIndexEngine
             }
         }
 
-        var results = new List<string>();
         var defaultExcludeSet = new HashSet<string>(DefaultExcludeDirs, StringComparer.OrdinalIgnoreCase);
+
+        // Phase 1: Collect candidates after hardcoded exclusions + parser check
+        var candidates = new List<(string AbsPath, string RelPath)>();
 
         foreach (var absPath in Directory.EnumerateFiles(canonicalRoot, "*", new EnumerationOptions
         {
@@ -375,6 +382,35 @@ public sealed partial class IndexEngine : IIndexEngine
             // Apply language filter
             if (allowedExtensions is not null && !allowedExtensions.Contains(ext))
             {
+                continue;
+            }
+
+            candidates.Add((absPath, relPath));
+        }
+
+        // Phase 2: Apply .gitignore filtering via git check-ignore
+        var candidateRelPaths = candidates.Select(c => c.RelPath).ToList();
+        var ignoredPaths = await _gitIgnoreFilter.GetIgnoredPathsAsync(canonicalRoot, candidateRelPaths, cancellationToken).ConfigureAwait(false);
+
+        // Phase 3: Apply gitignore + user-supplied patterns
+        var results = new List<string>();
+
+        foreach (var (absPath, relPath) in candidates)
+        {
+            // Skip files that git would ignore (unless overridden by includePatterns below)
+            if (ignoredPaths.Contains(relPath))
+            {
+                // If caller explicitly included this file, let it through
+                if (includeMatcher is not null)
+                {
+                    var includeMatch = includeMatcher.Match(relPath.Replace('\\', '/'));
+                    if (includeMatch.HasMatches)
+                    {
+                        results.Add(absPath);
+                        continue;
+                    }
+                }
+
                 continue;
             }
 

--- a/src/CodeCompress.Core/ServiceCollectionExtensions.cs
+++ b/src/CodeCompress.Core/ServiceCollectionExtensions.cs
@@ -31,6 +31,7 @@ public static class ServiceCollectionExtensions
         // Indexing
         services.AddSingleton<IFileHasher, FileHasher>();
         services.AddSingleton<IChangeTracker, ChangeTracker>();
+        services.AddSingleton<IGitIgnoreFilter, GitIgnoreFilter>();
         services.AddSingleton<IIndexEngine, IndexEngine>();
         services.AddSingleton<IProjectRootResolver, ProjectRootResolver>();
 

--- a/src/CodeCompress.Server/Scoping/ProjectScopeFactory.cs
+++ b/src/CodeCompress.Server/Scoping/ProjectScopeFactory.cs
@@ -13,6 +13,7 @@ internal sealed class ProjectScopeFactory : IProjectScopeFactory
     private readonly IChangeTracker _changeTracker;
     private readonly IEnumerable<ILanguageParser> _parsers;
     private readonly IPathValidator _pathValidator;
+    private readonly IGitIgnoreFilter _gitIgnoreFilter;
     private readonly IProjectRootResolver _rootResolver;
     private readonly ILoggerFactory _loggerFactory;
 
@@ -22,6 +23,7 @@ internal sealed class ProjectScopeFactory : IProjectScopeFactory
         IChangeTracker changeTracker,
         IEnumerable<ILanguageParser> parsers,
         IPathValidator pathValidator,
+        IGitIgnoreFilter gitIgnoreFilter,
         IProjectRootResolver rootResolver,
         ILoggerFactory loggerFactory)
     {
@@ -30,6 +32,7 @@ internal sealed class ProjectScopeFactory : IProjectScopeFactory
         ArgumentNullException.ThrowIfNull(changeTracker);
         ArgumentNullException.ThrowIfNull(parsers);
         ArgumentNullException.ThrowIfNull(pathValidator);
+        ArgumentNullException.ThrowIfNull(gitIgnoreFilter);
         ArgumentNullException.ThrowIfNull(rootResolver);
         ArgumentNullException.ThrowIfNull(loggerFactory);
 
@@ -38,6 +41,7 @@ internal sealed class ProjectScopeFactory : IProjectScopeFactory
         _changeTracker = changeTracker;
         _parsers = parsers;
         _pathValidator = pathValidator;
+        _gitIgnoreFilter = gitIgnoreFilter;
         _rootResolver = rootResolver;
         _loggerFactory = loggerFactory;
     }
@@ -59,6 +63,7 @@ internal sealed class ProjectScopeFactory : IProjectScopeFactory
             _parsers,
             store,
             _pathValidator,
+            _gitIgnoreFilter,
             _loggerFactory.CreateLogger<IndexEngine>());
 
         return new ProjectScope(connection, store, engine, repoId, canonicalRoot);

--- a/tests/CodeCompress.Core.Tests/Indexing/GitIgnoreFilterTests.cs
+++ b/tests/CodeCompress.Core.Tests/Indexing/GitIgnoreFilterTests.cs
@@ -1,0 +1,137 @@
+using CodeCompress.Core.Indexing;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace CodeCompress.Core.Tests.Indexing;
+
+internal sealed class GitIgnoreFilterTests
+{
+    private string _tempDir = null!;
+    private ILogger<GitIgnoreFilter> _logger = null!;
+    private GitIgnoreFilter _filter = null!;
+
+    [Before(Test)]
+    public void SetUp()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"GitIgnoreFilterTests_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _logger = Substitute.For<ILogger<GitIgnoreFilter>>();
+        _filter = new GitIgnoreFilter(_logger);
+    }
+
+    [After(Test)]
+    public void TearDown()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+    }
+
+    // ── Non-git directory fallback ────────────────────────────────────
+
+    [Test]
+    public async Task NonGitDirectoryReturnsEmptySet()
+    {
+        var paths = new List<string> { "src/Program.cs", "src/Models/User.cs" };
+
+        var result = await _filter.GetIgnoredPathsAsync(_tempDir, paths).ConfigureAwait(false);
+
+        await Assert.That(result).Count().IsEqualTo(0);
+    }
+
+    // ── Empty paths ──────────────────────────────────────────────────
+
+    [Test]
+    public async Task EmptyPathListReturnsEmptySet()
+    {
+        var result = await _filter.GetIgnoredPathsAsync(_tempDir, []).ConfigureAwait(false);
+
+        await Assert.That(result).Count().IsEqualTo(0);
+    }
+
+    // ── Real git repo — gitignore filtering ──────────────────────────
+
+    [Test]
+    public async Task GitRepoWithGitignoreFiltersIgnoredPaths()
+    {
+        await RunGitAsync(_tempDir, "init").ConfigureAwait(false);
+        await RunGitAsync(_tempDir, "config user.email test@test.com").ConfigureAwait(false);
+        await RunGitAsync(_tempDir, "config user.name Test").ConfigureAwait(false);
+
+        await File.WriteAllTextAsync(Path.Combine(_tempDir, ".gitignore"), "dist/\ncoverage/\n").ConfigureAwait(false);
+
+        CreateFile("src/Program.cs", "class Program {}");
+        CreateFile("dist/bundle.js", "var x = 1;");
+        CreateFile("coverage/report.html", "<html></html>");
+
+        var paths = new List<string> { "src/Program.cs", "dist/bundle.js", "coverage/report.html" };
+        var result = await _filter.GetIgnoredPathsAsync(_tempDir, paths).ConfigureAwait(false);
+
+        await Assert.That(result.Count).IsGreaterThanOrEqualTo(2);
+        await Assert.That(result).Contains(Path.Combine("dist", "bundle.js"));
+        await Assert.That(result).Contains(Path.Combine("coverage", "report.html"));
+        await Assert.That(result).DoesNotContain(Path.Combine("src", "Program.cs"));
+    }
+
+    [Test]
+    public async Task GitRepoWithNoGitignoreReturnsEmptySet()
+    {
+        await RunGitAsync(_tempDir, "init").ConfigureAwait(false);
+
+        CreateFile("src/Program.cs", "class Program {}");
+
+        var paths = new List<string> { "src/Program.cs" };
+        var result = await _filter.GetIgnoredPathsAsync(_tempDir, paths).ConfigureAwait(false);
+
+        await Assert.That(result).Count().IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task GitRepoWithNegationPatternIncludesNegatedFile()
+    {
+        await RunGitAsync(_tempDir, "init").ConfigureAwait(false);
+        await RunGitAsync(_tempDir, "config user.email test@test.com").ConfigureAwait(false);
+        await RunGitAsync(_tempDir, "config user.name Test").ConfigureAwait(false);
+
+        await File.WriteAllTextAsync(Path.Combine(_tempDir, ".gitignore"), "*.log\n!important.log\n").ConfigureAwait(false);
+
+        CreateFile("debug.log", "debug");
+        CreateFile("important.log", "important");
+        CreateFile("src/Program.cs", "class Program {}");
+
+        var paths = new List<string> { "debug.log", "important.log", "src/Program.cs" };
+        var result = await _filter.GetIgnoredPathsAsync(_tempDir, paths).ConfigureAwait(false);
+
+        await Assert.That(result).Contains("debug.log");
+        await Assert.That(result).DoesNotContain("important.log");
+        await Assert.That(result).DoesNotContain(Path.Combine("src", "Program.cs"));
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────
+
+    private void CreateFile(string relativePath, string content)
+    {
+        var fullPath = Path.Combine(_tempDir, relativePath);
+        var dir = Path.GetDirectoryName(fullPath)!;
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(fullPath, content);
+    }
+
+    private static async Task RunGitAsync(string workingDirectory, string arguments)
+    {
+        var psi = new System.Diagnostics.ProcessStartInfo
+        {
+            FileName = "git",
+            Arguments = arguments,
+            WorkingDirectory = workingDirectory,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+
+        using var process = System.Diagnostics.Process.Start(psi)!;
+        await process.WaitForExitAsync().ConfigureAwait(false);
+    }
+}

--- a/tests/CodeCompress.Core.Tests/Indexing/IndexEngineTests.cs
+++ b/tests/CodeCompress.Core.Tests/Indexing/IndexEngineTests.cs
@@ -16,6 +16,7 @@ internal sealed class IndexEngineTests
     private IChangeTracker _changeTracker = null!;
     private ISymbolStore _symbolStore = null!;
     private IPathValidator _pathValidator = null!;
+    private IGitIgnoreFilter _gitIgnoreFilter = null!;
     private ILogger<IndexEngine> _logger = null!;
     private StubLuauParser _luauParser = null!;
     private StubCSharpParser _csharpParser = null!;
@@ -31,7 +32,12 @@ internal sealed class IndexEngineTests
         _changeTracker = Substitute.For<IChangeTracker>();
         _symbolStore = Substitute.For<ISymbolStore>();
         _pathValidator = Substitute.For<IPathValidator>();
+        _gitIgnoreFilter = Substitute.For<IGitIgnoreFilter>();
         _logger = Substitute.For<ILogger<IndexEngine>>();
+
+        // Default: gitignore filter returns empty set (no files ignored)
+        _gitIgnoreFilter.GetIgnoredPathsAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>())
+            .Returns(new HashSet<string>());
         _luauParser = new StubLuauParser();
         _csharpParser = new StubCSharpParser();
 
@@ -54,6 +60,7 @@ internal sealed class IndexEngineTests
             new ILanguageParser[] { _luauParser, _csharpParser },
             _symbolStore,
             _pathValidator,
+            _gitIgnoreFilter,
             _logger);
     }
 

--- a/tests/CodeCompress.Integration.Tests/BlazorRazorEndToEndTests.cs
+++ b/tests/CodeCompress.Integration.Tests/BlazorRazorEndToEndTests.cs
@@ -5,6 +5,7 @@ using CodeCompress.Core.Storage;
 using CodeCompress.Core.Validation;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
 
 namespace CodeCompress.Integration.Tests;
 
@@ -13,6 +14,7 @@ internal sealed class BlazorRazorEndToEndTests : IDisposable
     private SqliteConnection _connection = null!;
     private SqliteSymbolStore _store = null!;
     private IndexEngine _engine = null!;
+    private IGitIgnoreFilter _gitIgnoreFilter = null!;
     private string _sampleProjectPath = null!;
     private string _repoId = null!;
 
@@ -35,6 +37,8 @@ internal sealed class BlazorRazorEndToEndTests : IDisposable
         var fileHasher = new FileHasher();
         var changeTracker = new ChangeTracker();
         var pathValidator = new PathValidatorService();
+        _gitIgnoreFilter = Substitute.For<IGitIgnoreFilter>();
+        _gitIgnoreFilter.GetIgnoredPathsAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns(new HashSet<string>());
 
         _engine = new IndexEngine(
             fileHasher,
@@ -42,6 +46,7 @@ internal sealed class BlazorRazorEndToEndTests : IDisposable
             parsers,
             _store,
             pathValidator,
+            _gitIgnoreFilter,
             NullLogger<IndexEngine>.Instance);
 
         _sampleProjectPath = FindBlazorRazorSampleProjectPath();

--- a/tests/CodeCompress.Integration.Tests/CSharpEndToEndTests.cs
+++ b/tests/CodeCompress.Integration.Tests/CSharpEndToEndTests.cs
@@ -5,6 +5,7 @@ using CodeCompress.Core.Storage;
 using CodeCompress.Core.Validation;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
 
 namespace CodeCompress.Integration.Tests;
 
@@ -13,6 +14,7 @@ internal sealed class CSharpEndToEndTests : IDisposable
     private SqliteConnection _connection = null!;
     private SqliteSymbolStore _store = null!;
     private IndexEngine _engine = null!;
+    private IGitIgnoreFilter _gitIgnoreFilter = null!;
     private string _sampleProjectPath = null!;
     private string _repoId = null!;
 
@@ -35,6 +37,8 @@ internal sealed class CSharpEndToEndTests : IDisposable
         var fileHasher = new FileHasher();
         var changeTracker = new ChangeTracker();
         var pathValidator = new PathValidatorService();
+        _gitIgnoreFilter = Substitute.For<IGitIgnoreFilter>();
+        _gitIgnoreFilter.GetIgnoredPathsAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns(new HashSet<string>());
 
         _engine = new IndexEngine(
             fileHasher,
@@ -42,6 +46,7 @@ internal sealed class CSharpEndToEndTests : IDisposable
             parsers,
             _store,
             pathValidator,
+            _gitIgnoreFilter,
             NullLogger<IndexEngine>.Instance);
 
         _sampleProjectPath = FindCSharpSampleProjectPath();

--- a/tests/CodeCompress.Integration.Tests/CodeCompress.Integration.Tests.csproj
+++ b/tests/CodeCompress.Integration.Tests/CodeCompress.Integration.Tests.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite" />
+    <PackageReference Include="NSubstitute" />
     <PackageReference Include="TUnit" />
   </ItemGroup>
 

--- a/tests/CodeCompress.Integration.Tests/EndToEndTests.cs
+++ b/tests/CodeCompress.Integration.Tests/EndToEndTests.cs
@@ -5,6 +5,7 @@ using CodeCompress.Core.Storage;
 using CodeCompress.Core.Validation;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
 
 namespace CodeCompress.Integration.Tests;
 
@@ -13,6 +14,7 @@ internal sealed class EndToEndTests : IDisposable
     private SqliteConnection _connection = null!;
     private SqliteSymbolStore _store = null!;
     private IndexEngine _engine = null!;
+    private IGitIgnoreFilter _gitIgnoreFilter = null!;
     private string _sampleProjectPath = null!;
     private string _repoId = null!;
 
@@ -35,6 +37,8 @@ internal sealed class EndToEndTests : IDisposable
         var fileHasher = new FileHasher();
         var changeTracker = new ChangeTracker();
         var pathValidator = new PathValidatorService();
+        _gitIgnoreFilter = Substitute.For<IGitIgnoreFilter>();
+        _gitIgnoreFilter.GetIgnoredPathsAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns(new HashSet<string>());
 
         _engine = new IndexEngine(
             fileHasher,
@@ -42,6 +46,7 @@ internal sealed class EndToEndTests : IDisposable
             parsers,
             _store,
             pathValidator,
+            _gitIgnoreFilter,
             NullLogger<IndexEngine>.Instance);
 
         _sampleProjectPath = FindSampleProjectPath();
@@ -230,6 +235,7 @@ internal sealed class EndToEndTests : IDisposable
                     new ILanguageParser[] { new LuauParser() },
                     tempStore,
                     new PathValidatorService(),
+                    _gitIgnoreFilter,
                     NullLogger<IndexEngine>.Instance);
 
                 var tempRepoId = IndexEngine.ComputeRepoId(Path.GetFullPath(tempDir));

--- a/tests/CodeCompress.Integration.Tests/GoEndToEndTests.cs
+++ b/tests/CodeCompress.Integration.Tests/GoEndToEndTests.cs
@@ -5,6 +5,7 @@ using CodeCompress.Core.Storage;
 using CodeCompress.Core.Validation;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
 
 namespace CodeCompress.Integration.Tests;
 
@@ -13,6 +14,7 @@ internal sealed class GoEndToEndTests : IDisposable
     private SqliteConnection _connection = null!;
     private SqliteSymbolStore _store = null!;
     private IndexEngine _engine = null!;
+    private IGitIgnoreFilter _gitIgnoreFilter = null!;
     private string _sampleProjectPath = null!;
     private string _repoId = null!;
 
@@ -35,6 +37,8 @@ internal sealed class GoEndToEndTests : IDisposable
         var fileHasher = new FileHasher();
         var changeTracker = new ChangeTracker();
         var pathValidator = new PathValidatorService();
+        _gitIgnoreFilter = Substitute.For<IGitIgnoreFilter>();
+        _gitIgnoreFilter.GetIgnoredPathsAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns(new HashSet<string>());
 
         _engine = new IndexEngine(
             fileHasher,
@@ -42,6 +46,7 @@ internal sealed class GoEndToEndTests : IDisposable
             parsers,
             _store,
             pathValidator,
+            _gitIgnoreFilter,
             NullLogger<IndexEngine>.Instance);
 
         _sampleProjectPath = FindGoSampleProjectPath();

--- a/tests/CodeCompress.Integration.Tests/JavaEndToEndTests.cs
+++ b/tests/CodeCompress.Integration.Tests/JavaEndToEndTests.cs
@@ -5,6 +5,7 @@ using CodeCompress.Core.Storage;
 using CodeCompress.Core.Validation;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
 
 namespace CodeCompress.Integration.Tests;
 
@@ -13,6 +14,7 @@ internal sealed class JavaEndToEndTests : IDisposable
     private SqliteConnection _connection = null!;
     private SqliteSymbolStore _store = null!;
     private IndexEngine _engine = null!;
+    private IGitIgnoreFilter _gitIgnoreFilter = null!;
     private string _sampleProjectPath = null!;
     private string _repoId = null!;
 
@@ -35,6 +37,8 @@ internal sealed class JavaEndToEndTests : IDisposable
         var fileHasher = new FileHasher();
         var changeTracker = new ChangeTracker();
         var pathValidator = new PathValidatorService();
+        _gitIgnoreFilter = Substitute.For<IGitIgnoreFilter>();
+        _gitIgnoreFilter.GetIgnoredPathsAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns(new HashSet<string>());
 
         _engine = new IndexEngine(
             fileHasher,
@@ -42,6 +46,7 @@ internal sealed class JavaEndToEndTests : IDisposable
             parsers,
             _store,
             pathValidator,
+            _gitIgnoreFilter,
             NullLogger<IndexEngine>.Instance);
 
         _sampleProjectPath = FindJavaSampleProjectPath();

--- a/tests/CodeCompress.Integration.Tests/JsonConfigEndToEndTests.cs
+++ b/tests/CodeCompress.Integration.Tests/JsonConfigEndToEndTests.cs
@@ -5,6 +5,7 @@ using CodeCompress.Core.Storage;
 using CodeCompress.Core.Validation;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
 
 namespace CodeCompress.Integration.Tests;
 
@@ -13,6 +14,7 @@ internal sealed class JsonConfigEndToEndTests : IDisposable
     private SqliteConnection _connection = null!;
     private SqliteSymbolStore _store = null!;
     private IndexEngine _engine = null!;
+    private IGitIgnoreFilter _gitIgnoreFilter = null!;
     private string _sampleProjectPath = null!;
     private string _repoId = null!;
 
@@ -35,6 +37,8 @@ internal sealed class JsonConfigEndToEndTests : IDisposable
         var fileHasher = new FileHasher();
         var changeTracker = new ChangeTracker();
         var pathValidator = new PathValidatorService();
+        _gitIgnoreFilter = Substitute.For<IGitIgnoreFilter>();
+        _gitIgnoreFilter.GetIgnoredPathsAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns(new HashSet<string>());
 
         _engine = new IndexEngine(
             fileHasher,
@@ -42,6 +46,7 @@ internal sealed class JsonConfigEndToEndTests : IDisposable
             parsers,
             _store,
             pathValidator,
+            _gitIgnoreFilter,
             NullLogger<IndexEngine>.Instance);
 
         _sampleProjectPath = FindJsonConfigSampleProjectPath();

--- a/tests/CodeCompress.Integration.Tests/MixedLanguageTests.cs
+++ b/tests/CodeCompress.Integration.Tests/MixedLanguageTests.cs
@@ -5,6 +5,7 @@ using CodeCompress.Core.Storage;
 using CodeCompress.Core.Validation;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
 
 namespace CodeCompress.Integration.Tests;
 
@@ -13,6 +14,7 @@ internal sealed class MixedLanguageTests : IDisposable
     private SqliteConnection _connection = null!;
     private SqliteSymbolStore _store = null!;
     private IndexEngine _engine = null!;
+    private IGitIgnoreFilter _gitIgnoreFilter = null!;
     private string _tempDir = null!;
     private string _repoId = null!;
 
@@ -36,6 +38,8 @@ internal sealed class MixedLanguageTests : IDisposable
         var fileHasher = new FileHasher();
         var changeTracker = new ChangeTracker();
         var pathValidator = new PathValidatorService();
+        _gitIgnoreFilter = Substitute.For<IGitIgnoreFilter>();
+        _gitIgnoreFilter.GetIgnoredPathsAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns(new HashSet<string>());
 
         _engine = new IndexEngine(
             fileHasher,
@@ -43,6 +47,7 @@ internal sealed class MixedLanguageTests : IDisposable
             parsers,
             _store,
             pathValidator,
+            _gitIgnoreFilter,
             NullLogger<IndexEngine>.Instance);
 
         _tempDir = Path.Combine(Path.GetTempPath(), $"codecompress-mixed-{Guid.NewGuid():N}");

--- a/tests/CodeCompress.Integration.Tests/ProjectDependencyGraphTests.cs
+++ b/tests/CodeCompress.Integration.Tests/ProjectDependencyGraphTests.cs
@@ -5,6 +5,7 @@ using CodeCompress.Core.Storage;
 using CodeCompress.Core.Validation;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
 
 namespace CodeCompress.Integration.Tests;
 
@@ -13,6 +14,7 @@ internal sealed class ProjectDependencyGraphTests : IDisposable
     private SqliteConnection _connection = null!;
     private SqliteSymbolStore _store = null!;
     private IndexEngine _engine = null!;
+    private IGitIgnoreFilter _gitIgnoreFilter = null!;
     private string _tempDir = null!;
     private string _repoId = null!;
 
@@ -41,6 +43,8 @@ internal sealed class ProjectDependencyGraphTests : IDisposable
         var fileHasher = new FileHasher();
         var changeTracker = new ChangeTracker();
         var pathValidator = new PathValidatorService();
+        _gitIgnoreFilter = Substitute.For<IGitIgnoreFilter>();
+        _gitIgnoreFilter.GetIgnoredPathsAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns(new HashSet<string>());
 
         _engine = new IndexEngine(
             fileHasher,
@@ -48,6 +52,7 @@ internal sealed class ProjectDependencyGraphTests : IDisposable
             parsers,
             _store,
             pathValidator,
+            _gitIgnoreFilter,
             NullLogger<IndexEngine>.Instance);
 
         _tempDir = Path.Combine(Path.GetTempPath(), "codecompress-test-" + Guid.NewGuid().ToString("N")[..8]);

--- a/tests/CodeCompress.Integration.Tests/PythonEndToEndTests.cs
+++ b/tests/CodeCompress.Integration.Tests/PythonEndToEndTests.cs
@@ -5,6 +5,7 @@ using CodeCompress.Core.Storage;
 using CodeCompress.Core.Validation;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
 
 namespace CodeCompress.Integration.Tests;
 
@@ -13,6 +14,7 @@ internal sealed class PythonEndToEndTests : IDisposable
     private SqliteConnection _connection = null!;
     private SqliteSymbolStore _store = null!;
     private IndexEngine _engine = null!;
+    private IGitIgnoreFilter _gitIgnoreFilter = null!;
     private string _sampleProjectPath = null!;
     private string _repoId = null!;
 
@@ -27,8 +29,10 @@ internal sealed class PythonEndToEndTests : IDisposable
         _store = new SqliteSymbolStore(_connection);
 
         var parsers = new ILanguageParser[] { new PythonParser() };
+        _gitIgnoreFilter = Substitute.For<IGitIgnoreFilter>();
+        _gitIgnoreFilter.GetIgnoredPathsAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns(new HashSet<string>());
         _engine = new IndexEngine(new FileHasher(), new ChangeTracker(), parsers, _store,
-            new PathValidatorService(), NullLogger<IndexEngine>.Instance);
+            new PathValidatorService(), _gitIgnoreFilter, NullLogger<IndexEngine>.Instance);
 
         _sampleProjectPath = FindSamplePath();
         _repoId = IndexEngine.ComputeRepoId(Path.GetFullPath(_sampleProjectPath));

--- a/tests/CodeCompress.Integration.Tests/RustEndToEndTests.cs
+++ b/tests/CodeCompress.Integration.Tests/RustEndToEndTests.cs
@@ -5,6 +5,7 @@ using CodeCompress.Core.Storage;
 using CodeCompress.Core.Validation;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
 
 namespace CodeCompress.Integration.Tests;
 
@@ -13,6 +14,7 @@ internal sealed class RustEndToEndTests : IDisposable
     private SqliteConnection _connection = null!;
     private SqliteSymbolStore _store = null!;
     private IndexEngine _engine = null!;
+    private IGitIgnoreFilter _gitIgnoreFilter = null!;
     private string _sampleProjectPath = null!;
     private string _repoId = null!;
 
@@ -27,8 +29,10 @@ internal sealed class RustEndToEndTests : IDisposable
         _store = new SqliteSymbolStore(_connection);
 
         var parsers = new ILanguageParser[] { new RustParser() };
+        _gitIgnoreFilter = Substitute.For<IGitIgnoreFilter>();
+        _gitIgnoreFilter.GetIgnoredPathsAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns(new HashSet<string>());
         _engine = new IndexEngine(new FileHasher(), new ChangeTracker(), parsers, _store,
-            new PathValidatorService(), NullLogger<IndexEngine>.Instance);
+            new PathValidatorService(), _gitIgnoreFilter, NullLogger<IndexEngine>.Instance);
 
         _sampleProjectPath = FindSamplePath();
         _repoId = IndexEngine.ComputeRepoId(Path.GetFullPath(_sampleProjectPath));

--- a/tests/CodeCompress.Integration.Tests/TerraformEndToEndTests.cs
+++ b/tests/CodeCompress.Integration.Tests/TerraformEndToEndTests.cs
@@ -5,6 +5,7 @@ using CodeCompress.Core.Storage;
 using CodeCompress.Core.Validation;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
 
 namespace CodeCompress.Integration.Tests;
 
@@ -13,6 +14,7 @@ internal sealed class TerraformEndToEndTests : IDisposable
     private SqliteConnection _connection = null!;
     private SqliteSymbolStore _store = null!;
     private IndexEngine _engine = null!;
+    private IGitIgnoreFilter _gitIgnoreFilter = null!;
     private string _sampleProjectPath = null!;
     private string _repoId = null!;
 
@@ -35,6 +37,8 @@ internal sealed class TerraformEndToEndTests : IDisposable
         var fileHasher = new FileHasher();
         var changeTracker = new ChangeTracker();
         var pathValidator = new PathValidatorService();
+        _gitIgnoreFilter = Substitute.For<IGitIgnoreFilter>();
+        _gitIgnoreFilter.GetIgnoredPathsAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns(new HashSet<string>());
 
         _engine = new IndexEngine(
             fileHasher,
@@ -42,6 +46,7 @@ internal sealed class TerraformEndToEndTests : IDisposable
             parsers,
             _store,
             pathValidator,
+            _gitIgnoreFilter,
             NullLogger<IndexEngine>.Instance);
 
         _sampleProjectPath = FindTerraformSampleProjectPath();

--- a/tests/CodeCompress.Integration.Tests/TypeScriptJavaScriptEndToEndTests.cs
+++ b/tests/CodeCompress.Integration.Tests/TypeScriptJavaScriptEndToEndTests.cs
@@ -5,6 +5,7 @@ using CodeCompress.Core.Storage;
 using CodeCompress.Core.Validation;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
 
 namespace CodeCompress.Integration.Tests;
 
@@ -13,6 +14,7 @@ internal sealed class TypeScriptJavaScriptEndToEndTests : IDisposable
     private SqliteConnection _connection = null!;
     private SqliteSymbolStore _store = null!;
     private IndexEngine _engine = null!;
+    private IGitIgnoreFilter _gitIgnoreFilter = null!;
     private string _sampleProjectPath = null!;
     private string _repoId = null!;
 
@@ -34,10 +36,12 @@ internal sealed class TypeScriptJavaScriptEndToEndTests : IDisposable
         var fileHasher = new FileHasher();
         var changeTracker = new ChangeTracker();
         var pathValidator = new PathValidatorService();
+        _gitIgnoreFilter = Substitute.For<IGitIgnoreFilter>();
+        _gitIgnoreFilter.GetIgnoredPathsAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns(new HashSet<string>());
 
         _engine = new IndexEngine(
             fileHasher, changeTracker, parsers, _store, pathValidator,
-            NullLogger<IndexEngine>.Instance);
+            _gitIgnoreFilter, NullLogger<IndexEngine>.Instance);
 
         _sampleProjectPath = FindSampleProjectPath();
         _repoId = IndexEngine.ComputeRepoId(Path.GetFullPath(_sampleProjectPath));

--- a/tests/CodeCompress.Integration.Tests/YamlConfigEndToEndTests.cs
+++ b/tests/CodeCompress.Integration.Tests/YamlConfigEndToEndTests.cs
@@ -5,6 +5,7 @@ using CodeCompress.Core.Storage;
 using CodeCompress.Core.Validation;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
 
 namespace CodeCompress.Integration.Tests;
 
@@ -13,6 +14,7 @@ internal sealed class YamlConfigEndToEndTests : IDisposable
     private SqliteConnection _connection = null!;
     private SqliteSymbolStore _store = null!;
     private IndexEngine _engine = null!;
+    private IGitIgnoreFilter _gitIgnoreFilter = null!;
     private string _sampleProjectPath = null!;
     private string _repoId = null!;
 
@@ -35,6 +37,8 @@ internal sealed class YamlConfigEndToEndTests : IDisposable
         var fileHasher = new FileHasher();
         var changeTracker = new ChangeTracker();
         var pathValidator = new PathValidatorService();
+        _gitIgnoreFilter = Substitute.For<IGitIgnoreFilter>();
+        _gitIgnoreFilter.GetIgnoredPathsAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns(new HashSet<string>());
 
         _engine = new IndexEngine(
             fileHasher,
@@ -42,6 +46,7 @@ internal sealed class YamlConfigEndToEndTests : IDisposable
             parsers,
             _store,
             pathValidator,
+            _gitIgnoreFilter,
             NullLogger<IndexEngine>.Instance);
 
         _sampleProjectPath = FindYamlConfigSampleProjectPath();


### PR DESCRIPTION
## Summary
- Adds `IGitIgnoreFilter` / `GitIgnoreFilter` service that runs `git check-ignore --stdin -z` to automatically exclude files matching `.gitignore` rules during indexing
- Hardcoded exclusions (`.git`, `node_modules`, `bin`, `obj`, etc.) remain as always-on baseline
- Falls back gracefully: non-git directory, git not installed, process timeout — all return empty set with no error
- Kills orphaned git processes on timeout/cancellation via `Process.Kill(entireProcessTree: true)`
- Integrates into `IndexEngine.DiscoverFilesAsync()` after hardcoded exclusions, before user-supplied patterns
- User `includePatterns` can override `.gitignore` (explicit intent wins)
- Applies to both MCP Server and CLI

Closes #170

## Test plan
- [x] 5 new unit tests: non-git dir, empty paths, gitignore filtering, no gitignore, negation patterns
- [x] All 1,186 tests pass (including all 13 integration test suites updated with new constructor param)
- [x] Zero build warnings
- [x] Security review completed — process kill on timeout added per MEDIUM finding

🤖 Generated with [Claude Code](https://claude.com/claude-code)