### PR TITLE
Release v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.0] - 2026-04-11
+
+### Added
+- `pathFilter` parameter on `assemble_context` — scopes assembled context to a specific directory prefix (e.g., `src/`), matching the existing pattern from `search_symbols` and `project_outline`. Applies to both MCP Server and CLI (#169)
+- `.gitignore` support during file discovery — `IndexEngine` now automatically excludes files matching `.gitignore` rules via `git check-ignore`. Hardcoded exclusions remain as baseline. Falls back gracefully when git is not installed or directory is not a git repo (#170)
+
+### Fixed
+- `assemble_context` now catches FTS5 query errors instead of returning a generic "An error occurred" message — retries with literal phrase, returns structured `FTS5_QUERY_ERROR` JSON on failure. Same fix applied to CLI `search-symbols` and `assemble` commands (#168)
+- `ValidatePathFilter` now LIKE-escapes `%`, `_`, and `!` characters instead of stripping them, fixing corruption of legitimate paths containing underscores (e.g., `src/my_module/` was silently mangled to `src/mymodule/`). Also adds missing `ESCAPE '!'` clause to `GetProjectOutlineAsync` (#173)
+
 ## [0.13.0] - 2026-03-25
 
 ### Added

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>0.13.0</VersionPrefix>
+    <VersionPrefix>0.14.0</VersionPrefix>
     <TargetFramework>net10.0</TargetFramework>
     <LangVersion>14</LangVersion>
     <Nullable>enable</Nullable>

--- a/src/CodeCompress.Cli/Program.cs
+++ b/src/CodeCompress.Cli/Program.cs
@@ -277,7 +277,17 @@ searchCommand.SetAction(async parseResult =>
     var scope = await CreateProjectScopeAsync(path, provider).ConfigureAwait(false);
     await using (scope.ConfigureAwait(false))
     {
-        var results = await scope.Store.SearchSymbolsAsync(scope.RepoId, query, kind, limit, pathFilter).ConfigureAwait(false);
+        IReadOnlyList<SymbolSearchResult> results;
+        try
+        {
+            results = await scope.Store.SearchSymbolsAsync(scope.RepoId, query, kind, limit, pathFilter).ConfigureAwait(false);
+        }
+        catch (System.Data.Common.DbException)
+        {
+            // FTS5 syntax error — retry with literal phrase
+            var literalQuery = $"\"{query.Replace("\"", string.Empty, StringComparison.Ordinal)}\"";
+            results = await scope.Store.SearchSymbolsAsync(scope.RepoId, literalQuery, kind, limit, pathFilter).ConfigureAwait(false);
+        }
 
         // Auto contains-match fallback for plain terms with zero results
         var fallbackUsed = false;
@@ -1205,7 +1215,17 @@ assembleCommand.SetAction(async parseResult =>
             ? Fts5QuerySanitizer.Sanitize(query)
             : tokenizedQuery;
 
-        var searchResults = await scope.Store.SearchSymbolsAsync(scope.RepoId, searchQuery, null, 50).ConfigureAwait(false);
+        IReadOnlyList<SymbolSearchResult> searchResults;
+        try
+        {
+            searchResults = await scope.Store.SearchSymbolsAsync(scope.RepoId, searchQuery, null, 50).ConfigureAwait(false);
+        }
+        catch (System.Data.Common.DbException)
+        {
+            // FTS5 syntax error — retry with literal phrase
+            var literalQuery = $"\"{query.Replace("\"", string.Empty, StringComparison.Ordinal)}\"";
+            searchResults = await scope.Store.SearchSymbolsAsync(scope.RepoId, literalQuery, null, 50).ConfigureAwait(false);
+        }
 
         // Auto contains-match fallback: try each term as *term* individually
         if (searchResults.Count == 0)
@@ -1223,8 +1243,16 @@ assembleCommand.SetAction(async parseResult =>
                     continue;
                 }
 
-                searchResults = await scope.Store.SearchSymbolsAsync(
-                    scope.RepoId, containsGlob.Fts5Query, null, 50, null, containsGlob.SqlLikePattern).ConfigureAwait(false);
+                try
+                {
+                    searchResults = await scope.Store.SearchSymbolsAsync(
+                        scope.RepoId, containsGlob.Fts5Query, null, 50, null, containsGlob.SqlLikePattern).ConfigureAwait(false);
+                }
+                catch (System.Data.Common.DbException)
+                {
+                    // Skip this term and try the next one
+                    continue;
+                }
 
                 if (searchResults.Count > 0)
                 {

--- a/src/CodeCompress.Cli/Program.cs
+++ b/src/CodeCompress.Cli/Program.cs
@@ -1495,6 +1495,7 @@ static async Task<CliProjectScope> CreateProjectScopeAsync(string path, ServiceP
         serviceProvider.GetRequiredService<IEnumerable<CodeCompress.Core.Parsers.ILanguageParser>>(),
         store,
         pathValidator,
+        serviceProvider.GetRequiredService<IGitIgnoreFilter>(),
         serviceProvider.GetRequiredService<ILoggerFactory>().CreateLogger<IndexEngine>());
 
     return new CliProjectScope(connection, store, engine, repoId, validatedPath);

--- a/src/CodeCompress.Cli/Program.cs
+++ b/src/CodeCompress.Cli/Program.cs
@@ -1184,6 +1184,7 @@ var assembleBudgetOption = new Option<int>("--budget")
     Description = "Maximum token budget (1000-200000, default 40000). Values outside range are clamped.",
     DefaultValueFactory = _ => 40000,
 };
+var assemblePathFilterOption = new Option<string?>("--path-filter") { Description = "Filter to files under this directory (e.g., 'src/')" };
 
 var assembleCommand = new Command("assemble",
     "Assemble relevant code context within a token budget. " +
@@ -1193,6 +1194,7 @@ var assembleCommand = new Command("assemble",
     assembleQueryOption,
     assembleActiveFileOption,
     assembleBudgetOption,
+    assemblePathFilterOption,
 };
 
 assembleCommand.SetAction(async parseResult =>
@@ -1201,6 +1203,7 @@ assembleCommand.SetAction(async parseResult =>
     var query = parseResult.GetValue(assembleQueryOption)!;
     _ = parseResult.GetValue(assembleActiveFileOption); // Reserved for future active-file priority
     var budget = Math.Clamp(parseResult.GetValue(assembleBudgetOption), 1000, 200000);
+    var pathFilter = parseResult.GetValue(assemblePathFilterOption);
     var json = parseResult.GetValue(jsonOption);
 
     var scope = await CreateProjectScopeAsync(path, provider).ConfigureAwait(false);
@@ -1218,13 +1221,13 @@ assembleCommand.SetAction(async parseResult =>
         IReadOnlyList<SymbolSearchResult> searchResults;
         try
         {
-            searchResults = await scope.Store.SearchSymbolsAsync(scope.RepoId, searchQuery, null, 50).ConfigureAwait(false);
+            searchResults = await scope.Store.SearchSymbolsAsync(scope.RepoId, searchQuery, null, 50, pathFilter).ConfigureAwait(false);
         }
         catch (System.Data.Common.DbException)
         {
             // FTS5 syntax error — retry with literal phrase
             var literalQuery = $"\"{query.Replace("\"", string.Empty, StringComparison.Ordinal)}\"";
-            searchResults = await scope.Store.SearchSymbolsAsync(scope.RepoId, literalQuery, null, 50).ConfigureAwait(false);
+            searchResults = await scope.Store.SearchSymbolsAsync(scope.RepoId, literalQuery, null, 50, pathFilter).ConfigureAwait(false);
         }
 
         // Auto contains-match fallback: try each term as *term* individually
@@ -1246,7 +1249,7 @@ assembleCommand.SetAction(async parseResult =>
                 try
                 {
                     searchResults = await scope.Store.SearchSymbolsAsync(
-                        scope.RepoId, containsGlob.Fts5Query, null, 50, null, containsGlob.SqlLikePattern).ConfigureAwait(false);
+                        scope.RepoId, containsGlob.Fts5Query, null, 50, pathFilter, containsGlob.SqlLikePattern).ConfigureAwait(false);
                 }
                 catch (System.Data.Common.DbException)
                 {

--- a/src/CodeCompress.Core/Indexing/GitIgnoreFilter.cs
+++ b/src/CodeCompress.Core/Indexing/GitIgnoreFilter.cs
@@ -1,0 +1,153 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace CodeCompress.Core.Indexing;
+
+public sealed partial class GitIgnoreFilter : IGitIgnoreFilter
+{
+    private static readonly TimeSpan ProcessTimeout = TimeSpan.FromSeconds(30);
+
+    private readonly ILogger<GitIgnoreFilter> _logger;
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "No .git directory found in {ProjectRoot} — skipping gitignore filtering")]
+    private partial void LogNoGitDirectory(string projectRoot);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "git binary not found — skipping gitignore filtering")]
+    private partial void LogGitNotFound();
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "git check-ignore timed out after {Timeout}s — skipping gitignore filtering")]
+    private partial void LogGitTimeout(double timeout);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "git check-ignore identified {Count} ignored files")]
+    private partial void LogIgnoredCount(int count);
+
+    public GitIgnoreFilter(ILogger<GitIgnoreFilter> logger)
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+        _logger = logger;
+    }
+
+    public async Task<HashSet<string>> GetIgnoredPathsAsync(
+        string projectRoot,
+        IReadOnlyList<string> relativePaths,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(projectRoot);
+        ArgumentNullException.ThrowIfNull(relativePaths);
+
+        if (relativePaths.Count == 0)
+        {
+            return [];
+        }
+
+        // Check if this is a git repository
+        var gitDir = Path.Combine(projectRoot, ".git");
+        if (!Directory.Exists(gitDir) && !File.Exists(gitDir))
+        {
+            LogNoGitDirectory(projectRoot);
+            return [];
+        }
+
+        try
+        {
+            return await RunGitCheckIgnoreAsync(projectRoot, relativePaths, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            // Timeout from our internal CTS — not caller cancellation
+            LogGitTimeout(ProcessTimeout.TotalSeconds);
+            return [];
+        }
+        catch (OperationCanceledException)
+        {
+            // Caller cancelled — propagate
+            throw;
+        }
+#pragma warning disable CA1031 // Catch general exception for graceful fallback
+        catch (Exception ex) when (ex is System.ComponentModel.Win32Exception or IOException)
+#pragma warning restore CA1031
+        {
+            // git not found on PATH, or I/O error
+            LogGitNotFound();
+            return [];
+        }
+    }
+
+    private async Task<HashSet<string>> RunGitCheckIgnoreAsync(
+        string projectRoot,
+        IReadOnlyList<string> relativePaths,
+        CancellationToken cancellationToken)
+    {
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(ProcessTimeout);
+        var linkedToken = timeoutCts.Token;
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "git",
+            Arguments = "check-ignore --stdin -z",
+            WorkingDirectory = projectRoot,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+
+        using var process = new Process { StartInfo = psi };
+        process.Start();
+
+        try
+        {
+            // Write all paths to stdin, null-separated
+            var stdin = process.StandardInput;
+            foreach (var path in relativePaths)
+            {
+                // Normalize to forward slashes for git
+                var normalized = path.Replace('\\', '/');
+                await stdin.WriteAsync(normalized).ConfigureAwait(false);
+                await stdin.WriteAsync('\0').ConfigureAwait(false);
+            }
+
+            stdin.Close(); // Signal EOF to git
+
+            // Read stdout — git returns ignored paths, null-separated
+            var stdout = await process.StandardOutput.ReadToEndAsync(linkedToken).ConfigureAwait(false);
+
+            await process.WaitForExitAsync(linkedToken).ConfigureAwait(false);
+
+            // Parse null-separated output
+            var ignoredPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            if (stdout.Length > 0)
+            {
+                var parts = stdout.Split('\0', StringSplitOptions.RemoveEmptyEntries);
+                foreach (var part in parts)
+                {
+                    // Normalize back to OS-native separator for matching
+                    var normalized = part.Replace('/', Path.DirectorySeparatorChar);
+                    ignoredPaths.Add(normalized);
+                }
+            }
+
+            LogIgnoredCount(ignoredPaths.Count);
+            return ignoredPaths;
+        }
+        finally
+        {
+            // Ensure the git process is killed on timeout or cancellation
+            // Process.Dispose() only releases the handle — it does not kill the child process
+            if (!process.HasExited)
+            {
+                try
+                {
+                    process.Kill(entireProcessTree: true);
+                }
+                catch (InvalidOperationException)
+                {
+                    // Process already exited between HasExited check and Kill — safe to ignore
+                }
+            }
+        }
+    }
+}

