### PR TITLE
fix: LIKE-escape wildcards in ValidatePathFilter instead of stripping

### DIFF
--- a/src/CodeCompress.Core/Storage/SqliteSymbolStore.cs
+++ b/src/CodeCompress.Core/Storage/SqliteSymbolStore.cs
@@ -1329,7 +1329,7 @@ public sealed class SqliteSymbolStore : ISymbolStore
 
         if (pathFilter is not null)
         {
-            whereClause.Append(" AND f.relative_path LIKE @pathPrefix || '%'");
+            whereClause.Append(" AND f.relative_path LIKE @pathPrefix || '%' ESCAPE '!'");
         }
 
         // Step 1: Get total symbol count for truncation detection

--- a/src/CodeCompress.Core/Validation/PathValidator.cs
+++ b/src/CodeCompress.Core/Validation/PathValidator.cs
@@ -142,9 +142,12 @@ public static class PathValidator
             throw new ArgumentException("Path filter must not contain parent directory traversal.", nameof(pathFilter));
         }
 
-        // Strip LIKE wildcards to prevent unintended pattern matching
-        normalized = normalized.Replace("%", string.Empty, StringComparison.Ordinal)
-                               .Replace("_", string.Empty, StringComparison.Ordinal);
+        // Escape LIKE wildcards to prevent unintended pattern matching.
+        // Uses '!' as the ESCAPE character, matching the ESCAPE '!' clause in SQL queries.
+        // Order matters: escape '!' first so existing '!' aren't double-escaped.
+        normalized = normalized.Replace("!", "!!", StringComparison.Ordinal)
+                               .Replace("%", "!%", StringComparison.Ordinal)
+                               .Replace("_", "!_", StringComparison.Ordinal);
 
         // Strip trailing slash
         normalized = normalized.TrimEnd('/');

--- a/tests/CodeCompress.Core.Tests/Validation/PathValidatorTests.cs
+++ b/tests/CodeCompress.Core.Tests/Validation/PathValidatorTests.cs
@@ -351,10 +351,35 @@ internal sealed class PathValidatorTests
     }
 
     [Test]
-    public async Task ValidatePathFilterStripsLikeWildcards()
+    public async Task ValidatePathFilterEscapesLikeWildcards()
     {
         var result = PathValidator.ValidatePathFilter("src/%models_");
 
-        await Assert.That(result).IsEqualTo("src/models");
+        await Assert.That(result).IsEqualTo("src/!%models!_");
+    }
+
+    [Test]
+    public async Task ValidatePathFilterPreservesUnderscoresInPaths()
+    {
+        var result = PathValidator.ValidatePathFilter("src/my_module/sub_dir");
+
+        await Assert.That(result).IsEqualTo("src/my!_module/sub!_dir");
+    }
+
+    [Test]
+    public async Task ValidatePathFilterEscapesExclamationMark()
+    {
+        var result = PathValidator.ValidatePathFilter("src/important!/dir");
+
+        await Assert.That(result).IsEqualTo("src/important!!/dir");
+    }
+
+    [Test]
+    public async Task ValidatePathFilterEscapesAllSpecialCharsInOrder()
+    {
+        // ! must be escaped first, then % and _
+        var result = PathValidator.ValidatePathFilter("a!b%c_d");
+
+        await Assert.That(result).IsEqualTo("a!!b!%c!_d");
     }
 }


### PR DESCRIPTION
## Summary
- Replaces aggressive stripping of `%` and `_` in `ValidatePathFilter` with proper LIKE-escaping (`!%`, `!_`, `!!`) matching the `ESCAPE '!'` clause already used in SQL queries
- Fixes corruption of legitimate paths containing underscores (e.g., `src/my_module/` was sanitized to `src/mymodule/` which matched nothing)
- Adds missing `ESCAPE '!'` clause to `GetProjectOutlineAsync`'s pathFilter LIKE query for consistency with all other methods

Closes #173

## Test plan
- [x] 4 new/updated tests: LIKE wildcard escaping, underscore preservation, exclamation mark escaping, combined special chars
- [x] All 1,189 tests pass
- [x] Zero build warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)