--- a/src/CodeCompress.Core/Indexing/IGitIgnoreFilter.cs
+++ b/src/CodeCompress.Core/Indexing/IGitIgnoreFilter.cs
@@ -1,0 +1,16 @@
+namespace CodeCompress.Core.Indexing;
+
+/// <summary>
+/// Filters file paths by querying git for .gitignore rules.
+/// Returns an empty set on graceful fallback (non-git directory, git not installed, timeout).
+/// </summary>
+public interface IGitIgnoreFilter
+{
+    /// <summary>
+    /// Returns the subset of <paramref name="relativePaths"/> that git would ignore.
+    /// </summary>
+    public Task<HashSet<string>> GetIgnoredPathsAsync(
+        string projectRoot,
+        IReadOnlyList<string> relativePaths,
+        CancellationToken cancellationToken = default);
+}

--- a/src/CodeCompress.Core/Indexing/IndexEngine.cs
+++ b/src/CodeCompress.Core/Indexing/IndexEngine.cs
@@ -29,6 +29,7 @@ public sealed partial class IndexEngine : IIndexEngine
     private readonly IChangeTracker _changeTracker;
     private readonly ISymbolStore _symbolStore;
     private readonly IPathValidator _pathValidator;
+    private readonly IGitIgnoreFilter _gitIgnoreFilter;
     private readonly ILogger<IndexEngine> _logger;
     private readonly Dictionary<string, ILanguageParser> _parsersByExtension;
     private readonly Dictionary<string, ILanguageParser> _parsersByLanguageId;
@@ -42,6 +43,7 @@ public sealed partial class IndexEngine : IIndexEngine
         IEnumerable<ILanguageParser> parsers,
         ISymbolStore symbolStore,
         IPathValidator pathValidator,
+        IGitIgnoreFilter gitIgnoreFilter,
         ILogger<IndexEngine> logger)
     {
         ArgumentNullException.ThrowIfNull(fileHasher);
@@ -49,12 +51,14 @@ public sealed partial class IndexEngine : IIndexEngine
         ArgumentNullException.ThrowIfNull(parsers);
         ArgumentNullException.ThrowIfNull(symbolStore);
         ArgumentNullException.ThrowIfNull(pathValidator);
+        ArgumentNullException.ThrowIfNull(gitIgnoreFilter);
         ArgumentNullException.ThrowIfNull(logger);
 
         _fileHasher = fileHasher;
         _changeTracker = changeTracker;
         _symbolStore = symbolStore;
         _pathValidator = pathValidator;
+        _gitIgnoreFilter = gitIgnoreFilter;
         _logger = logger;
 
         _parsersByExtension = new Dictionary<string, ILanguageParser>(StringComparer.OrdinalIgnoreCase);
@@ -91,7 +95,7 @@ public sealed partial class IndexEngine : IIndexEngine
         var repoId = ComputeRepoId(canonicalRoot);
 
         // 3. Discover source files
-        var discoveredFiles = DiscoverFiles(canonicalRoot, language, includePatterns, excludePatterns);
+        var discoveredFiles = await DiscoverFilesAsync(canonicalRoot, language, includePatterns, excludePatterns, cancellationToken).ConfigureAwait(false);
 
         if (discoveredFiles.Count == 0)
         {
@@ -303,11 +307,12 @@ public sealed partial class IndexEngine : IIndexEngine
             parseFailures.IsEmpty ? null : [.. parseFailures]);
     }
 
-    private List<string> DiscoverFiles(
+    private async Task<List<string>> DiscoverFilesAsync(
         string canonicalRoot,
         string? language,
         string[]? includePatterns,
-        string[]? excludePatterns)
+        string[]? excludePatterns,
+        CancellationToken cancellationToken)
     {
         // Determine which extensions to consider
         HashSet<string>? allowedExtensions = null;
@@ -341,8 +346,10 @@ public sealed partial class IndexEngine : IIndexEngine
             }
         }
 
-        var results = new List<string>();
         var defaultExcludeSet = new HashSet<string>(DefaultExcludeDirs, StringComparer.OrdinalIgnoreCase);
+
+        // Phase 1: Collect candidates after hardcoded exclusions + parser check
+        var candidates = new List<(string AbsPath, string RelPath)>();
 
         foreach (var absPath in Directory.EnumerateFiles(canonicalRoot, "*", new EnumerationOptions
         {
@@ -375,6 +382,35 @@ public sealed partial class IndexEngine : IIndexEngine
             // Apply language filter
             if (allowedExtensions is not null && !allowedExtensions.Contains(ext))
             {
+                continue;
+            }
+
+            candidates.Add((absPath, relPath));
+        }
+
+        // Phase 2: Apply .gitignore filtering via git check-ignore
+        var candidateRelPaths = candidates.Select(c => c.RelPath).ToList();
+        var ignoredPaths = await _gitIgnoreFilter.GetIgnoredPathsAsync(canonicalRoot, candidateRelPaths, cancellationToken).ConfigureAwait(false);
+
+        // Phase 3: Apply gitignore + user-supplied patterns
+        var results = new List<string>();
+
+        foreach (var (absPath, relPath) in candidates)
+        {
+            // Skip files that git would ignore (unless overridden by includePatterns below)
+            if (ignoredPaths.Contains(relPath))
+            {
+                // If caller explicitly included this file, let it through
+                if (includeMatcher is not null)
+                {
+                    var includeMatch = includeMatcher.Match(relPath.Replace('\\', '/'));
+                    if (includeMatch.HasMatches)
+                    {
+                        results.Add(absPath);
+                        continue;
+                    }
+                }
+
                 continue;
             }
 

--- a/src/CodeCompress.Core/ServiceCollectionExtensions.cs
+++ b/src/CodeCompress.Core/ServiceCollectionExtensions.cs
@@ -31,6 +31,7 @@ public static class ServiceCollectionExtensions
         // Indexing
         services.AddSingleton<IFileHasher, FileHasher>();
         services.AddSingleton<IChangeTracker, ChangeTracker>();
+        services.AddSingleton<IGitIgnoreFilter, GitIgnoreFilter>();
         services.AddSingleton<IIndexEngine, IndexEngine>();
         services.AddSingleton<IProjectRootResolver, ProjectRootResolver>();
 

--- a/src/CodeCompress.Core/Storage/SqliteSymbolStore.cs
+++ b/src/CodeCompress.Core/Storage/SqliteSymbolStore.cs
@@ -1329,7 +1329,7 @@ public sealed class SqliteSymbolStore : ISymbolStore
 
         if (pathFilter is not null)
         {
-            whereClause.Append(" AND f.relative_path LIKE @pathPrefix || '%'");
+            whereClause.Append(" AND f.relative_path LIKE @pathPrefix || '%' ESCAPE '!'");
         }
 
         // Step 1: Get total symbol count for truncation detection

--- a/src/CodeCompress.Core/Validation/PathValidator.cs
+++ b/src/CodeCompress.Core/Validation/PathValidator.cs
@@ -142,9 +142,12 @@ public static class PathValidator
             throw new ArgumentException("Path filter must not contain parent directory traversal.", nameof(pathFilter));
         }
 
-        // Strip LIKE wildcards to prevent unintended pattern matching
-        normalized = normalized.Replace("%", string.Empty, StringComparison.Ordinal)
-                               .Replace("_", string.Empty, StringComparison.Ordinal);
+        // Escape LIKE wildcards to prevent unintended pattern matching.
+        // Uses '!' as the ESCAPE character, matching the ESCAPE '!' clause in SQL queries.
+        // Order matters: escape '!' first so existing '!' aren't double-escaped.
+        normalized = normalized.Replace("!", "!!", StringComparison.Ordinal)
+                               .Replace("%", "!%", StringComparison.Ordinal)
+                               .Replace("_", "!_", StringComparison.Ordinal);
 
         // Strip trailing slash
         normalized = normalized.TrimEnd('/');

--- a/src/CodeCompress.Server/Scoping/ProjectScopeFactory.cs
+++ b/src/CodeCompress.Server/Scoping/ProjectScopeFactory.cs
@@ -13,6 +13,7 @@ internal sealed class ProjectScopeFactory : IProjectScopeFactory
     private readonly IChangeTracker _changeTracker;
     private readonly IEnumerable<ILanguageParser> _parsers;
     private readonly IPathValidator _pathValidator;
+    private readonly IGitIgnoreFilter _gitIgnoreFilter;
     private readonly IProjectRootResolver _rootResolver;
     private readonly ILoggerFactory _loggerFactory;
 
@@ -22,6 +23,7 @@ internal sealed class ProjectScopeFactory : IProjectScopeFactory
         IChangeTracker changeTracker,
         IEnumerable<ILanguageParser> parsers,
         IPathValidator pathValidator,
+        IGitIgnoreFilter gitIgnoreFilter,
         IProjectRootResolver rootResolver,
         ILoggerFactory loggerFactory)
     {
@@ -30,6 +32,7 @@ internal sealed class ProjectScopeFactory : IProjectScopeFactory
         ArgumentNullException.ThrowIfNull(changeTracker);
         ArgumentNullException.ThrowIfNull(parsers);
         ArgumentNullException.ThrowIfNull(pathValidator);
+        ArgumentNullException.ThrowIfNull(gitIgnoreFilter);
         ArgumentNullException.ThrowIfNull(rootResolver);
         ArgumentNullException.ThrowIfNull(loggerFactory);
 
@@ -38,6 +41,7 @@ internal sealed class ProjectScopeFactory : IProjectScopeFactory
         _changeTracker = changeTracker;
         _parsers = parsers;
         _pathValidator = pathValidator;
+        _gitIgnoreFilter = gitIgnoreFilter;
         _rootResolver = rootResolver;
         _loggerFactory = loggerFactory;
     }
@@ -59,6 +63,7 @@ internal sealed class ProjectScopeFactory : IProjectScopeFactory
             _parsers,
             store,
             _pathValidator,
+            _gitIgnoreFilter,
             _loggerFactory.CreateLogger<IndexEngine>());
 
         return new ProjectScope(connection, store, engine, repoId, canonicalRoot);

--- a/src/CodeCompress.Server/Tools/ContextTools.cs
+++ b/src/CodeCompress.Server/Tools/ContextTools.cs
@@ -35,7 +35,7 @@ internal sealed class ContextTools
     }
 
     [McpServerTool(Name = "assemble_context")]
-    [Description("One-shot context assembly — searches symbols, retrieves source code, and builds a structured overview within a token budget. Use INSTEAD of manually calling search_symbols + get_symbol + project_outline when starting a task. Reduces 5-10 tool round-trips to 1. Returns Markdown: file tree overview, source code sections grouped by file (with syntax-highlighted fenced blocks), and a metadata footer showing token usage. Large symbols (>16KB) are automatically summarized with signature + child list — use expand_symbol for individual methods. Set activeFile to prioritize the file you're editing. Requires index_project first. Zero-result response is JSON: {query, total_matches: 0, hint}. Errors return JSON {error, code, retryable}. Codes: INVALID_PATH, EMPTY_QUERY.")]
+    [Description("One-shot context assembly — searches symbols, retrieves source code, and builds a structured overview within a token budget. Use INSTEAD of manually calling search_symbols + get_symbol + project_outline when starting a task. Reduces 5-10 tool round-trips to 1. Returns Markdown: file tree overview, source code sections grouped by file (with syntax-highlighted fenced blocks), and a metadata footer showing token usage. Large symbols (>16KB) are automatically summarized with signature + child list — use expand_symbol for individual methods. Set activeFile to prioritize the file you're editing. Requires index_project first. Zero-result response is JSON: {query, total_matches: 0, hint}. Errors return JSON {error, code, retryable}. Codes: INVALID_PATH, EMPTY_QUERY, FTS5_QUERY_ERROR.")]
     public async Task<string> AssembleContext(
         [Description("ABSOLUTE path to the project root directory — the same root used with index_project (e.g., 'C:\\Projects\\MyApp' or '/home/user/my-project'). Must NOT be a subdirectory or relative path.")] string path,
         [Description("Task description or search terms describing what you're working on (e.g., 'authentication middleware', 'database connection pooling', 'UserService'). Supports FTS5 full-text search — plain terms, prefix*, *contains*, and boolean operators (AND, OR, NOT).")] string query,
@@ -76,8 +76,26 @@ internal sealed class ContextTools
                 ? Fts5QuerySanitizer.Sanitize(query)
                 : tokenizedQuery;
 
-            var searchResults = await scope.Store.SearchSymbolsAsync(
-                scope.RepoId, searchQuery, null, MaxSearchResults).ConfigureAwait(false);
+            IReadOnlyList<SymbolSearchResult> searchResults;
+            try
+            {
+                searchResults = await scope.Store.SearchSymbolsAsync(
+                    scope.RepoId, searchQuery, null, MaxSearchResults).ConfigureAwait(false);
+            }
+            catch (System.Data.Common.DbException)
+            {
+                // FTS5 syntax error — retry with literal phrase
+                var literalQuery = $"\"{query.Replace("\"", string.Empty, StringComparison.Ordinal)}\"";
+                try
+                {
+                    searchResults = await scope.Store.SearchSymbolsAsync(
+                        scope.RepoId, literalQuery, null, MaxSearchResults).ConfigureAwait(false);
+                }
+                catch (System.Data.Common.DbException)
+                {
+                    return SerializeError("FTS5 query failed — try simpler search terms", "FTS5_QUERY_ERROR");
+                }
+            }
 
             // Auto contains-match fallback: try each term as *term* individually
             if (searchResults.Count == 0)
@@ -95,8 +113,16 @@ internal sealed class ContextTools
                         continue;
                     }
 
-                    searchResults = await scope.Store.SearchSymbolsAsync(
-                        scope.RepoId, containsGlob.Fts5Query, null, MaxSearchResults, null, containsGlob.SqlLikePattern).ConfigureAwait(false);
+                    try
+                    {
+                        searchResults = await scope.Store.SearchSymbolsAsync(
+                            scope.RepoId, containsGlob.Fts5Query, null, MaxSearchResults, null, containsGlob.SqlLikePattern).ConfigureAwait(false);
+                    }
+                    catch (System.Data.Common.DbException)
+                    {
+                        // Skip this term and try the next one
+                        continue;
+                    }
 
                     if (searchResults.Count > 0)
                     {
@@ -109,7 +135,7 @@ internal sealed class ContextTools
             {
                 return JsonSerializer.Serialize(new
                 {
-                    Query = query,
+                    Query = SanitizeForDisplay(query),
                     TotalMatches = 0,
                     TokensUsed = 0,
                     Budget = clampedBudget,

--- a/src/CodeCompress.Server/Tools/ContextTools.cs
+++ b/src/CodeCompress.Server/Tools/ContextTools.cs
@@ -35,11 +35,12 @@ internal sealed class ContextTools
     }
 
     [McpServerTool(Name = "assemble_context")]
-    [Description("One-shot context assembly — searches symbols, retrieves source code, and builds a structured overview within a token budget. Use INSTEAD of manually calling search_symbols + get_symbol + project_outline when starting a task. Reduces 5-10 tool round-trips to 1. Returns Markdown: file tree overview, source code sections grouped by file (with syntax-highlighted fenced blocks), and a metadata footer showing token usage. Large symbols (>16KB) are automatically summarized with signature + child list — use expand_symbol for individual methods. Set activeFile to prioritize the file you're editing. Requires index_project first. Zero-result response is JSON: {query, total_matches: 0, hint}. Errors return JSON {error, code, retryable}. Codes: INVALID_PATH, EMPTY_QUERY, FTS5_QUERY_ERROR.")]
+    [Description("One-shot context assembly — searches symbols, retrieves source code, and builds a structured overview within a token budget. Use INSTEAD of manually calling search_symbols + get_symbol + project_outline when starting a task. Reduces 5-10 tool round-trips to 1. Returns Markdown: file tree overview, source code sections grouped by file (with syntax-highlighted fenced blocks), and a metadata footer showing token usage. Large symbols (>16KB) are automatically summarized with signature + child list — use expand_symbol for individual methods. Set activeFile to prioritize the file you're editing. Requires index_project first. Zero-result response is JSON: {query, total_matches: 0, hint}. Errors return JSON {error, code, retryable}. Codes: INVALID_PATH, EMPTY_QUERY, FTS5_QUERY_ERROR, INVALID_PATH_FILTER.")]
     public async Task<string> AssembleContext(
         [Description("ABSOLUTE path to the project root directory — the same root used with index_project (e.g., 'C:\\Projects\\MyApp' or '/home/user/my-project'). Must NOT be a subdirectory or relative path.")] string path,
         [Description("Task description or search terms describing what you're working on (e.g., 'authentication middleware', 'database connection pooling', 'UserService'). Supports FTS5 full-text search — plain terms, prefix*, *contains*, and boolean operators (AND, OR, NOT).")] string query,
         [Description("Relative path to the file you're currently editing (e.g., 'src/services/UserService.ts'). Symbols from this file get highest priority in the assembled context. Optional — omit if you don't have a specific file focus.")] string? activeFile = null,
+        [Description("Filter results to files under this relative directory path. Scopes results to only files within the specified directory. Examples: 'src/' (exclude tests), 'src/Core/Models' (specific module), 'lib/' (library code only).")] string? pathFilter = null,
         [Description("Maximum token budget for the response (1000-200000, default 40000). The assembled context will not exceed this limit. Larger budgets include more symbols and source code. Values outside range are clamped.")] int budget = DefaultBudget,
         [Description("Maximum depth for dependency traversal (0-5, default 2). Higher values include more transitive dependencies but consume more budget.")] int maxDepth = 2,
         CancellationToken cancellationToken = default)
@@ -57,6 +58,19 @@ internal sealed class ContextTools
         if (string.IsNullOrWhiteSpace(query))
         {
             return SerializeError("Query cannot be empty", "EMPTY_QUERY");
+        }
+
+        string? validatedPathFilter = null;
+        if (pathFilter is not null)
+        {
+            try
+            {
+                validatedPathFilter = PathValidator.ValidatePathFilter(pathFilter);
+            }
+            catch (ArgumentException)
+            {
+                return SerializeError("Invalid path filter", "INVALID_PATH_FILTER");
+            }
         }
 
         var clampedBudget = Math.Clamp(budget, 1_000, 200_000);
@@ -80,7 +94,7 @@ internal sealed class ContextTools
             try
             {
                 searchResults = await scope.Store.SearchSymbolsAsync(
-                    scope.RepoId, searchQuery, null, MaxSearchResults).ConfigureAwait(false);
+                    scope.RepoId, searchQuery, null, MaxSearchResults, validatedPathFilter).ConfigureAwait(false);
             }
             catch (System.Data.Common.DbException)
             {
@@ -89,7 +103,7 @@ internal sealed class ContextTools
                 try
                 {
                     searchResults = await scope.Store.SearchSymbolsAsync(
-                        scope.RepoId, literalQuery, null, MaxSearchResults).ConfigureAwait(false);
+                        scope.RepoId, literalQuery, null, MaxSearchResults, validatedPathFilter).ConfigureAwait(false);
                 }
                 catch (System.Data.Common.DbException)
                 {
@@ -116,7 +130,7 @@ internal sealed class ContextTools
                     try
                     {
                         searchResults = await scope.Store.SearchSymbolsAsync(
-                            scope.RepoId, containsGlob.Fts5Query, null, MaxSearchResults, null, containsGlob.SqlLikePattern).ConfigureAwait(false);
+                            scope.RepoId, containsGlob.Fts5Query, null, MaxSearchResults, validatedPathFilter, containsGlob.SqlLikePattern).ConfigureAwait(false);
                     }
                     catch (System.Data.Common.DbException)
                     {

--- a/tests/CodeCompress.Core.Tests/Indexing/GitIgnoreFilterTests.cs
+++ b/tests/CodeCompress.Core.Tests/Indexing/GitIgnoreFilterTests.cs
@@ -1,0 +1,137 @@
+using CodeCompress.Core.Indexing;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace CodeCompress.Core.Tests.Indexing;
+
+internal sealed class GitIgnoreFilterTests
+{
+    private string _tempDir = null!;
+    private ILogger<GitIgnoreFilter> _logger = null!;
+    private GitIgnoreFilter _filter = null!;
+
+    [Before(Test)]
+    public void SetUp()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"GitIgnoreFilterTests_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _logger = Substitute.For<ILogger<GitIgnoreFilter>>();
+        _filter = new GitIgnoreFilter(_logger);
+    }
+
+    [After(Test)]
+    public void TearDown()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+    }
+
+    // ── Non-git directory fallback ────────────────────────────────────
+
+    [Test]
+    public async Task NonGitDirectoryReturnsEmptySet()
+    {
+        var paths = new List<string> { "src/Program.cs", "src/Models/User.cs" };
+
+        var result = await _filter.GetIgnoredPathsAsync(_tempDir, paths).ConfigureAwait(false);
+
+        await Assert.That(result).Count().IsEqualTo(0);
+    }
+
+    // ── Empty paths ──────────────────────────────────────────────────
+
+    [Test]
+    public async Task EmptyPathListReturnsEmptySet()
+    {
+        var result = await _filter.GetIgnoredPathsAsync(_tempDir, []).ConfigureAwait(false);
+
+        await Assert.That(result).Count().IsEqualTo(0);
+    }
+
+    // ── Real git repo — gitignore filtering ──────────────────────────
+
+    [Test]
+    public async Task GitRepoWithGitignoreFiltersIgnoredPaths()
+    {
+        await RunGitAsync(_tempDir, "init").ConfigureAwait(false);
+        await RunGitAsync(_tempDir, "config user.email test@test.com").ConfigureAwait(false);
+        await RunGitAsync(_tempDir, "config user.name Test").ConfigureAwait(false);
+
+        await File.WriteAllTextAsync(Path.Combine(_tempDir, ".gitignore"), "dist/\ncoverage/\n").ConfigureAwait(false);
+
+        CreateFile("src/Program.cs", "class Program {}");
+        CreateFile("dist/bundle.js", "var x = 1;");
+        CreateFile("coverage/report.html", "<html></html>");
+
+        var paths = new List<string> { "src/Program.cs", "dist/bundle.js", "coverage/report.html" };
+        var result = await _filter.GetIgnoredPathsAsync(_tempDir, paths).ConfigureAwait(false);
+
+        await Assert.That(result.Count).IsGreaterThanOrEqualTo(2);
+        await Assert.That(result).Contains(Path.Combine("dist", "bundle.js"));
+        await Assert.That(result).Contains(Path.Combine("coverage", "report.html"));
+        await Assert.That(result).DoesNotContain(Path.Combine("src", "Program.cs"));
+    }
+
+    [Test]
+    public async Task GitRepoWithNoGitignoreReturnsEmptySet()
+    {
+        await RunGitAsync(_tempDir, "init").ConfigureAwait(false);
+
+        CreateFile("src/Program.cs", "class Program {}");
+
+        var paths = new List<string> { "src/Program.cs" };
+        var result = await _filter.GetIgnoredPathsAsync(_tempDir, paths).ConfigureAwait(false);
+
+        await Assert.That(result).Count().IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task GitRepoWithNegationPatternIncludesNegatedFile()
+    {
+        await RunGitAsync(_tempDir, "init").ConfigureAwait(false);
+        await RunGitAsync(_tempDir, "config user.email test@test.com").ConfigureAwait(false);
+        await RunGitAsync(_tempDir, "config user.name Test").ConfigureAwait(false);
+
+        await File.WriteAllTextAsync(Path.Combine(_tempDir, ".gitignore"), "*.log\n!important.log\n").ConfigureAwait(false);
+
+        CreateFile("debug.log", "debug");
+        CreateFile("important.log", "important");
+        CreateFile("src/Program.cs", "class Program {}");
+
+        var paths = new List<string> { "debug.log", "important.log", "src/Program.cs" };
+        var result = await _filter.GetIgnoredPathsAsync(_tempDir, paths).ConfigureAwait(false);
+
+        await Assert.That(result).Contains("debug.log");
+        await Assert.That(result).DoesNotContain("important.log");
+        await Assert.That(result).DoesNotContain(Path.Combine("src", "Program.cs"));
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────
+
+    private void CreateFile(string relativePath, string content)
+    {
+        var fullPath = Path.Combine(_tempDir, relativePath);
+        var dir = Path.GetDirectoryName(fullPath)!;
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(fullPath, content);
+    }
+
+    private static async Task RunGitAsync(string workingDirectory, string arguments)
+    {
+        var psi = new System.Diagnostics.ProcessStartInfo
+        {
+            FileName = "git",
+            Arguments = arguments,
+            WorkingDirectory = workingDirectory,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+
+        using var process = System.Diagnostics.Process.Start(psi)!;
+        await process.WaitForExitAsync().ConfigureAwait(false);
+    }
+}

--- a/tests/CodeCompress.Core.Tests/Indexing/IndexEngineTests.cs
+++ b/tests/CodeCompress.Core.Tests/Indexing/IndexEngineTests.cs
@@ -16,6 +16,7 @@ internal sealed class IndexEngineTests
     private IChangeTracker _changeTracker = null!;
     private ISymbolStore _symbolStore = null!;
     private IPathValidator _pathValidator = null!;
+    private IGitIgnoreFilter _gitIgnoreFilter = null!;
     private ILogger<IndexEngine> _logger = null!;
     private StubLuauParser _luauParser = null!;
     private StubCSharpParser _csharpParser = null!;
@@ -31,7 +32,12 @@ internal sealed class IndexEngineTests
         _changeTracker = Substitute.For<IChangeTracker>();
         _symbolStore = Substitute.For<ISymbolStore>();
         _pathValidator = Substitute.For<IPathValidator>();
+        _gitIgnoreFilter = Substitute.For<IGitIgnoreFilter>();
         _logger = Substitute.For<ILogger<IndexEngine>>();
+
+        // Default: gitignore filter returns empty set (no files ignored)
+        _gitIgnoreFilter.GetIgnoredPathsAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>())
+            .Returns(new HashSet<string>());
         _luauParser = new StubLuauParser();
         _csharpParser = new StubCSharpParser();
 
@@ -54,6 +60,7 @@ internal sealed class IndexEngineTests
             new ILanguageParser[] { _luauParser, _csharpParser },
             _symbolStore,
             _pathValidator,
+            _gitIgnoreFilter,
             _logger);
     }
 

--- a/tests/CodeCompress.Core.Tests/Validation/PathValidatorTests.cs
+++ b/tests/CodeCompress.Core.Tests/Validation/PathValidatorTests.cs
@@ -351,10 +351,35 @@ internal sealed class PathValidatorTests
     }
 
     [Test]
-    public async Task ValidatePathFilterStripsLikeWildcards()
+    public async Task ValidatePathFilterEscapesLikeWildcards()
     {
         var result = PathValidator.ValidatePathFilter("src/%models_");
 
-        await Assert.That(result).IsEqualTo("src/models");
+        await Assert.That(result).IsEqualTo("src/!%models!_");
+    }
+
+    [Test]
+    public async Task ValidatePathFilterPreservesUnderscoresInPaths()
+    {
+        var result = PathValidator.ValidatePathFilter("src/my_module/sub_dir");
+
+        await Assert.That(result).IsEqualTo("src/my!_module/sub!_dir");
+    }
+
+    [Test]
+    public async Task ValidatePathFilterEscapesExclamationMark()
+    {
+        var result = PathValidator.ValidatePathFilter("src/important!/dir");
+
+        await Assert.That(result).IsEqualTo("src/important!!/dir");
+    }
+
+    [Test]
+    public async Task ValidatePathFilterEscapesAllSpecialCharsInOrder()
+    {
+        // ! must be escaped first, then % and _
+        var result = PathValidator.ValidatePathFilter("a!b%c_d");
+
+        await Assert.That(result).IsEqualTo("a!!b!%c!_d");
     }
 }

--- a/tests/CodeCompress.Integration.Tests/BlazorRazorEndToEndTests.cs
+++ b/tests/CodeCompress.Integration.Tests/BlazorRazorEndToEndTests.cs
@@ -5,6 +5,7 @@ using CodeCompress.Core.Storage;
 using CodeCompress.Core.Validation;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
 
 namespace CodeCompress.Integration.Tests;
 
@@ -13,6 +14,7 @@ internal sealed class BlazorRazorEndToEndTests : IDisposable
     private SqliteConnection _connection = null!;
     private SqliteSymbolStore _store = null!;
     private IndexEngine _engine = null!;
+    private IGitIgnoreFilter _gitIgnoreFilter = null!;
     private string _sampleProjectPath = null!;
     private string _repoId = null!;
 
@@ -35,6 +37,8 @@ internal sealed class BlazorRazorEndToEndTests : IDisposable
         var fileHasher = new FileHasher();
         var changeTracker = new ChangeTracker();
         var pathValidator = new PathValidatorService();
+        _gitIgnoreFilter = Substitute.For<IGitIgnoreFilter>();
+        _gitIgnoreFilter.GetIgnoredPathsAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns(new HashSet<string>());
 
         _engine = new IndexEngine(
             fileHasher,
@@ -42,6 +46,7 @@ internal sealed class BlazorRazorEndToEndTests : IDisposable
             parsers,
             _store,
             pathValidator,
+            _gitIgnoreFilter,
             NullLogger<IndexEngine>.Instance);
 
         _sampleProjectPath = FindBlazorRazorSampleProjectPath();

--- a/tests/CodeCompress.Integration.Tests/CSharpEndToEndTests.cs
+++ b/tests/CodeCompress.Integration.Tests/CSharpEndToEndTests.cs
@@ -5,6 +5,7 @@ using CodeCompress.Core.Storage;
 using CodeCompress.Core.Validation;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
 
 namespace CodeCompress.Integration.Tests;
 
@@ -13,6 +14,7 @@ internal sealed class CSharpEndToEndTests : IDisposable
     private SqliteConnection _connection = null!;
     private SqliteSymbolStore _store = null!;
     private IndexEngine _engine = null!;
+    private IGitIgnoreFilter _gitIgnoreFilter = null!;
     private string _sampleProjectPath = null!;
     private string _repoId = null!;
 
@@ -35,6 +37,8 @@ internal sealed class CSharpEndToEndTests : IDisposable
         var fileHasher = new FileHasher();
         var changeTracker = new ChangeTracker();
         var pathValidator = new PathValidatorService();
+        _gitIgnoreFilter = Substitute.For<IGitIgnoreFilter>();
+        _gitIgnoreFilter.GetIgnoredPathsAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns(new HashSet<string>());
 
         _engine = new IndexEngine(
             fileHasher,
@@ -42,6 +46,7 @@ internal sealed class CSharpEndToEndTests : IDisposable
             parsers,
             _store,
             pathValidator,
+            _gitIgnoreFilter,
             NullLogger<IndexEngine>.Instance);
 
         _sampleProjectPath = FindCSharpSampleProjectPath();

--- a/tests/CodeCompress.Integration.Tests/CodeCompress.Integration.Tests.csproj
+++ b/tests/CodeCompress.Integration.Tests/CodeCompress.Integration.Tests.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite" />
+    <PackageReference Include="NSubstitute" />
     <PackageReference Include="TUnit" />
   </ItemGroup>
 

--- a/tests/CodeCompress.Integration.Tests/EndToEndTests.cs
+++ b/tests/CodeCompress.Integration.Tests/EndToEndTests.cs
@@ -5,6 +5,7 @@ using CodeCompress.Core.Storage;
 using CodeCompress.Core.Validation;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
 
 namespace CodeCompress.Integration.Tests;
 
@@ -13,6 +14,7 @@ internal sealed class EndToEndTests : IDisposable
     private SqliteConnection _connection = null!;
     private SqliteSymbolStore _store = null!;
     private IndexEngine _engine = null!;
+    private IGitIgnoreFilter _gitIgnoreFilter = null!;
     private string _sampleProjectPath = null!;
     private string _repoId = null!;
 
@@ -35,6 +37,8 @@ internal sealed class EndToEndTests : IDisposable
         var fileHasher = new FileHasher();
         var changeTracker = new ChangeTracker();
         var pathValidator = new PathValidatorService();
+        _gitIgnoreFilter = Substitute.For<IGitIgnoreFilter>();
+        _gitIgnoreFilter.GetIgnoredPathsAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns(new HashSet<string>());
 
         _engine = new IndexEngine(
             fileHasher,
@@ -42,6 +46,7 @@ internal sealed class EndToEndTests : IDisposable
             parsers,
             _store,
             pathValidator,
+            _gitIgnoreFilter,
             NullLogger<IndexEngine>.Instance);
 
         _sampleProjectPath = FindSampleProjectPath();
@@ -230,6 +235,7 @@ internal sealed class EndToEndTests : IDisposable
                     new ILanguageParser[] { new LuauParser() },
                     tempStore,
                     new PathValidatorService(),
+                    _gitIgnoreFilter,
                     NullLogger<IndexEngine>.Instance);
 
                 var tempRepoId = IndexEngine.ComputeRepoId(Path.GetFullPath(tempDir));

--- a/tests/CodeCompress.Integration.Tests/GoEndToEndTests.cs
+++ b/tests/CodeCompress.Integration.Tests/GoEndToEndTests.cs
@@ -5,6 +5,7 @@ using CodeCompress.Core.Storage;
 using CodeCompress.Core.Validation;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
 
 namespace CodeCompress.Integration.Tests;
 
@@ -13,6 +14,7 @@ internal sealed class GoEndToEndTests : IDisposable
     private SqliteConnection _connection = null!;
     private SqliteSymbolStore _store = null!;
     private IndexEngine _engine = null!;
+    private IGitIgnoreFilter _gitIgnoreFilter = null!;
     private string _sampleProjectPath = null!;
     private string _repoId = null!;
 
@@ -35,6 +37,8 @@ internal sealed class GoEndToEndTests : IDisposable
         var fileHasher = new FileHasher();
         var changeTracker = new ChangeTracker();
         var pathValidator = new PathValidatorService();
+        _gitIgnoreFilter = Substitute.For<IGitIgnoreFilter>();
+        _gitIgnoreFilter.GetIgnoredPathsAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns(new HashSet<string>());
 
         _engine = new IndexEngine(
             fileHasher,
@@ -42,6 +46,7 @@ internal sealed class GoEndToEndTests : IDisposable
             parsers,
             _store,
             pathValidator,
+            _gitIgnoreFilter,
             NullLogger<IndexEngine>.Instance);
 
         _sampleProjectPath = FindGoSampleProjectPath();

--- a/tests/CodeCompress.Integration.Tests/JavaEndToEndTests.cs
+++ b/tests/CodeCompress.Integration.Tests/JavaEndToEndTests.cs
@@ -5,6 +5,7 @@ using CodeCompress.Core.Storage;
 using CodeCompress.Core.Validation;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
 
 namespace CodeCompress.Integration.Tests;
 
@@ -13,6 +14,7 @@ internal sealed class JavaEndToEndTests : IDisposable
     private SqliteConnection _connection = null!;
     private SqliteSymbolStore _store = null!;
     private IndexEngine _engine = null!;
+    private IGitIgnoreFilter _gitIgnoreFilter = null!;
     private string _sampleProjectPath = null!;
     private string _repoId = null!;
 
@@ -35,6 +37,8 @@ internal sealed class JavaEndToEndTests : IDisposable
         var fileHasher = new FileHasher();
         var changeTracker = new ChangeTracker();
         var pathValidator = new PathValidatorService();
+        _gitIgnoreFilter = Substitute.For<IGitIgnoreFilter>();
+        _gitIgnoreFilter.GetIgnoredPathsAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns(new HashSet<string>());
 
         _engine = new IndexEngine(
             fileHasher,
@@ -42,6 +46,7 @@ internal sealed class JavaEndToEndTests : IDisposable
             parsers,
             _store,
             pathValidator,
+            _gitIgnoreFilter,
             NullLogger<IndexEngine>.Instance);
 
         _sampleProjectPath = FindJavaSampleProjectPath();

--- a/tests/CodeCompress.Integration.Tests/JsonConfigEndToEndTests.cs
+++ b/tests/CodeCompress.Integration.Tests/JsonConfigEndToEndTests.cs
@@ -5,6 +5,7 @@ using CodeCompress.Core.Storage;
 using CodeCompress.Core.Validation;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
 
 namespace CodeCompress.Integration.Tests;
 
@@ -13,6 +14,7 @@ internal sealed class JsonConfigEndToEndTests : IDisposable
     private SqliteConnection _connection = null!;
     private SqliteSymbolStore _store = null!;
     private IndexEngine _engine = null!;
+    private IGitIgnoreFilter _gitIgnoreFilter = null!;
     private string _sampleProjectPath = null!;
     private string _repoId = null!;
 
@@ -35,6 +37,8 @@ internal sealed class JsonConfigEndToEndTests : IDisposable
         var fileHasher = new FileHasher();
         var changeTracker = new ChangeTracker();
         var pathValidator = new PathValidatorService();
+        _gitIgnoreFilter = Substitute.For<IGitIgnoreFilter>();
+        _gitIgnoreFilter.GetIgnoredPathsAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns(new HashSet<string>());
 
         _engine = new IndexEngine(
             fileHasher,
@@ -42,6 +46,7 @@ internal sealed class JsonConfigEndToEndTests : IDisposable
             parsers,
             _store,
             pathValidator,
+            _gitIgnoreFilter,
             NullLogger<IndexEngine>.Instance);
 
         _sampleProjectPath = FindJsonConfigSampleProjectPath();

--- a/tests/CodeCompress.Integration.Tests/MixedLanguageTests.cs
+++ b/tests/CodeCompress.Integration.Tests/MixedLanguageTests.cs
@@ -5,6 +5,7 @@ using CodeCompress.Core.Storage;
 using CodeCompress.Core.Validation;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
 
 namespace CodeCompress.Integration.Tests;
 
@@ -13,6 +14,7 @@ internal sealed class MixedLanguageTests : IDisposable
     private SqliteConnection _connection = null!;
     private SqliteSymbolStore _store = null!;
     private IndexEngine _engine = null!;
+    private IGitIgnoreFilter _gitIgnoreFilter = null!;
     private string _tempDir = null!;
     private string _repoId = null!;
 
@@ -36,6 +38,8 @@ internal sealed class MixedLanguageTests : IDisposable
         var fileHasher = new FileHasher();
         var changeTracker = new ChangeTracker();
         var pathValidator = new PathValidatorService();
+        _gitIgnoreFilter = Substitute.For<IGitIgnoreFilter>();
+        _gitIgnoreFilter.GetIgnoredPathsAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns(new HashSet<string>());
 
         _engine = new IndexEngine(
             fileHasher,
@@ -43,6 +47,7 @@ internal sealed class MixedLanguageTests : IDisposable
             parsers,
             _store,
             pathValidator,
+            _gitIgnoreFilter,
             NullLogger<IndexEngine>.Instance);
 
         _tempDir = Path.Combine(Path.GetTempPath(), $"codecompress-mixed-{Guid.NewGuid():N}");

--- a/tests/CodeCompress.Integration.Tests/ProjectDependencyGraphTests.cs
+++ b/tests/CodeCompress.Integration.Tests/ProjectDependencyGraphTests.cs
@@ -5,6 +5,7 @@ using CodeCompress.Core.Storage;
 using CodeCompress.Core.Validation;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
 
 namespace CodeCompress.Integration.Tests;
 
@@ -13,6 +14,7 @@ internal sealed class ProjectDependencyGraphTests : IDisposable
     private SqliteConnection _connection = null!;
     private SqliteSymbolStore _store = null!;
     private IndexEngine _engine = null!;
+    private IGitIgnoreFilter _gitIgnoreFilter = null!;
     private string _tempDir = null!;
     private string _repoId = null!;
 
@@ -41,6 +43,8 @@ internal sealed class ProjectDependencyGraphTests : IDisposable
         var fileHasher = new FileHasher();
         var changeTracker = new ChangeTracker();
         var pathValidator = new PathValidatorService();
+        _gitIgnoreFilter = Substitute.For<IGitIgnoreFilter>();
+        _gitIgnoreFilter.GetIgnoredPathsAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns(new HashSet<string>());
 
         _engine = new IndexEngine(
             fileHasher,
@@ -48,6 +52,7 @@ internal sealed class ProjectDependencyGraphTests : IDisposable
             parsers,
             _store,
             pathValidator,
+            _gitIgnoreFilter,
             NullLogger<IndexEngine>.Instance);
 
         _tempDir = Path.Combine(Path.GetTempPath(), "codecompress-test-" + Guid.NewGuid().ToString("N")[..8]);

--- a/tests/CodeCompress.Integration.Tests/PythonEndToEndTests.cs
+++ b/tests/CodeCompress.Integration.Tests/PythonEndToEndTests.cs
@@ -5,6 +5,7 @@ using CodeCompress.Core.Storage;
 using CodeCompress.Core.Validation;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
 
 namespace CodeCompress.Integration.Tests;
 
@@ -13,6 +14,7 @@ internal sealed class PythonEndToEndTests : IDisposable
     private SqliteConnection _connection = null!;
     private SqliteSymbolStore _store = null!;
     private IndexEngine _engine = null!;
+    private IGitIgnoreFilter _gitIgnoreFilter = null!;
     private string _sampleProjectPath = null!;
     private string _repoId = null!;
 
@@ -27,8 +29,10 @@ internal sealed class PythonEndToEndTests : IDisposable
         _store = new SqliteSymbolStore(_connection);
 
         var parsers = new ILanguageParser[] { new PythonParser() };
+        _gitIgnoreFilter = Substitute.For<IGitIgnoreFilter>();
+        _gitIgnoreFilter.GetIgnoredPathsAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns(new HashSet<string>());
         _engine = new IndexEngine(new FileHasher(), new ChangeTracker(), parsers, _store,
-            new PathValidatorService(), NullLogger<IndexEngine>.Instance);
+            new PathValidatorService(), _gitIgnoreFilter, NullLogger<IndexEngine>.Instance);
 
         _sampleProjectPath = FindSamplePath();
         _repoId = IndexEngine.ComputeRepoId(Path.GetFullPath(_sampleProjectPath));

--- a/tests/CodeCompress.Integration.Tests/RustEndToEndTests.cs
+++ b/tests/CodeCompress.Integration.Tests/RustEndToEndTests.cs
@@ -5,6 +5,7 @@ using CodeCompress.Core.Storage;
 using CodeCompress.Core.Validation;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
 
 namespace CodeCompress.Integration.Tests;
 
@@ -13,6 +14,7 @@ internal sealed class RustEndToEndTests : IDisposable
     private SqliteConnection _connection = null!;
     private SqliteSymbolStore _store = null!;
     private IndexEngine _engine = null!;
+    private IGitIgnoreFilter _gitIgnoreFilter = null!;
     private string _sampleProjectPath = null!;
     private string _repoId = null!;
 
@@ -27,8 +29,10 @@ internal sealed class RustEndToEndTests : IDisposable
         _store = new SqliteSymbolStore(_connection);
 
         var parsers = new ILanguageParser[] { new RustParser() };
+        _gitIgnoreFilter = Substitute.For<IGitIgnoreFilter>();
+        _gitIgnoreFilter.GetIgnoredPathsAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns(new HashSet<string>());
         _engine = new IndexEngine(new FileHasher(), new ChangeTracker(), parsers, _store,
-            new PathValidatorService(), NullLogger<IndexEngine>.Instance);
+            new PathValidatorService(), _gitIgnoreFilter, NullLogger<IndexEngine>.Instance);
 
         _sampleProjectPath = FindSamplePath();
         _repoId = IndexEngine.ComputeRepoId(Path.GetFullPath(_sampleProjectPath));

--- a/tests/CodeCompress.Integration.Tests/TerraformEndToEndTests.cs
+++ b/tests/CodeCompress.Integration.Tests/TerraformEndToEndTests.cs
@@ -5,6 +5,7 @@ using CodeCompress.Core.Storage;
 using CodeCompress.Core.Validation;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
 
 namespace CodeCompress.Integration.Tests;
 
@@ -13,6 +14,7 @@ internal sealed class TerraformEndToEndTests : IDisposable
     private SqliteConnection _connection = null!;
     private SqliteSymbolStore _store = null!;
     private IndexEngine _engine = null!;
+    private IGitIgnoreFilter _gitIgnoreFilter = null!;
     private string _sampleProjectPath = null!;
     private string _repoId = null!;
 
@@ -35,6 +37,8 @@ internal sealed class TerraformEndToEndTests : IDisposable
         var fileHasher = new FileHasher();
         var changeTracker = new ChangeTracker();
         var pathValidator = new PathValidatorService();
+        _gitIgnoreFilter = Substitute.For<IGitIgnoreFilter>();
+        _gitIgnoreFilter.GetIgnoredPathsAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns(new HashSet<string>());
 
         _engine = new IndexEngine(
             fileHasher,
@@ -42,6 +46,7 @@ internal sealed class TerraformEndToEndTests : IDisposable
             parsers,
             _store,
             pathValidator,
+            _gitIgnoreFilter,
             NullLogger<IndexEngine>.Instance);
 
         _sampleProjectPath = FindTerraformSampleProjectPath();

--- a/tests/CodeCompress.Integration.Tests/TypeScriptJavaScriptEndToEndTests.cs
+++ b/tests/CodeCompress.Integration.Tests/TypeScriptJavaScriptEndToEndTests.cs
@@ -5,6 +5,7 @@ using CodeCompress.Core.Storage;
 using CodeCompress.Core.Validation;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
 
 namespace CodeCompress.Integration.Tests;
 
@@ -13,6 +14,7 @@ internal sealed class TypeScriptJavaScriptEndToEndTests : IDisposable
     private SqliteConnection _connection = null!;
     private SqliteSymbolStore _store = null!;
     private IndexEngine _engine = null!;
+    private IGitIgnoreFilter _gitIgnoreFilter = null!;
     private string _sampleProjectPath = null!;
     private string _repoId = null!;
 
@@ -34,10 +36,12 @@ internal sealed class TypeScriptJavaScriptEndToEndTests : IDisposable
         var fileHasher = new FileHasher();
         var changeTracker = new ChangeTracker();
         var pathValidator = new PathValidatorService();
+        _gitIgnoreFilter = Substitute.For<IGitIgnoreFilter>();
+        _gitIgnoreFilter.GetIgnoredPathsAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns(new HashSet<string>());
 
         _engine = new IndexEngine(
             fileHasher, changeTracker, parsers, _store, pathValidator,
-            NullLogger<IndexEngine>.Instance);
+            _gitIgnoreFilter, NullLogger<IndexEngine>.Instance);
 
         _sampleProjectPath = FindSampleProjectPath();
         _repoId = IndexEngine.ComputeRepoId(Path.GetFullPath(_sampleProjectPath));

--- a/tests/CodeCompress.Integration.Tests/YamlConfigEndToEndTests.cs
+++ b/tests/CodeCompress.Integration.Tests/YamlConfigEndToEndTests.cs
@@ -5,6 +5,7 @@ using CodeCompress.Core.Storage;
 using CodeCompress.Core.Validation;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
 
 namespace CodeCompress.Integration.Tests;
 
@@ -13,6 +14,7 @@ internal sealed class YamlConfigEndToEndTests : IDisposable
     private SqliteConnection _connection = null!;
     private SqliteSymbolStore _store = null!;
     private IndexEngine _engine = null!;
+    private IGitIgnoreFilter _gitIgnoreFilter = null!;
     private string _sampleProjectPath = null!;
     private string _repoId = null!;
 
@@ -35,6 +37,8 @@ internal sealed class YamlConfigEndToEndTests : IDisposable
         var fileHasher = new FileHasher();
         var changeTracker = new ChangeTracker();
         var pathValidator = new PathValidatorService();
+        _gitIgnoreFilter = Substitute.For<IGitIgnoreFilter>();
+        _gitIgnoreFilter.GetIgnoredPathsAsync(Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>()).Returns(new HashSet<string>());
 
         _engine = new IndexEngine(
             fileHasher,
@@ -42,6 +46,7 @@ internal sealed class YamlConfigEndToEndTests : IDisposable
             parsers,
             _store,
             pathValidator,
+            _gitIgnoreFilter,
             NullLogger<IndexEngine>.Instance);
 
         _sampleProjectPath = FindYamlConfigSampleProjectPath();

--- a/tests/CodeCompress.Server.Tests/Tools/ContextToolsTests.cs
+++ b/tests/CodeCompress.Server.Tests/Tools/ContextToolsTests.cs
@@ -311,6 +311,103 @@ internal sealed class ContextToolsTests
         await Assert.That(result).Contains("TenantFilter.cs");
     }
 
+    // ── pathFilter ────────────────────────────────────────────────────
+
+    [Test]
+    public async Task PathFilterScopesResultsToMatchingDirectory()
+    {
+        var srcSymbol = new SymbolSearchResult(
+            CreateSymbol(1, 1, "UserService", "Class", "public class UserService"), "src/Services/UserService.cs", 1.0);
+
+        // When pathFilter is provided, SearchSymbolsAsync receives the validated filter
+        _store.SearchSymbolsAsync("test-repo-id", Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<int>(), Arg.Is<string?>(p => p != null), Arg.Any<string?>())
+            .Returns(new List<SymbolSearchResult> { srcSymbol });
+        _store.GetFilesByRepoAsync("test-repo-id")
+            .Returns(new List<FileRecord>
+            {
+                new(1, "test-repo-id", "src/Services/UserService.cs", "hash1", 500, 20, 1000, 2000),
+                new(2, "test-repo-id", "tests/UserServiceTests.cs", "hash2", 300, 10, 1000, 2000),
+            });
+
+        var result = await _tools.AssembleContext("/valid/path", "UserService", pathFilter: "src/").ConfigureAwait(false);
+
+        await Assert.That(result).Contains("UserService.cs");
+        await Assert.That(result).DoesNotContain("UserServiceTests.cs");
+    }
+
+    [Test]
+    public async Task NullPathFilterPreservesExistingBehavior()
+    {
+        var searchResults = new List<SymbolSearchResult>
+        {
+            new(CreateSymbol(1, 1, "PathValidator", "Class", "public class PathValidator"), "src/Validation/PathValidator.cs", 1.0),
+        };
+
+        // When pathFilter is null, SearchSymbolsAsync receives null for pathFilter
+        _store.SearchSymbolsAsync("test-repo-id", Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<int>(), Arg.Is<string?>(p => p == null), Arg.Any<string?>())
+            .Returns(searchResults);
+        _store.GetFilesByRepoAsync("test-repo-id")
+            .Returns(new List<FileRecord>
+            {
+                new(1, "test-repo-id", "src/Validation/PathValidator.cs", "hash1", 500, 20, 1000, 2000),
+            });
+
+        var result = await _tools.AssembleContext("/valid/path", "PathValidator").ConfigureAwait(false);
+
+        await Assert.That(result).Contains("## File Overview");
+        await Assert.That(result).Contains("PathValidator.cs");
+    }
+
+    [Test]
+    [Arguments("../escape")]
+    [Arguments("/etc/passwd")]
+    [Arguments("src/../../etc")]
+    public async Task InvalidPathFilterReturnsStructuredError(string badFilter)
+    {
+        var result = await _tools.AssembleContext("/valid/path", "query", pathFilter: badFilter).ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        await Assert.That(doc.RootElement.GetProperty("code").GetString()).IsEqualTo("INVALID_PATH_FILTER");
+    }
+
+    [Test]
+    public async Task PathFilterAppliesToContainsMatchFallback()
+    {
+        var searchResults = new List<SymbolSearchResult>
+        {
+            new(CreateSymbol(1, 1, "TenantFilter", "Class", "public class TenantFilter"), "src/Data/TenantFilter.cs", 1.0),
+        };
+
+        // First call (OR query, with pathFilter) returns empty
+        _store.SearchSymbolsAsync("test-repo-id", Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<int>(), Arg.Is<string?>(p => p != null), Arg.Is<string?>(p => p == null))
+            .Returns(new List<SymbolSearchResult>());
+
+        // Contains-match fallback also receives pathFilter
+        _store.SearchSymbolsAsync("test-repo-id", Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<int>(), Arg.Is<string?>(p => p != null), Arg.Is<string?>(p => p != null))
+            .Returns(searchResults);
+        _store.GetFilesByRepoAsync("test-repo-id")
+            .Returns(new List<FileRecord>
+            {
+                new(1, "test-repo-id", "src/Data/TenantFilter.cs", "hash1", 500, 20, 1000, 2000),
+            });
+
+        var result = await _tools.AssembleContext("/valid/path", "filter tenant", pathFilter: "src/").ConfigureAwait(false);
+
+        await Assert.That(result).Contains("TenantFilter.cs");
+    }
+
+    [Test]
+    public async Task PathFilterWithNoMatchesReturnsZeroResultResponse()
+    {
+        _store.SearchSymbolsAsync("test-repo-id", Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>())
+            .Returns(new List<SymbolSearchResult>());
+
+        var result = await _tools.AssembleContext("/valid/path", "UserService", pathFilter: "nonexistent/").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        await Assert.That(doc.RootElement.GetProperty("total_matches").GetInt32()).IsEqualTo(0);
+    }
+
     // ── Helpers ────────────────────────────────────────────────────────
 
     private static Symbol CreateSymbol(

--- a/tests/CodeCompress.Server.Tests/Tools/ContextToolsTests.cs
+++ b/tests/CodeCompress.Server.Tests/Tools/ContextToolsTests.cs
@@ -226,6 +226,91 @@ internal sealed class ContextToolsTests
         await Assert.That(result).Contains("PathValidator.cs");
     }
 
+    // ── FTS5 error handling ─────────────────────────────────────────────
+
+    [Test]
+    public async Task PrimarySearchDbExceptionRetriesWithLiteralPhrase()
+    {
+        var callCount = 0;
+        var searchResults = new List<SymbolSearchResult>
+        {
+            new(CreateSymbol(1, 1, "PathValidator", "Class", "public class PathValidator"), "src/Validation/PathValidator.cs", 1.0),
+        };
+
+        _store.SearchSymbolsAsync("test-repo-id", Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>())
+            .Returns(callInfo =>
+            {
+                callCount++;
+                if (callCount == 1)
+                {
+                    throw new Microsoft.Data.Sqlite.SqliteException("fts5: syntax error", 1);
+                }
+
+                return searchResults;
+            });
+        _store.GetFilesByRepoAsync("test-repo-id")
+            .Returns(new List<FileRecord>
+            {
+                new(1, "test-repo-id", "src/Validation/PathValidator.cs", "hash1", 500, 20, 1000, 2000),
+            });
+
+        var result = await _tools.AssembleContext("/valid/path", "Program.cs host config").ConfigureAwait(false);
+
+        // Should succeed via literal phrase retry, not throw
+        await Assert.That(result).Contains("## File Overview");
+        await Assert.That(result).Contains("PathValidator.cs");
+    }
+
+    [Test]
+    public async Task PrimarySearchDbExceptionBothAttemptsFailReturnsStructuredError()
+    {
+        _store.SearchSymbolsAsync("test-repo-id", Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<string?>())
+            .Throws(new Microsoft.Data.Sqlite.SqliteException("fts5: syntax error", 1));
+
+        var result = await _tools.AssembleContext("/valid/path", "broken OR query").ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        await Assert.That(doc.RootElement.GetProperty("error").GetString()).Contains("FTS5");
+        await Assert.That(doc.RootElement.GetProperty("code").GetString()).IsEqualTo("FTS5_QUERY_ERROR");
+    }
+
+    [Test]
+    public async Task ContainsMatchFallbackDbExceptionSkipsTermAndContinues()
+    {
+        var callCount = 0;
+        var searchResults = new List<SymbolSearchResult>
+        {
+            new(CreateSymbol(1, 1, "TenantFilter", "Class", "public class TenantFilter"), "src/Data/TenantFilter.cs", 1.0),
+        };
+
+        _store.SearchSymbolsAsync("test-repo-id", Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Is<string?>(p => p == null))
+            .Returns(new List<SymbolSearchResult>());
+
+        _store.SearchSymbolsAsync("test-repo-id", Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<int>(), Arg.Any<string?>(), Arg.Is<string?>(p => p != null))
+            .Returns(callInfo =>
+            {
+                callCount++;
+                if (callCount == 1)
+                {
+                    // First contains-match term fails
+                    throw new Microsoft.Data.Sqlite.SqliteException("fts5: syntax error", 1);
+                }
+
+                // Second term succeeds
+                return searchResults;
+            });
+        _store.GetFilesByRepoAsync("test-repo-id")
+            .Returns(new List<FileRecord>
+            {
+                new(1, "test-repo-id", "src/Data/TenantFilter.cs", "hash1", 500, 20, 1000, 2000),
+            });
+
+        var result = await _tools.AssembleContext("/valid/path", "broken filter tenant").ConfigureAwait(false);
+
+        // Should succeed — skipped the broken term, found results on the next term
+        await Assert.That(result).Contains("TenantFilter.cs");
+    }
+
     // ── Helpers ────────────────────────────────────────────────────────
 
     private static Symbol CreateSymbol(


### PR DESCRIPTION
## Release v0.14.0

### Added
- `pathFilter` parameter on `assemble_context` — scopes assembled context to a specific directory prefix (e.g., `src/`), matching the existing pattern from `search_symbols` and `project_outline`. Applies to both MCP Server and CLI (#169)
- `.gitignore` support during file discovery — `IndexEngine` now automatically excludes files matching `.gitignore` rules via `git check-ignore`. Hardcoded exclusions remain as baseline. Falls back gracefully when git is not installed or directory is not a git repo (#170)

### Fixed
- `assemble_context` now catches FTS5 query errors instead of returning a generic "An error occurred" message — retries with literal phrase, returns structured `FTS5_QUERY_ERROR` JSON on failure. Same fix applied to CLI `search-symbols` and `assemble` commands (#168)
- `ValidatePathFilter` now LIKE-escapes `%`, `_`, and `!` characters instead of stripping them, fixing corruption of legitimate paths containing underscores (e.g., `src/my_module/` was silently mangled to `src/mymodule/`). Also adds missing `ESCAPE '!'` clause to `GetProjectOutlineAsync` (#173)

---
**Release type:** minor
**Previous version:** v0.13.0