### PR TITLE
feat: typed dependency edges, blast_radius, and find_unused_symbols (#178)

### DIFF
--- a/src/CodeCompress.Cli/Program.cs
+++ b/src/CodeCompress.Cli/Program.cs
@@ -580,6 +580,7 @@ var depsPathOption = CreatePathOption();
 var depsFileOption = new Option<string?>("--file") { Description = "Start from a specific file (relative path)" };
 var depsDirectionOption = new Option<string>("--direction") { Description = "Traversal direction. Allowed values: 'dependencies' (outgoing), 'dependents' (incoming), 'both' (default). Other values rejected.", DefaultValueFactory = _ => "both" };
 var depsDepthOption = new Option<int>("--depth") { Description = "Maximum traversal depth (1-50, default 3). Values outside range are clamped.", DefaultValueFactory = _ => 3 };
+var depsEdgeKindOption = new Option<string?>("--edge-kind") { Description = "Filter edges by kind: imports, calls, implements, inherits, references. Omit for all." };
 
 var depsCommand = new Command("deps",
     "Show the import/require dependency graph. " +
@@ -589,6 +590,7 @@ var depsCommand = new Command("deps",
     depsFileOption,
     depsDirectionOption,
     depsDepthOption,
+    depsEdgeKindOption,
 };
 
 depsCommand.SetAction(async parseResult =>
@@ -597,12 +599,13 @@ depsCommand.SetAction(async parseResult =>
     var rootFile = parseResult.GetValue(depsFileOption) is { } rf ? PathValidator.NormalizeRelativePath(rf) : null;
     var direction = parseResult.GetValue(depsDirectionOption)!;
     var depth = Math.Clamp(parseResult.GetValue(depsDepthOption), 1, 50);
+    var edgeKind = parseResult.GetValue(depsEdgeKindOption);
     var json = parseResult.GetValue(jsonOption);
 
     var scope = await CreateProjectScopeAsync(path, provider).ConfigureAwait(false);
     await using (scope.ConfigureAwait(false))
     {
-        var graph = await scope.Store.GetDependencyGraphAsync(scope.RepoId, rootFile, direction, depth).ConfigureAwait(false);
+        var graph = await scope.Store.GetDependencyGraphAsync(scope.RepoId, rootFile, direction, depth, edgeKind).ConfigureAwait(false);
 
         if (json)
         {
@@ -610,16 +613,112 @@ depsCommand.SetAction(async parseResult =>
         }
         else
         {
-            Console.WriteLine($"Dependency graph ({graph.Nodes.Count} nodes, {graph.Edges.Count} edges):");
+            var kindSuffix = edgeKind is not null ? $" [{edgeKind}]" : string.Empty;
+            Console.WriteLine($"Dependency graph ({graph.Nodes.Count} nodes, {graph.Edges.Count} edges{kindSuffix}):");
             foreach (var edge in graph.Edges)
             {
-                Console.WriteLine($"  {edge.From} → {edge.To}" + (edge.Alias is not null ? $" (alias: {edge.Alias})" : ""));
+                var edgeLabel = edge.EdgeKind is not null ? $" [{edge.EdgeKind}]" : string.Empty;
+                Console.WriteLine($"  {edge.From} → {edge.To}{edgeLabel}" + (edge.Alias is not null ? $" (alias: {edge.Alias})" : ""));
             }
         }
     }
 });
 
 rootCommand.Subcommands.Add(depsCommand);
+
+// ── blast-radius ─────────────────────────────────────────────
+
+var blastRadiusPathOption = CreatePathOption();
+var blastRadiusFileOption = new Option<string?>("--file") { Description = "Relative path to the file to analyze" };
+var blastRadiusSymbolOption = new Option<string?>("--symbol") { Description = "Symbol name to analyze (alternative to --file)" };
+var blastRadiusMaxDepthOption = new Option<int>("--max-depth") { Description = "Maximum BFS depth (1-20, default 5). Values outside range are clamped.", DefaultValueFactory = _ => 5 };
+
+var blastRadiusCommand = new Command("blast-radius",
+    "Find all files affected if a given file or symbol changes. " +
+    "Performs reverse BFS over dependency edges. Requires index.")
+{
+    blastRadiusPathOption,
+    blastRadiusFileOption,
+    blastRadiusSymbolOption,
+    blastRadiusMaxDepthOption,
+};
+
+blastRadiusCommand.SetAction(async parseResult =>
+{
+    var path = parseResult.GetValue(blastRadiusPathOption)!;
+    var filePath = parseResult.GetValue(blastRadiusFileOption) is { } fp ? PathValidator.NormalizeRelativePath(fp) : null;
+    var symbolName = parseResult.GetValue(blastRadiusSymbolOption);
+    var maxDepth = Math.Clamp(parseResult.GetValue(blastRadiusMaxDepthOption), 1, 20);
+    var json = parseResult.GetValue(jsonOption);
+
+    var scope = await CreateProjectScopeAsync(path, provider).ConfigureAwait(false);
+    await using (scope.ConfigureAwait(false))
+    {
+        var result = await scope.Store.GetBlastRadiusAsync(scope.RepoId, filePath, symbolName, maxDepth).ConfigureAwait(false);
+
+        if (json)
+        {
+            Console.WriteLine(JsonSerializer.Serialize(result, jsonSerializerOptions));
+        }
+        else
+        {
+            Console.WriteLine($"Blast radius: {result.TotalAffected} file(s) affected");
+            foreach (var depth in result.Depths)
+            {
+                Console.WriteLine($"  Depth {depth.Depth}: {string.Join(", ", depth.Files)}");
+            }
+        }
+    }
+});
+
+rootCommand.Subcommands.Add(blastRadiusCommand);
+
+// ── unused-symbols ──────────────────────────────────────────
+
+var unusedPathOption = CreatePathOption();
+var unusedLimitOption = new Option<int>("--limit") { Description = "Maximum results to return (1-500, default 100). Values outside range are clamped.", DefaultValueFactory = _ => 100 };
+
+var unusedCommand = new Command("unused-symbols",
+    "Find public symbols with no incoming dependency edges (best-effort dead code detection). " +
+    "Excludes test files, Main entry point, and HTTP controller actions. Requires index.")
+{
+    unusedPathOption,
+    unusedLimitOption,
+};
+
+unusedCommand.SetAction(async parseResult =>
+{
+    var path = parseResult.GetValue(unusedPathOption)!;
+    var limit = Math.Clamp(parseResult.GetValue(unusedLimitOption), 1, 500);
+    var json = parseResult.GetValue(jsonOption);
+
+    var scope = await CreateProjectScopeAsync(path, provider).ConfigureAwait(false);
+    await using (scope.ConfigureAwait(false))
+    {
+        var results = await scope.Store.FindUnusedSymbolsAsync(scope.RepoId, limit).ConfigureAwait(false);
+
+        if (json)
+        {
+            Console.WriteLine(JsonSerializer.Serialize(results, jsonSerializerOptions));
+        }
+        else
+        {
+            if (results.Count == 0)
+            {
+                Console.WriteLine("No potentially unused public symbols found.");
+                return;
+            }
+
+            Console.WriteLine($"Found {results.Count} potentially unused public symbol(s):");
+            foreach (var s in results)
+            {
+                Console.WriteLine($"  {s.Kind,-12} {s.Name,-30} {s.Signature}");
+            }
+        }
+    }
+});
+
+rootCommand.Subcommands.Add(unusedCommand);
 
 // ── invalidate-cache ────────────────────────────────────────
 
@@ -1407,7 +1506,12 @@ agentInstructionsCommand.SetAction(_ =>
         7. `codecompress search-text --path <project-root> --query <term>` — Search raw file contents
            for string literals, comments, or non-symbol patterns.
         8. `codecompress deps --path <project-root>` — Understand import/dependency relationships.
-        9. `codecompress file-tree --path <project-root>` — Quick directory structure (no index required).
+           Add `--edge-kind imports|calls|implements|inherits|references` to filter by edge type.
+        9. `codecompress blast-radius --path <project-root> --file <rel-path>` — Find all files
+           affected if a given file changes (reverse BFS). Use `--symbol <name>` for symbol input.
+        10. `codecompress unused-symbols --path <project-root>` — Best-effort dead code detection.
+            Returns public symbols with no incoming dependency edges.
+        11. `codecompress file-tree --path <project-root>` — Quick directory structure (no index required).
 
         ## JSON Output (--json)
 

--- a/src/CodeCompress.Core/Indexing/IndexEngine.cs
+++ b/src/CodeCompress.Core/Indexing/IndexEngine.cs
@@ -112,7 +112,7 @@ public sealed partial class IndexEngine : IIndexEngine
 
         foreach (var (absPath, hash) in currentAbsoluteHashes)
         {
-            var relPath = Path.GetRelativePath(canonicalRoot, absPath);
+            var relPath = Path.GetRelativePath(canonicalRoot, absPath).Replace('\\', '/');
             currentHashes[relPath] = hash;
             absoluteByRelative[relPath] = absPath;
         }
@@ -357,7 +357,7 @@ public sealed partial class IndexEngine : IIndexEngine
             IgnoreInaccessible = true,
         }))
         {
-            var relPath = Path.GetRelativePath(canonicalRoot, absPath);
+            var relPath = Path.GetRelativePath(canonicalRoot, absPath).Replace('\\', '/');
 
             // Skip default excluded directories
             if (IsInExcludedDirectory(relPath, defaultExcludeSet))

--- a/src/CodeCompress.Core/Indexing/IndexEngine.cs
+++ b/src/CodeCompress.Core/Indexing/IndexEngine.cs
@@ -490,11 +490,20 @@ public sealed partial class IndexEngine : IIndexEngine
 
         foreach (var d in infos)
         {
-            deps.Add(new Dependency(0, fileId, d.RequirePath, null, d.Alias));
+            deps.Add(new Dependency(0, fileId, d.RequirePath, null, d.Alias, EdgeKindToString(d.EdgeKind)));
         }
 
         return deps;
     }
+
+    private static string EdgeKindToString(EdgeKind kind) => kind switch
+    {
+        EdgeKind.Calls => "calls",
+        EdgeKind.Implements => "implements",
+        EdgeKind.Inherits => "inherits",
+        EdgeKind.References => "references",
+        _ => "imports",
+    };
 
     public static string ComputeRepoId(string canonicalRoot)
     {

--- a/src/CodeCompress.Core/Models/BlastRadiusResult.cs
+++ b/src/CodeCompress.Core/Models/BlastRadiusResult.cs
@@ -5,5 +5,6 @@ public sealed record BlastRadiusDepth(
     IReadOnlyList<string> Files);
 
 public sealed record BlastRadiusResult(
+    bool Found,
     int TotalAffected,
     IReadOnlyList<BlastRadiusDepth> Depths);

--- a/src/CodeCompress.Core/Models/BlastRadiusResult.cs
+++ b/src/CodeCompress.Core/Models/BlastRadiusResult.cs
@@ -1,0 +1,9 @@
+namespace CodeCompress.Core.Models;
+
+public sealed record BlastRadiusDepth(
+    int Depth,
+    IReadOnlyList<string> Files);
+
+public sealed record BlastRadiusResult(
+    int TotalAffected,
+    IReadOnlyList<BlastRadiusDepth> Depths);

--- a/src/CodeCompress.Core/Models/Dependency.cs
+++ b/src/CodeCompress.Core/Models/Dependency.cs
@@ -5,4 +5,5 @@ public sealed record Dependency(
     long FileId,
     string RequiresPath,
     long? ResolvedFileId,
-    string? Alias);
+    string? Alias,
+    string EdgeKind = "imports");

--- a/src/CodeCompress.Core/Models/DependencyEdge.cs
+++ b/src/CodeCompress.Core/Models/DependencyEdge.cs
@@ -3,4 +3,5 @@ namespace CodeCompress.Core.Models;
 public sealed record DependencyEdge(
     string From,
     string To,
-    string? Alias);
+    string? Alias,
+    string? EdgeKind = null);

--- a/src/CodeCompress.Core/Models/DependencyInfo.cs
+++ b/src/CodeCompress.Core/Models/DependencyInfo.cs
@@ -2,4 +2,5 @@ namespace CodeCompress.Core.Models;
 
 public sealed record DependencyInfo(
     string RequirePath,
-    string? Alias);
+    string? Alias,
+    EdgeKind EdgeKind = EdgeKind.Imports);

--- a/src/CodeCompress.Core/Models/EdgeKind.cs
+++ b/src/CodeCompress.Core/Models/EdgeKind.cs
@@ -1,0 +1,10 @@
+namespace CodeCompress.Core.Models;
+
+public enum EdgeKind
+{
+    Imports,
+    Calls,
+    Implements,
+    Inherits,
+    References,
+}

--- a/src/CodeCompress.Core/Storage/ISymbolStore.cs
+++ b/src/CodeCompress.Core/Storage/ISymbolStore.cs
@@ -51,9 +51,11 @@ public interface ISymbolStore
     // Aggregation
     public Task<ProjectOutline> GetProjectOutlineAsync(string repoId, bool includePrivate, string groupBy, int maxDepth, string? pathFilter = null, int offset = 0, int limit = 0);
     public Task<ModuleApi> GetModuleApiAsync(string repoId, string filePath);
-    public Task<DependencyGraph> GetDependencyGraphAsync(string repoId, string? rootFile, string direction, int depth);
+    public Task<DependencyGraph> GetDependencyGraphAsync(string repoId, string? rootFile, string direction, int depth, string? edgeKind = null);
     public Task<ProjectDependencyResult> GetProjectDependencyGraphAsync(string repoId, string? projectFilter);
     public Task<ChangedFilesResult> GetChangedFilesAsync(string repoId, long snapshotId);
+    public Task<BlastRadiusResult> GetBlastRadiusAsync(string repoId, string? filePath, string? symbolName, int maxDepth = 5);
+    public Task<IReadOnlyList<SymbolSummary>> FindUnusedSymbolsAsync(string repoId, int limit = 100);
 
     // Topic outline
     public Task<ProjectOutline> SearchTopicOutlineAsync(string repoId, string query, int limit, string? pathFilter = null);

--- a/src/CodeCompress.Core/Storage/Migrations.cs
+++ b/src/CodeCompress.Core/Storage/Migrations.cs
@@ -53,7 +53,8 @@ public static class Migrations
             file_id INTEGER NOT NULL REFERENCES files(id) ON DELETE CASCADE,
             requires_path TEXT NOT NULL,
             resolved_file_id INTEGER REFERENCES files(id) ON DELETE SET NULL,
-            alias TEXT
+            alias TEXT,
+            edge_kind TEXT NOT NULL DEFAULT 'imports'
         )
         """,
         """
@@ -123,6 +124,9 @@ public static class Migrations
 
         // Add body line columns to existing databases that predate this migration
         await AddBodyLineColumnsIfNeededAsync(connection).ConfigureAwait(false);
+
+        // Add edge_kind column to existing databases that predate this migration
+        await AddEdgeKindColumnIfNeededAsync(connection).ConfigureAwait(false);
     }
 
     private static async Task AddBodyLineColumnsIfNeededAsync(SqliteConnection connection)
@@ -153,6 +157,29 @@ public static class Migrations
 #pragma warning restore CA2100
             await command.ExecuteNonQueryAsync().ConfigureAwait(false);
         }
+
+        await transaction.CommitAsync().ConfigureAwait(false);
+    }
+
+    private static async Task AddEdgeKindColumnIfNeededAsync(SqliteConnection connection)
+    {
+        using var checkCmd = connection.CreateCommand();
+        checkCmd.CommandText = "SELECT sql FROM sqlite_master WHERE type='table' AND name='dependencies'";
+        if (await checkCmd.ExecuteScalarAsync().ConfigureAwait(false) is not string depsSql
+            || depsSql.Contains("edge_kind", StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        var transaction = await connection.BeginTransactionAsync().ConfigureAwait(false);
+        await using var tx = transaction.ConfigureAwait(false);
+
+        using var command = connection.CreateCommand();
+        command.Transaction = (SqliteTransaction)transaction;
+#pragma warning disable CA2100 // DDL statement is a static literal, not user input
+        command.CommandText = "ALTER TABLE dependencies ADD COLUMN edge_kind TEXT NOT NULL DEFAULT 'imports'";
+#pragma warning restore CA2100
+        await command.ExecuteNonQueryAsync().ConfigureAwait(false);
 
         await transaction.CommitAsync().ConfigureAwait(false);
     }

--- a/src/CodeCompress.Core/Storage/SqliteSymbolStore.cs
+++ b/src/CodeCompress.Core/Storage/SqliteSymbolStore.cs
@@ -1680,7 +1680,7 @@ public sealed class SqliteSymbolStore : ISymbolStore
             var file = await GetFileByPathAsync(repoId, filePath).ConfigureAwait(false);
             if (file is null)
             {
-                return new BlastRadiusResult(0, []);
+                return new BlastRadiusResult(false, 0, []);
             }
 
             rootFileId = file.Id;
@@ -1690,7 +1690,7 @@ public sealed class SqliteSymbolStore : ISymbolStore
             var symbol = await GetSymbolByNameAsync(repoId, symbolName).ConfigureAwait(false);
             if (symbol is null)
             {
-                return new BlastRadiusResult(0, []);
+                return new BlastRadiusResult(false, 0, []);
             }
 
             rootFileId = symbol.FileId;
@@ -1698,7 +1698,7 @@ public sealed class SqliteSymbolStore : ISymbolStore
 
         if (rootFileId is null)
         {
-            return new BlastRadiusResult(0, []);
+            return new BlastRadiusResult(false, 0, []);
         }
 
         // Load file lookups
@@ -1751,7 +1751,7 @@ public sealed class SqliteSymbolStore : ISymbolStore
         }
 
         var totalAffected = depths.Sum(d => d.Files.Count);
-        return new BlastRadiusResult(totalAffected, depths);
+        return new BlastRadiusResult(true, totalAffected, depths);
     }
 
     public async Task<IReadOnlyList<SymbolSummary>> FindUnusedSymbolsAsync(string repoId, int limit = 100)
@@ -1773,7 +1773,7 @@ public sealed class SqliteSymbolStore : ISymbolStore
             JOIN files f ON s.file_id = f.id
             WHERE f.repo_id = @repoId
               AND s.visibility = 'Public'
-              AND s.kind NOT IN ('module', 'constant', 'namespace')
+              AND s.kind NOT IN ('Module', 'Constant', 'Namespace', 'ConfigKey', 'Export')
               AND f.relative_path NOT LIKE '%Test%'
               AND f.relative_path NOT LIKE '%Spec%'
               AND f.relative_path NOT LIKE '%Fixture%'

--- a/src/CodeCompress.Core/Storage/SqliteSymbolStore.cs
+++ b/src/CodeCompress.Core/Storage/SqliteSymbolStore.cs
@@ -454,8 +454,8 @@ public sealed class SqliteSymbolStore : ISymbolStore
 #pragma warning disable CA2100
             command.CommandText =
                 """
-                INSERT INTO dependencies (file_id, requires_path, resolved_file_id, alias)
-                VALUES (@fileId, @requiresPath, @resolvedFileId, @alias)
+                INSERT INTO dependencies (file_id, requires_path, resolved_file_id, alias, edge_kind)
+                VALUES (@fileId, @requiresPath, @resolvedFileId, @alias, @edgeKind)
                 """;
 #pragma warning restore CA2100
 
@@ -463,6 +463,7 @@ public sealed class SqliteSymbolStore : ISymbolStore
             var pRequiresPath = command.Parameters.Add(new SqliteParameter("@requiresPath", ""));
             var pResolvedFileId = command.Parameters.Add(new SqliteParameter("@resolvedFileId", 0L));
             var pAlias = command.Parameters.Add(new SqliteParameter("@alias", ""));
+            var pEdgeKind = command.Parameters.Add(new SqliteParameter("@edgeKind", "imports"));
 
             foreach (var dep in deps)
             {
@@ -470,6 +471,7 @@ public sealed class SqliteSymbolStore : ISymbolStore
                 pRequiresPath.Value = dep.RequiresPath;
                 pResolvedFileId.Value = dep.ResolvedFileId.HasValue ? dep.ResolvedFileId.Value : DBNull.Value;
                 pAlias.Value = (object?)dep.Alias ?? DBNull.Value;
+                pEdgeKind.Value = dep.EdgeKind;
 
                 await command.ExecuteNonQueryAsync().ConfigureAwait(false);
             }
@@ -490,7 +492,7 @@ public sealed class SqliteSymbolStore : ISymbolStore
 #pragma warning disable CA2100
         command.CommandText =
             """
-            SELECT id, file_id, requires_path, resolved_file_id, alias
+            SELECT id, file_id, requires_path, resolved_file_id, alias, edge_kind
             FROM dependencies WHERE file_id = @fileId
             """;
 #pragma warning restore CA2100
@@ -507,7 +509,8 @@ public sealed class SqliteSymbolStore : ISymbolStore
                 reader.GetInt64(1),
                 reader.GetString(2),
                 await reader.IsDBNullAsync(3).ConfigureAwait(false) ? null : reader.GetInt64(3),
-                await reader.IsDBNullAsync(4).ConfigureAwait(false) ? null : reader.GetString(4)));
+                await reader.IsDBNullAsync(4).ConfigureAwait(false) ? null : reader.GetString(4),
+                await reader.IsDBNullAsync(5).ConfigureAwait(false) ? "imports" : reader.GetString(5)));
         }
 
         return results;
@@ -1520,12 +1523,13 @@ public sealed class SqliteSymbolStore : ISymbolStore
         return new ModuleApi(file, symbols, dependencies);
     }
 
-    public async Task<DependencyGraph> GetDependencyGraphAsync(string repoId, string? rootFile, string direction, int depth)
+    public async Task<DependencyGraph> GetDependencyGraphAsync(string repoId, string? rootFile, string direction, int depth, string? edgeKind = null)
     {
         ArgumentNullException.ThrowIfNull(repoId);
         ArgumentNullException.ThrowIfNull(direction);
 
         var clampedDepth = Math.Min(Math.Max(depth, 1), 50);
+        var normalizedEdgeKind = edgeKind;
 
         // Load all files for this repo into a lookup
         var allFiles = await GetFilesByRepoAsync(repoId).ConfigureAwait(false);
@@ -1561,7 +1565,8 @@ public sealed class SqliteSymbolStore : ISymbolStore
             frontier.AddRange(allFiles.Select(f => f.Id));
         }
 
-        var isDependencies = string.Equals(direction, "dependencies", StringComparison.OrdinalIgnoreCase);
+        var showDependencies = !string.Equals(direction, "dependents", StringComparison.OrdinalIgnoreCase);
+        var showDependents = !string.Equals(direction, "dependencies", StringComparison.OrdinalIgnoreCase);
 
         for (int level = 0; level < clampedDepth && frontier.Count > 0; level++)
         {
@@ -1581,12 +1586,18 @@ public sealed class SqliteSymbolStore : ISymbolStore
 
                 nodes.Add(currentFile.RelativePath);
 
-                if (isDependencies)
+                if (showDependencies)
                 {
                     var deps = await GetDependenciesByFileAsync(fileId).ConfigureAwait(false);
 
                     foreach (var dep in deps)
                     {
+                        if (normalizedEdgeKind is not null &&
+                            !string.Equals(dep.EdgeKind, normalizedEdgeKind, StringComparison.OrdinalIgnoreCase))
+                        {
+                            continue;
+                        }
+
                         var toPath = dep.RequiresPath;
 
                         if (dep.ResolvedFileId.HasValue && fileById.TryGetValue(dep.ResolvedFileId.Value, out var resolved))
@@ -1600,36 +1611,48 @@ public sealed class SqliteSymbolStore : ISymbolStore
                             nodes.Add(toPath);
                         }
 
-                        edges.Add(new DependencyEdge(currentFile.RelativePath, toPath, dep.Alias));
+                        edges.Add(new DependencyEdge(currentFile.RelativePath, toPath, dep.Alias, dep.EdgeKind));
                     }
                 }
-                else
+
+                if (showDependents)
                 {
-                    // Dependents: find files that depend on the current file
+                    // Dependents: find files that depend on the current file (scoped to this repo)
                     using var command = _connection.CreateCommand();
 
 #pragma warning disable CA2100
                     command.CommandText =
                         """
-                        SELECT d.id, d.file_id, d.requires_path, d.resolved_file_id, d.alias
+                        SELECT d.id, d.file_id, d.requires_path, d.resolved_file_id, d.alias, d.edge_kind
                         FROM dependencies d
+                        JOIN files f2 ON d.file_id = f2.id
                         WHERE d.resolved_file_id = @fileId
+                          AND f2.repo_id = @repoId
                         """;
 #pragma warning restore CA2100
 
                     command.Parameters.AddWithValue("@fileId", fileId);
+                    command.Parameters.AddWithValue("@repoId", repoId);
 
                     using var reader = await command.ExecuteReaderAsync().ConfigureAwait(false);
 
                     while (await reader.ReadAsync().ConfigureAwait(false))
                     {
+                        var depEdgeKind = await reader.IsDBNullAsync(5).ConfigureAwait(false) ? "imports" : reader.GetString(5);
+
+                        if (normalizedEdgeKind is not null &&
+                            !string.Equals(depEdgeKind, normalizedEdgeKind, StringComparison.OrdinalIgnoreCase))
+                        {
+                            continue;
+                        }
+
                         var depFileId = reader.GetInt64(1);
                         var alias = await reader.IsDBNullAsync(4).ConfigureAwait(false) ? null : reader.GetString(4);
 
                         if (fileById.TryGetValue(depFileId, out var dependentFile))
                         {
                             nodes.Add(dependentFile.RelativePath);
-                            edges.Add(new DependencyEdge(dependentFile.RelativePath, currentFile.RelativePath, alias));
+                            edges.Add(new DependencyEdge(dependentFile.RelativePath, currentFile.RelativePath, alias, depEdgeKind));
                             nextFrontier.Add(depFileId);
                         }
                     }
@@ -1642,6 +1665,151 @@ public sealed class SqliteSymbolStore : ISymbolStore
         return new DependencyGraph(
             nodes.OrderBy(n => n, StringComparer.Ordinal).ToList(),
             edges);
+    }
+
+    public async Task<BlastRadiusResult> GetBlastRadiusAsync(string repoId, string? filePath, string? symbolName, int maxDepth = 5)
+    {
+        ArgumentNullException.ThrowIfNull(repoId);
+
+        var clampedDepth = Math.Clamp(maxDepth, 1, 20);
+
+        long? rootFileId = null;
+
+        if (filePath is not null)
+        {
+            var file = await GetFileByPathAsync(repoId, filePath).ConfigureAwait(false);
+            if (file is null)
+            {
+                return new BlastRadiusResult(0, []);
+            }
+
+            rootFileId = file.Id;
+        }
+        else if (symbolName is not null)
+        {
+            var symbol = await GetSymbolByNameAsync(repoId, symbolName).ConfigureAwait(false);
+            if (symbol is null)
+            {
+                return new BlastRadiusResult(0, []);
+            }
+
+            rootFileId = symbol.FileId;
+        }
+
+        if (rootFileId is null)
+        {
+            return new BlastRadiusResult(0, []);
+        }
+
+        // Load file lookups
+        var allFiles = await GetFilesByRepoAsync(repoId).ConfigureAwait(false);
+        var fileById = allFiles.ToDictionary(f => f.Id);
+
+        // BFS over reverse edges (dependents)
+        var depths = new List<BlastRadiusDepth>();
+        var visited = new HashSet<long> { rootFileId.Value };
+        var frontier = new List<long> { rootFileId.Value };
+
+        for (int level = 1; level <= clampedDepth && frontier.Count > 0; level++)
+        {
+            var nextFrontier = new List<long>();
+            var levelFiles = new List<string>();
+
+            foreach (var fid in frontier)
+            {
+                using var command = _connection.CreateCommand();
+#pragma warning disable CA2100
+                command.CommandText =
+                    """
+                    SELECT d.file_id FROM dependencies d
+                    JOIN files f ON d.file_id = f.id
+                    WHERE d.resolved_file_id = @fileId
+                      AND f.repo_id = @repoId
+                    """;
+#pragma warning restore CA2100
+                command.Parameters.AddWithValue("@fileId", fid);
+                command.Parameters.AddWithValue("@repoId", repoId);
+
+                using var reader = await command.ExecuteReaderAsync().ConfigureAwait(false);
+                while (await reader.ReadAsync().ConfigureAwait(false))
+                {
+                    var depFileId = reader.GetInt64(0);
+                    if (visited.Add(depFileId) && fileById.TryGetValue(depFileId, out var depFile))
+                    {
+                        levelFiles.Add(depFile.RelativePath);
+                        nextFrontier.Add(depFileId);
+                    }
+                }
+            }
+
+            if (levelFiles.Count > 0)
+            {
+                depths.Add(new BlastRadiusDepth(level, levelFiles.Order(StringComparer.Ordinal).ToList()));
+            }
+
+            frontier = nextFrontier;
+        }
+
+        var totalAffected = depths.Sum(d => d.Files.Count);
+        return new BlastRadiusResult(totalAffected, depths);
+    }
+
+    public async Task<IReadOnlyList<SymbolSummary>> FindUnusedSymbolsAsync(string repoId, int limit = 100)
+    {
+        ArgumentNullException.ThrowIfNull(repoId);
+
+        var clampedLimit = Math.Clamp(limit, 1, 1000);
+
+        // Best-effort: public symbols with no incoming dependency edges and not excluded by heuristics.
+        // Excludes: private symbols, test files (*Test*, *Spec*, *Fixture*), Main entry point,
+        // HTTP controller action attributes, module/constant/namespace kinds.
+        using var command = _connection.CreateCommand();
+
+#pragma warning disable CA2100
+        command.CommandText =
+            """
+            SELECT s.name, s.kind, s.signature
+            FROM symbols s
+            JOIN files f ON s.file_id = f.id
+            WHERE f.repo_id = @repoId
+              AND s.visibility = 'public'
+              AND s.kind NOT IN ('module', 'constant', 'namespace')
+              AND f.relative_path NOT LIKE '%Test%'
+              AND f.relative_path NOT LIKE '%Spec%'
+              AND f.relative_path NOT LIKE '%Fixture%'
+              AND s.name != 'Main'
+              AND s.signature NOT LIKE '%[HttpGet]%'
+              AND s.signature NOT LIKE '%[HttpPost]%'
+              AND s.signature NOT LIKE '%[HttpPut]%'
+              AND s.signature NOT LIKE '%[HttpDelete]%'
+              AND s.signature NOT LIKE '%[Route]%'
+              AND s.signature NOT LIKE '%[ApiController]%'
+              AND NOT EXISTS (
+                  SELECT 1 FROM dependencies d
+                  JOIN files f2 ON d.file_id = f2.id
+                  WHERE f2.repo_id = @repoId
+                    AND d.resolved_file_id = f.id
+              )
+            ORDER BY s.name
+            LIMIT @limit
+            """;
+#pragma warning restore CA2100
+
+        command.Parameters.AddWithValue("@repoId", repoId);
+        command.Parameters.AddWithValue("@limit", clampedLimit);
+
+        using var reader = await command.ExecuteReaderAsync().ConfigureAwait(false);
+        var results = new List<SymbolSummary>();
+
+        while (await reader.ReadAsync().ConfigureAwait(false))
+        {
+            results.Add(new SymbolSummary(
+                reader.GetString(0),
+                reader.GetString(1),
+                reader.GetString(2)));
+        }
+
+        return results;
     }
 
     public async Task<ProjectDependencyResult> GetProjectDependencyGraphAsync(string repoId, string? projectFilter)

--- a/src/CodeCompress.Core/Storage/SqliteSymbolStore.cs
+++ b/src/CodeCompress.Core/Storage/SqliteSymbolStore.cs
@@ -1772,7 +1772,7 @@ public sealed class SqliteSymbolStore : ISymbolStore
             FROM symbols s
             JOIN files f ON s.file_id = f.id
             WHERE f.repo_id = @repoId
-              AND s.visibility = 'public'
+              AND s.visibility = 'Public'
               AND s.kind NOT IN ('module', 'constant', 'namespace')
               AND f.relative_path NOT LIKE '%Test%'
               AND f.relative_path NOT LIKE '%Spec%'

--- a/src/CodeCompress.Core/Storage/SqliteSymbolStore.cs
+++ b/src/CodeCompress.Core/Storage/SqliteSymbolStore.cs
@@ -804,8 +804,8 @@ public sealed class SqliteSymbolStore : ISymbolStore
         if (pathFilter is not null)
         {
             // Normalize to OS-native separator to match stored relative_path values
-            var normalizedPrefix = pathFilter.Replace('/', Path.DirectorySeparatorChar);
-            command.Parameters.AddWithValue("@pathPrefix", normalizedPrefix + Path.DirectorySeparatorChar);
+            var normalizedPrefix = pathFilter.Replace('\\', '/');
+            command.Parameters.AddWithValue("@pathPrefix", normalizedPrefix + '/');
         }
 
         using var reader = await command.ExecuteReaderAsync().ConfigureAwait(false);
@@ -886,8 +886,8 @@ public sealed class SqliteSymbolStore : ISymbolStore
 
         if (pathFilter is not null)
         {
-            var normalizedPrefix = pathFilter.Replace('/', Path.DirectorySeparatorChar);
-            command.Parameters.AddWithValue("@pathPrefix", normalizedPrefix + Path.DirectorySeparatorChar);
+            var normalizedPrefix = pathFilter.Replace('\\', '/');
+            command.Parameters.AddWithValue("@pathPrefix", normalizedPrefix + '/');
         }
 
         using var reader = await command.ExecuteReaderAsync().ConfigureAwait(false);
@@ -948,8 +948,8 @@ public sealed class SqliteSymbolStore : ISymbolStore
 
         if (pathFilter is not null)
         {
-            var normalizedPrefix = pathFilter.Replace('/', Path.DirectorySeparatorChar);
-            command.Parameters.AddWithValue("@pathPrefix", normalizedPrefix + Path.DirectorySeparatorChar);
+            var normalizedPrefix = pathFilter.Replace('\\', '/');
+            command.Parameters.AddWithValue("@pathPrefix", normalizedPrefix + '/');
         }
 
         using var reader = await command.ExecuteReaderAsync().ConfigureAwait(false);
@@ -1375,10 +1375,10 @@ public sealed class SqliteSymbolStore : ISymbolStore
         string? normalizedPrefix = null;
         if (pathFilter is not null)
         {
-            normalizedPrefix = pathFilter.Replace('/', Path.DirectorySeparatorChar);
-            normalizedPrefix = normalizedPrefix.EndsWith(Path.DirectorySeparatorChar)
+            normalizedPrefix = pathFilter.Replace('\\', '/');
+            normalizedPrefix = normalizedPrefix.EndsWith('/')
                 ? normalizedPrefix
-                : normalizedPrefix + Path.DirectorySeparatorChar;
+                : normalizedPrefix + '/';
             countCommand.Parameters.AddWithValue("@pathPrefix", normalizedPrefix);
         }
 
@@ -2050,10 +2050,10 @@ public sealed class SqliteSymbolStore : ISymbolStore
         string? normalizedPrefix = null;
         if (pathFilter is not null)
         {
-            normalizedPrefix = pathFilter.Replace('/', Path.DirectorySeparatorChar);
-            normalizedPrefix = normalizedPrefix.EndsWith(Path.DirectorySeparatorChar)
+            normalizedPrefix = pathFilter.Replace('\\', '/');
+            normalizedPrefix = normalizedPrefix.EndsWith('/')
                 ? normalizedPrefix
-                : normalizedPrefix + Path.DirectorySeparatorChar;
+                : normalizedPrefix + '/';
             countCommand.Parameters.AddWithValue("@pathPrefix", normalizedPrefix);
         }
 

--- a/src/CodeCompress.Server/Tools/DependencyTools.cs
+++ b/src/CodeCompress.Server/Tools/DependencyTools.cs
@@ -140,11 +140,25 @@ internal sealed class DependencyTools
 
         var clampedDepth = Math.Clamp(maxDepth, 1, 20);
 
+        if (normalizedFilePath is null && symbolName is null)
+        {
+            return SerializeError("Provide either filePath or symbolName", "INVALID_INPUT");
+        }
+
         var scope = await _scopeFactory.CreateAsync(validatedPath, cancellationToken).ConfigureAwait(false);
         await using (scope.ConfigureAwait(false))
         {
             var result = await scope.Store.GetBlastRadiusAsync(
                 scope.RepoId, normalizedFilePath, symbolName, clampedDepth).ConfigureAwait(false);
+
+            if (!result.Found)
+            {
+                return SerializeError(
+                    normalizedFilePath is not null
+                        ? "File not found in index — verify the relative path and run index_project"
+                        : "Symbol not found in index — use search_symbols to find the correct name",
+                    "NOT_FOUND");
+            }
 
             return JsonSerializer.Serialize(
                 new

--- a/src/CodeCompress.Server/Tools/DependencyTools.cs
+++ b/src/CodeCompress.Server/Tools/DependencyTools.cs
@@ -22,6 +22,11 @@ internal sealed class DependencyTools
         "dependencies", "dependents", "both",
     };
 
+    private static readonly HashSet<string> ValidEdgeKinds = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "imports", "calls", "implements", "inherits", "references",
+    };
+
     private readonly IPathValidator _pathValidator;
     private readonly IProjectScopeFactory _scopeFactory;
 
@@ -35,12 +40,13 @@ internal sealed class DependencyTools
     }
 
     [McpServerTool(Name = "dependency_graph")]
-    [Description("Get the import/require dependency graph for a project or specific file — shows which files depend on which others. Use to understand code relationships before making changes. Requires index_project to have been called first. Returns plain text: each file node followed by 'requires -> file1, file2' and 'required by -> file3' edges, with a total summary line. Errors return JSON {error, code, retryable}. Codes: INVALID_PATH, INVALID_DIRECTION (see direction param for valid values), FILE_NOT_FOUND (rootFile not in index — verify path and run index_project).")]
+    [Description("Get the import/require dependency graph for a project or specific file — shows which files depend on which others. Use to understand code relationships before making changes. Requires index_project to have been called first. Returns plain text: each file node followed by 'requires -> file1, file2' and 'required by -> file3' edges, with a total summary line. Errors return JSON {error, code, retryable}. Codes: INVALID_PATH, INVALID_DIRECTION (see direction param for valid values), INVALID_EDGE_KIND (see edgeKind param), FILE_NOT_FOUND (rootFile not in index — verify path and run index_project).")]
     public async Task<string> DependencyGraph(
         [Description("ABSOLUTE path to the project root directory — the same root used with index_project (e.g., 'C:\\Projects\\MyGame' or '/home/user/my-project'). Must NOT be a subdirectory or relative path.")] string path,
         [Description("Start traversal from a specific file (relative path). Omit for full project graph.")] string? rootFile = null,
         [Description("Traversal direction. Allowed values: 'dependencies' (outgoing imports), 'dependents' (incoming — who imports this file), 'both' (default). Other values are rejected.")] string direction = "both",
         [Description("Maximum traversal depth (1-50, default 50). Values outside this range are clamped. Omit for full depth.")] int? depth = null,
+        [Description("Filter edges by kind. Allowed values: 'imports', 'calls', 'implements', 'inherits', 'references'. Omit for all edge kinds.")] string? edgeKind = null,
         CancellationToken cancellationToken = default)
     {
         string validatedPath;
@@ -58,6 +64,13 @@ internal sealed class DependencyTools
             return SerializeError(
                 "Invalid direction. Must be one of: dependencies, dependents, both",
                 "INVALID_DIRECTION");
+        }
+
+        if (edgeKind is not null && !ValidEdgeKinds.Contains(edgeKind))
+        {
+            return SerializeError(
+                "Invalid edge kind. Must be one of: imports, calls, implements, inherits, references",
+                "INVALID_EDGE_KIND");
         }
 
         var normalizedRootFile = rootFile is not null ? PathValidator.NormalizeRelativePath(rootFile) : null;
@@ -80,7 +93,7 @@ internal sealed class DependencyTools
         await using (scope.ConfigureAwait(false))
         {
             var graph = await scope.Store.GetDependencyGraphAsync(
-                scope.RepoId, normalizedRootFile, direction, clampedDepth).ConfigureAwait(false);
+                scope.RepoId, normalizedRootFile, direction, clampedDepth, edgeKind).ConfigureAwait(false);
 
             // Non-existent root file returns empty graph
             if (normalizedRootFile is not null && graph.Nodes.Count == 0)
@@ -88,24 +101,113 @@ internal sealed class DependencyTools
                 return SerializeError("File not found in index", "FILE_NOT_FOUND");
             }
 
-            return FormatGraph(graph, normalizedRootFile, direction, clampedDepth);
+            return FormatGraph(graph, normalizedRootFile, direction, clampedDepth, edgeKind);
         }
     }
 
-    private static string FormatGraph(DependencyGraph graph, string? rootFile, string direction, int depth)
+    [McpServerTool(Name = "blast_radius")]
+    [Description("Perform a reverse BFS to find all files affected if a given file or symbol changes — answers 'what breaks if I change X?' Requires index_project to have been called first. Returns JSON with total_affected count and depths array (each entry: depth, files). Errors return JSON {error, code, retryable}. Codes: INVALID_PATH, NOT_FOUND (file or symbol not in index).")]
+    public async Task<string> BlastRadius(
+        [Description("ABSOLUTE path to the project root directory.")] string path,
+        [Description("Relative path to the file to analyze (e.g., 'src/Core/Service.cs'). Provide either filePath or symbolName, not both.")] string? filePath = null,
+        [Description("Symbol name to analyze (e.g., 'ProcessPayment'). Provide either filePath or symbolName, not both.")] string? symbolName = null,
+        [Description("Maximum BFS depth (1-20, default 5). Values outside this range are clamped.")] int maxDepth = 5,
+        CancellationToken cancellationToken = default)
+    {
+        string validatedPath;
+        try
+        {
+            validatedPath = _pathValidator.ValidatePath(path, path);
+        }
+        catch (ArgumentException)
+        {
+            return SerializeError("Path validation failed", "INVALID_PATH");
+        }
+
+        var normalizedFilePath = filePath is not null ? PathValidator.NormalizeRelativePath(filePath) : null;
+
+        if (normalizedFilePath is not null)
+        {
+            try
+            {
+                _pathValidator.ValidateRelativePath(normalizedFilePath, validatedPath);
+            }
+            catch (ArgumentException)
+            {
+                return SerializeError("Path validation failed", "INVALID_PATH");
+            }
+        }
+
+        var clampedDepth = Math.Clamp(maxDepth, 1, 20);
+
+        var scope = await _scopeFactory.CreateAsync(validatedPath, cancellationToken).ConfigureAwait(false);
+        await using (scope.ConfigureAwait(false))
+        {
+            var result = await scope.Store.GetBlastRadiusAsync(
+                scope.RepoId, normalizedFilePath, symbolName, clampedDepth).ConfigureAwait(false);
+
+            return JsonSerializer.Serialize(
+                new
+                {
+                    result.TotalAffected,
+                    Depths = result.Depths.Select(d => new { d.Depth, d.Files }),
+                },
+                SerializerOptions);
+        }
+    }
+
+    [McpServerTool(Name = "find_unused_symbols")]
+    [Description("Find public symbols with no incoming dependency edges — best-effort dead code detection. Excludes test files, Main entry point, HTTP controller action attributes. Requires index_project to have been called first. Returns JSON array of {name, kind, signature}. Errors return JSON {error, code, retryable}. Code: INVALID_PATH.")]
+    public async Task<string> FindUnusedSymbols(
+        [Description("ABSOLUTE path to the project root directory.")] string path,
+        [Description("Maximum number of results to return (1-500, default 100). Values outside this range are clamped.")] int limit = 100,
+        CancellationToken cancellationToken = default)
+    {
+        string validatedPath;
+        try
+        {
+            validatedPath = _pathValidator.ValidatePath(path, path);
+        }
+        catch (ArgumentException)
+        {
+            return SerializeError("Path validation failed", "INVALID_PATH");
+        }
+
+        var clampedLimit = Math.Clamp(limit, 1, 500);
+
+        var scope = await _scopeFactory.CreateAsync(validatedPath, cancellationToken).ConfigureAwait(false);
+        await using (scope.ConfigureAwait(false))
+        {
+            var results = await scope.Store.FindUnusedSymbolsAsync(scope.RepoId, clampedLimit).ConfigureAwait(false);
+
+            return JsonSerializer.Serialize(
+                results.Select(s => new { s.Name, s.Kind, s.Signature }),
+                SerializerOptions);
+        }
+    }
+
+    private static string SanitizePath(string path) =>
+        path.ReplaceLineEndings(string.Empty)
+            .Replace('\0', '_')
+            .Replace('[', '(')
+            .Replace(']', ')');
+
+    private static string FormatGraph(DependencyGraph graph, string? rootFile, string direction, int depth, string? edgeKind = null)
     {
         var sb = new StringBuilder();
+        var edgeKindSuffix = edgeKind is not null ? $", edge: {edgeKind}" : string.Empty;
 
         // Header
         if (rootFile is not null)
         {
+            var safeRootFile = SanitizePath(rootFile);
             sb.AppendLine(CultureInfo.InvariantCulture,
-                $"Dependency graph for \"{rootFile}\" (depth: {depth}, direction: {direction}):");
+                $"Dependency graph for \"{safeRootFile}\" (depth: {depth}, direction: {direction}{edgeKindSuffix}):");
         }
         else
         {
             sb.AppendLine(CultureInfo.InvariantCulture,
-                $"Dependency graph (full project, direction: {direction}):");
+                $"Dependency graph (full project, direction: {direction}{edgeKindSuffix}):");
         }
 
         sb.AppendLine();

--- a/tests/CodeCompress.Core.Tests/Indexing/IndexEngineTests.cs
+++ b/tests/CodeCompress.Core.Tests/Indexing/IndexEngineTests.cs
@@ -113,7 +113,7 @@ internal sealed class IndexEngineTests
         });
 
         SetupChangeSet(new ChangeSet(
-            ["src\\main.luau", "src\\utils.luau", "src\\lib.luau"],
+            ["src/main.luau", "src/utils.luau", "src/lib.luau"],
             [], [], []));
 
         var result = await _engine.IndexProjectAsync(_tempDir).ConfigureAwait(false);
@@ -252,7 +252,7 @@ internal sealed class IndexEngineTests
                 return Task.FromResult(new Dictionary<string, string> { [mainPath] = "hash1" });
             });
 
-        SetupChangeSet(new ChangeSet(["src\\main.luau"], [], [], []));
+        SetupChangeSet(new ChangeSet(["src/main.luau"], [], [], []));
 
         await _engine.IndexProjectAsync(
             _tempDir,
@@ -278,7 +278,7 @@ internal sealed class IndexEngineTests
             [mainPath] = "hash1",
         });
 
-        SetupChangeSet(new ChangeSet(["src\\main.luau"], [], [], []));
+        SetupChangeSet(new ChangeSet(["src/main.luau"], [], [], []));
 
         await _engine.IndexProjectAsync(
             _tempDir,
@@ -353,7 +353,7 @@ internal sealed class IndexEngineTests
             [mainPath] = "hash1",
         });
 
-        SetupChangeSet(new ChangeSet(["src\\main.luau"], [], [], []));
+        SetupChangeSet(new ChangeSet(["src/main.luau"], [], [], []));
 
         await _engine.IndexProjectAsync(_tempDir).ConfigureAwait(false);
 

--- a/tests/CodeCompress.Core.Tests/Models/BlastRadiusResultTests.cs
+++ b/tests/CodeCompress.Core.Tests/Models/BlastRadiusResultTests.cs
@@ -7,9 +7,16 @@ internal sealed class BlastRadiusResultTests
     [Test]
     public async Task EmptyResultHasZeroTotalAffected()
     {
-        var result = new BlastRadiusResult(0, []);
+        var result = new BlastRadiusResult(true, 0, []);
         await Assert.That(result.TotalAffected).IsEqualTo(0);
         await Assert.That(result.Depths).Count().IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task NotFoundResultHasFoundFalse()
+    {
+        var result = new BlastRadiusResult(false, 0, []);
+        await Assert.That(result.Found).IsFalse();
     }
 
     [Test]
@@ -20,8 +27,9 @@ internal sealed class BlastRadiusResultTests
             new(1, ["B.cs", "C.cs"]),
             new(2, ["D.cs"]),
         };
-        var result = new BlastRadiusResult(3, depths);
+        var result = new BlastRadiusResult(true, 3, depths);
 
+        await Assert.That(result.Found).IsTrue();
         await Assert.That(result.TotalAffected).IsEqualTo(3);
         await Assert.That(result.Depths).Count().IsEqualTo(2);
         await Assert.That(result.Depths[0].Depth).IsEqualTo(1);
@@ -35,8 +43,8 @@ internal sealed class BlastRadiusResultTests
     {
         var files = new List<string> { "B.cs" };
         var depths = new List<BlastRadiusDepth> { new(1, files) };
-        var r1 = new BlastRadiusResult(1, depths);
-        var r2 = new BlastRadiusResult(1, depths);
+        var r1 = new BlastRadiusResult(true, 1, depths);
+        var r2 = new BlastRadiusResult(true, 1, depths);
 
         await Assert.That(r1).IsEqualTo(r2);
     }

--- a/tests/CodeCompress.Core.Tests/Models/BlastRadiusResultTests.cs
+++ b/tests/CodeCompress.Core.Tests/Models/BlastRadiusResultTests.cs
@@ -1,0 +1,43 @@
+using CodeCompress.Core.Models;
+
+namespace CodeCompress.Core.Tests.Models;
+
+internal sealed class BlastRadiusResultTests
+{
+    [Test]
+    public async Task EmptyResultHasZeroTotalAffected()
+    {
+        var result = new BlastRadiusResult(0, []);
+        await Assert.That(result.TotalAffected).IsEqualTo(0);
+        await Assert.That(result.Depths).Count().IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task DepthGroupsFilesCorrectly()
+    {
+        var depths = new List<BlastRadiusDepth>
+        {
+            new(1, ["B.cs", "C.cs"]),
+            new(2, ["D.cs"]),
+        };
+        var result = new BlastRadiusResult(3, depths);
+
+        await Assert.That(result.TotalAffected).IsEqualTo(3);
+        await Assert.That(result.Depths).Count().IsEqualTo(2);
+        await Assert.That(result.Depths[0].Depth).IsEqualTo(1);
+        await Assert.That(result.Depths[0].Files).Count().IsEqualTo(2);
+        await Assert.That(result.Depths[1].Depth).IsEqualTo(2);
+        await Assert.That(result.Depths[1].Files).Count().IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task EqualityTwoIdenticalResultsAreEqual()
+    {
+        var files = new List<string> { "B.cs" };
+        var depths = new List<BlastRadiusDepth> { new(1, files) };
+        var r1 = new BlastRadiusResult(1, depths);
+        var r2 = new BlastRadiusResult(1, depths);
+
+        await Assert.That(r1).IsEqualTo(r2);
+    }
+}

--- a/tests/CodeCompress.Core.Tests/Models/EdgeKindTests.cs
+++ b/tests/CodeCompress.Core.Tests/Models/EdgeKindTests.cs
@@ -1,0 +1,66 @@
+using CodeCompress.Core.Models;
+
+namespace CodeCompress.Core.Tests.Models;
+
+internal sealed class EdgeKindTests
+{
+    [Test]
+    public async Task HasFiveMembers()
+    {
+        var values = Enum.GetValues<EdgeKind>();
+        await Assert.That(values).Count().IsEqualTo(5);
+    }
+
+    [Arguments(EdgeKind.Imports, 0)]
+    [Arguments(EdgeKind.Calls, 1)]
+    [Arguments(EdgeKind.Implements, 2)]
+    [Arguments(EdgeKind.Inherits, 3)]
+    [Arguments(EdgeKind.References, 4)]
+    [Test]
+    public async Task EnumMemberHasExpectedIntValue(EdgeKind kind, int expectedValue)
+    {
+        await Assert.That((int)kind).IsEqualTo(expectedValue);
+    }
+
+    [Test]
+    public async Task DefaultDependencyInfoEdgeKindIsImports()
+    {
+        var info = new DependencyInfo("some.path", null);
+        await Assert.That(info.EdgeKind).IsEqualTo(EdgeKind.Imports);
+    }
+
+    [Test]
+    public async Task DependencyInfoEdgeKindCanBeSetExplicitly()
+    {
+        var info = new DependencyInfo("Base", null, EdgeKind.Inherits);
+        await Assert.That(info.EdgeKind).IsEqualTo(EdgeKind.Inherits);
+    }
+
+    [Test]
+    public async Task DefaultDependencyEdgeKindIsImports()
+    {
+        var dep = new Dependency(0, 1, "some.path", null, null);
+        await Assert.That(dep.EdgeKind).IsEqualTo("imports");
+    }
+
+    [Test]
+    public async Task DependencyEdgeKindCanBeSetExplicitly()
+    {
+        var dep = new Dependency(0, 1, "IFoo", null, null, "implements");
+        await Assert.That(dep.EdgeKind).IsEqualTo("implements");
+    }
+
+    [Test]
+    public async Task DependencyEdgeEdgeKindDefaultsToNull()
+    {
+        var edge = new DependencyEdge("A.cs", "B.cs", null);
+        await Assert.That(edge.EdgeKind).IsNull();
+    }
+
+    [Test]
+    public async Task DependencyEdgeEdgeKindCanBeSetExplicitly()
+    {
+        var edge = new DependencyEdge("A.cs", "B.cs", null, "inherits");
+        await Assert.That(edge.EdgeKind).IsEqualTo("inherits");
+    }
+}

--- a/tests/CodeCompress.Core.Tests/Storage/DependencyGraphQueryTests.cs
+++ b/tests/CodeCompress.Core.Tests/Storage/DependencyGraphQueryTests.cs
@@ -1,0 +1,526 @@
+using CodeCompress.Core.Models;
+using CodeCompress.Core.Storage;
+using Microsoft.Data.Sqlite;
+
+namespace CodeCompress.Core.Tests.Storage;
+
+internal sealed class DependencyGraphQueryTests
+{
+    private static async Task<SqliteConnection> CreateTestConnectionAsync()
+    {
+        var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync().ConfigureAwait(false);
+
+        using var fkCmd = connection.CreateCommand();
+        fkCmd.CommandText = "PRAGMA foreign_keys=ON;";
+        await fkCmd.ExecuteNonQueryAsync().ConfigureAwait(false);
+
+        await Migrations.ApplyAsync(connection).ConfigureAwait(false);
+        return connection;
+    }
+
+    private static Repository MakeRepo() =>
+        new("repo1", "/root", "Test", "csharp", 0, 0, 0);
+
+    private static FileRecord MakeFile(string repoId, string path, long id = 0) =>
+        new(id, repoId, path, "hash", 100, 10, 0, 0);
+
+    private static Dependency MakeDep(long fileId, string requiresPath, long? resolvedFileId, string edgeKind = "imports") =>
+        new(0, fileId, requiresPath, resolvedFileId, null, edgeKind);
+
+    private static Symbol MakeSymbol(long fileId, string name, string kind = "method", string visibility = "public") =>
+        new(0, fileId, name, kind, $"{visibility} {kind} {name}()", null, 0, 10, 1, 5, visibility, null, null, null);
+
+    // ── Dependency edge_kind roundtrip ───────────────────────────────
+
+    [Test]
+    public async Task InsertAndReadDependencyPreservesEdgeKind()
+    {
+        using var conn = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(conn);
+        var repo = MakeRepo();
+        await store.UpsertRepositoryAsync(repo).ConfigureAwait(false);
+        await store.InsertFilesAsync([MakeFile(repo.Id, "A.cs")]).ConfigureAwait(false);
+        var files = await store.GetFilesByRepoAsync(repo.Id).ConfigureAwait(false);
+        var fileId = files[0].Id;
+
+        await store.InsertDependenciesAsync([
+            MakeDep(fileId, "Base", null, "inherits"),
+            MakeDep(fileId, "IFoo", null, "implements"),
+            MakeDep(fileId, "System.Linq", null, "imports"),
+        ]).ConfigureAwait(false);
+
+        var deps = await store.GetDependenciesByFileAsync(fileId).ConfigureAwait(false);
+
+        await Assert.That(deps).Count().IsEqualTo(3);
+        var inherits = deps.First(d => d.RequiresPath == "Base");
+        var implements = deps.First(d => d.RequiresPath == "IFoo");
+        var imports = deps.First(d => d.RequiresPath == "System.Linq");
+        await Assert.That(inherits.EdgeKind).IsEqualTo("inherits");
+        await Assert.That(implements.EdgeKind).IsEqualTo("implements");
+        await Assert.That(imports.EdgeKind).IsEqualTo("imports");
+    }
+
+    [Test]
+    public async Task InsertDependencyDefaultEdgeKindIsImports()
+    {
+        using var conn = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(conn);
+        var repo = MakeRepo();
+        await store.UpsertRepositoryAsync(repo).ConfigureAwait(false);
+        await store.InsertFilesAsync([MakeFile(repo.Id, "A.cs")]).ConfigureAwait(false);
+        var files = await store.GetFilesByRepoAsync(repo.Id).ConfigureAwait(false);
+        var fileId = files[0].Id;
+
+        // Insert without specifying EdgeKind — should default to "imports"
+        await store.InsertDependenciesAsync([new Dependency(0, fileId, "Foo", null, null)]).ConfigureAwait(false);
+
+        var deps = await store.GetDependenciesByFileAsync(fileId).ConfigureAwait(false);
+        await Assert.That(deps[0].EdgeKind).IsEqualTo("imports");
+    }
+
+    // ── GetDependencyGraphAsync edgeKind filter ──────────────────────
+
+    [Test]
+    public async Task GetDependencyGraphFiltersByEdgeKind()
+    {
+        using var conn = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(conn);
+        var repo = MakeRepo();
+        await store.UpsertRepositoryAsync(repo).ConfigureAwait(false);
+        await store.InsertFilesAsync([
+            MakeFile(repo.Id, "A.cs"),
+            MakeFile(repo.Id, "B.cs"),
+            MakeFile(repo.Id, "C.cs"),
+        ]).ConfigureAwait(false);
+        var files = await store.GetFilesByRepoAsync(repo.Id).ConfigureAwait(false);
+        var a = files.First(f => f.RelativePath == "A.cs");
+        var b = files.First(f => f.RelativePath == "B.cs");
+        var c = files.First(f => f.RelativePath == "C.cs");
+
+        await store.InsertDependenciesAsync([
+            MakeDep(a.Id, "B", b.Id, "imports"),
+            MakeDep(a.Id, "C", c.Id, "inherits"),
+        ]).ConfigureAwait(false);
+
+        var importsOnly = await store.GetDependencyGraphAsync(
+            repo.Id, "A.cs", "dependencies", 5, "imports").ConfigureAwait(false);
+        var inheritsOnly = await store.GetDependencyGraphAsync(
+            repo.Id, "A.cs", "dependencies", 5, "inherits").ConfigureAwait(false);
+        var allEdges = await store.GetDependencyGraphAsync(
+            repo.Id, "A.cs", "dependencies", 5).ConfigureAwait(false);
+
+        await Assert.That(importsOnly.Edges).Count().IsEqualTo(1);
+        await Assert.That(importsOnly.Edges[0].To).IsEqualTo("B.cs");
+        await Assert.That(inheritsOnly.Edges).Count().IsEqualTo(1);
+        await Assert.That(inheritsOnly.Edges[0].To).IsEqualTo("C.cs");
+        await Assert.That(allEdges.Edges).Count().IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task GetDependencyGraphEdgesIncludeEdgeKind()
+    {
+        using var conn = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(conn);
+        var repo = MakeRepo();
+        await store.UpsertRepositoryAsync(repo).ConfigureAwait(false);
+        await store.InsertFilesAsync([
+            MakeFile(repo.Id, "A.cs"),
+            MakeFile(repo.Id, "B.cs"),
+        ]).ConfigureAwait(false);
+        var files = await store.GetFilesByRepoAsync(repo.Id).ConfigureAwait(false);
+        var a = files.First(f => f.RelativePath == "A.cs");
+        var b = files.First(f => f.RelativePath == "B.cs");
+
+        await store.InsertDependenciesAsync([
+            MakeDep(a.Id, "B", b.Id, "inherits"),
+        ]).ConfigureAwait(false);
+
+        var graph = await store.GetDependencyGraphAsync(repo.Id, "A.cs", "dependencies", 5).ConfigureAwait(false);
+
+        await Assert.That(graph.Edges).Count().IsEqualTo(1);
+        await Assert.That(graph.Edges[0].EdgeKind).IsEqualTo("inherits");
+    }
+
+    // ── blast_radius ─────────────────────────────────────────────────
+
+    [Test]
+    public async Task BlastRadiusNoIncomingEdgesReturnsEmpty()
+    {
+        using var conn = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(conn);
+        var repo = MakeRepo();
+        await store.UpsertRepositoryAsync(repo).ConfigureAwait(false);
+        await store.InsertFilesAsync([MakeFile(repo.Id, "Isolated.cs")]).ConfigureAwait(false);
+
+        var result = await store.GetBlastRadiusAsync(repo.Id, "Isolated.cs", null, 5).ConfigureAwait(false);
+
+        await Assert.That(result.TotalAffected).IsEqualTo(0);
+        await Assert.That(result.Depths).Count().IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task BlastRadiusDepth1ReturnsDirectImporters()
+    {
+        using var conn = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(conn);
+        var repo = MakeRepo();
+        await store.UpsertRepositoryAsync(repo).ConfigureAwait(false);
+        await store.InsertFilesAsync([
+            MakeFile(repo.Id, "Core.cs"),
+            MakeFile(repo.Id, "ServiceA.cs"),
+            MakeFile(repo.Id, "ServiceB.cs"),
+        ]).ConfigureAwait(false);
+        var files = await store.GetFilesByRepoAsync(repo.Id).ConfigureAwait(false);
+        var core = files.First(f => f.RelativePath == "Core.cs");
+        var svcA = files.First(f => f.RelativePath == "ServiceA.cs");
+        var svcB = files.First(f => f.RelativePath == "ServiceB.cs");
+
+        await store.InsertDependenciesAsync([
+            MakeDep(svcA.Id, "Core", core.Id),
+            MakeDep(svcB.Id, "Core", core.Id),
+        ]).ConfigureAwait(false);
+
+        var result = await store.GetBlastRadiusAsync(repo.Id, "Core.cs", null, 5).ConfigureAwait(false);
+
+        await Assert.That(result.TotalAffected).IsEqualTo(2);
+        await Assert.That(result.Depths).Count().IsEqualTo(1);
+        await Assert.That(result.Depths[0].Depth).IsEqualTo(1);
+        await Assert.That(result.Depths[0].Files).Count().IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task BlastRadiusTransitiveDependentsGroupedByDepth()
+    {
+        using var conn = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(conn);
+        var repo = MakeRepo();
+        await store.UpsertRepositoryAsync(repo).ConfigureAwait(false);
+        // A <- B <- C (chain: A is imported by B, B is imported by C)
+        await store.InsertFilesAsync([
+            MakeFile(repo.Id, "A.cs"),
+            MakeFile(repo.Id, "B.cs"),
+            MakeFile(repo.Id, "C.cs"),
+        ]).ConfigureAwait(false);
+        var files = await store.GetFilesByRepoAsync(repo.Id).ConfigureAwait(false);
+        var a = files.First(f => f.RelativePath == "A.cs");
+        var b = files.First(f => f.RelativePath == "B.cs");
+        var c = files.First(f => f.RelativePath == "C.cs");
+
+        await store.InsertDependenciesAsync([
+            MakeDep(b.Id, "A", a.Id),
+            MakeDep(c.Id, "B", b.Id),
+        ]).ConfigureAwait(false);
+
+        var result = await store.GetBlastRadiusAsync(repo.Id, "A.cs", null, 5).ConfigureAwait(false);
+
+        await Assert.That(result.TotalAffected).IsEqualTo(2);
+        await Assert.That(result.Depths).Count().IsEqualTo(2);
+        var depth1Files = result.Depths.First(d => d.Depth == 1).Files;
+        var depth2Files = result.Depths.First(d => d.Depth == 2).Files;
+        await Assert.That(depth1Files).Contains("B.cs");
+        await Assert.That(depth2Files).Contains("C.cs");
+    }
+
+    [Test]
+    public async Task BlastRadiusMaxDepthLimitsTraversal()
+    {
+        using var conn = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(conn);
+        var repo = MakeRepo();
+        await store.UpsertRepositoryAsync(repo).ConfigureAwait(false);
+        // A <- B <- C chain, but maxDepth=1 should stop at B
+        await store.InsertFilesAsync([
+            MakeFile(repo.Id, "A.cs"),
+            MakeFile(repo.Id, "B.cs"),
+            MakeFile(repo.Id, "C.cs"),
+        ]).ConfigureAwait(false);
+        var files = await store.GetFilesByRepoAsync(repo.Id).ConfigureAwait(false);
+        var a = files.First(f => f.RelativePath == "A.cs");
+        var b = files.First(f => f.RelativePath == "B.cs");
+        var c = files.First(f => f.RelativePath == "C.cs");
+
+        await store.InsertDependenciesAsync([
+            MakeDep(b.Id, "A", a.Id),
+            MakeDep(c.Id, "B", b.Id),
+        ]).ConfigureAwait(false);
+
+        var result = await store.GetBlastRadiusAsync(repo.Id, "A.cs", null, 1).ConfigureAwait(false);
+
+        await Assert.That(result.TotalAffected).IsEqualTo(1);
+        await Assert.That(result.Depths).Count().IsEqualTo(1);
+        await Assert.That(result.Depths[0].Files).Contains("B.cs");
+    }
+
+    [Test]
+    public async Task BlastRadiusFileNotInIndexReturnsEmpty()
+    {
+        using var conn = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(conn);
+        var repo = MakeRepo();
+        await store.UpsertRepositoryAsync(repo).ConfigureAwait(false);
+
+        var result = await store.GetBlastRadiusAsync(repo.Id, "nonexistent.cs", null, 5).ConfigureAwait(false);
+
+        await Assert.That(result.TotalAffected).IsEqualTo(0);
+        await Assert.That(result.Depths).Count().IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task BlastRadiusRootNotIncludedInResults()
+    {
+        using var conn = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(conn);
+        var repo = MakeRepo();
+        await store.UpsertRepositoryAsync(repo).ConfigureAwait(false);
+        await store.InsertFilesAsync([
+            MakeFile(repo.Id, "Core.cs"),
+            MakeFile(repo.Id, "Service.cs"),
+        ]).ConfigureAwait(false);
+        var files = await store.GetFilesByRepoAsync(repo.Id).ConfigureAwait(false);
+        var core = files.First(f => f.RelativePath == "Core.cs");
+        var svc = files.First(f => f.RelativePath == "Service.cs");
+
+        await store.InsertDependenciesAsync([MakeDep(svc.Id, "Core", core.Id)]).ConfigureAwait(false);
+
+        var result = await store.GetBlastRadiusAsync(repo.Id, "Core.cs", null, 5).ConfigureAwait(false);
+
+        foreach (var depth in result.Depths)
+        {
+            await Assert.That(depth.Files).DoesNotContain("Core.cs");
+        }
+    }
+
+    // ── find_unused_symbols ──────────────────────────────────────────
+
+    [Test]
+    public async Task FindUnusedSymbolsReturnsPublicSymbolWithNoIncomingEdges()
+    {
+        using var conn = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(conn);
+        var repo = MakeRepo();
+        await store.UpsertRepositoryAsync(repo).ConfigureAwait(false);
+        await store.InsertFilesAsync([MakeFile(repo.Id, "Helpers.cs")]).ConfigureAwait(false);
+        var files = await store.GetFilesByRepoAsync(repo.Id).ConfigureAwait(false);
+        var fileId = files[0].Id;
+
+        await store.InsertSymbolsAsync([
+            MakeSymbol(fileId, "LegacyHelper", "method", "public"),
+        ]).ConfigureAwait(false);
+
+        var result = await store.FindUnusedSymbolsAsync(repo.Id, 100).ConfigureAwait(false);
+
+        await Assert.That(result.Any(s => s.Name == "LegacyHelper")).IsTrue();
+    }
+
+    [Test]
+    public async Task FindUnusedSymbolsExcludesPrivateSymbols()
+    {
+        using var conn = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(conn);
+        var repo = MakeRepo();
+        await store.UpsertRepositoryAsync(repo).ConfigureAwait(false);
+        await store.InsertFilesAsync([MakeFile(repo.Id, "Helpers.cs")]).ConfigureAwait(false);
+        var files = await store.GetFilesByRepoAsync(repo.Id).ConfigureAwait(false);
+        var fileId = files[0].Id;
+
+        await store.InsertSymbolsAsync([
+            MakeSymbol(fileId, "PrivateHelper", "method", "private"),
+        ]).ConfigureAwait(false);
+
+        var result = await store.FindUnusedSymbolsAsync(repo.Id, 100).ConfigureAwait(false);
+
+        await Assert.That(result.Any(s => s.Name == "PrivateHelper")).IsFalse();
+    }
+
+    [Test]
+    public async Task FindUnusedSymbolsExcludesSymbolsInTestFiles()
+    {
+        using var conn = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(conn);
+        var repo = MakeRepo();
+        await store.UpsertRepositoryAsync(repo).ConfigureAwait(false);
+        await store.InsertFilesAsync([MakeFile(repo.Id, "tests/FooTests.cs")]).ConfigureAwait(false);
+        var files = await store.GetFilesByRepoAsync(repo.Id).ConfigureAwait(false);
+        var fileId = files[0].Id;
+
+        await store.InsertSymbolsAsync([
+            MakeSymbol(fileId, "TestMethod", "method", "public"),
+        ]).ConfigureAwait(false);
+
+        var result = await store.FindUnusedSymbolsAsync(repo.Id, 100).ConfigureAwait(false);
+
+        await Assert.That(result.Any(s => s.Name == "TestMethod")).IsFalse();
+    }
+
+    [Test]
+    public async Task FindUnusedSymbolsExcludesMainEntryPoint()
+    {
+        using var conn = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(conn);
+        var repo = MakeRepo();
+        await store.UpsertRepositoryAsync(repo).ConfigureAwait(false);
+        await store.InsertFilesAsync([MakeFile(repo.Id, "Program.cs")]).ConfigureAwait(false);
+        var files = await store.GetFilesByRepoAsync(repo.Id).ConfigureAwait(false);
+        var fileId = files[0].Id;
+
+        await store.InsertSymbolsAsync([
+            new Symbol(0, fileId, "Main", "method", "public static void Main()", null, 0, 10, 1, 5, "public", null, null, null),
+        ]).ConfigureAwait(false);
+
+        var result = await store.FindUnusedSymbolsAsync(repo.Id, 100).ConfigureAwait(false);
+
+        await Assert.That(result.Any(s => s.Name == "Main")).IsFalse();
+    }
+
+    [Test]
+    public async Task FindUnusedSymbolsLimitIsRespected()
+    {
+        using var conn = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(conn);
+        var repo = MakeRepo();
+        await store.UpsertRepositoryAsync(repo).ConfigureAwait(false);
+        await store.InsertFilesAsync([MakeFile(repo.Id, "Helpers.cs")]).ConfigureAwait(false);
+        var files = await store.GetFilesByRepoAsync(repo.Id).ConfigureAwait(false);
+        var fileId = files[0].Id;
+
+        var symbols = Enumerable.Range(1, 10)
+            .Select(i => MakeSymbol(fileId, $"Helper{i}", "method", "public"))
+            .ToList();
+        await store.InsertSymbolsAsync(symbols).ConfigureAwait(false);
+
+        var result = await store.FindUnusedSymbolsAsync(repo.Id, 3).ConfigureAwait(false);
+
+        await Assert.That(result).Count().IsEqualTo(3);
+    }
+
+    // ── direction = "both" ──────────────────────────────────────────
+
+    [Test]
+    public async Task GetDependencyGraphDirectionBothReturnsBidirectionalEdges()
+    {
+        using var conn = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(conn);
+        var repo = MakeRepo();
+        await store.UpsertRepositoryAsync(repo).ConfigureAwait(false);
+        // A -> B -> C: querying B with direction=both should return edges to A and C
+        await store.InsertFilesAsync([
+            MakeFile(repo.Id, "A.cs"),
+            MakeFile(repo.Id, "B.cs"),
+            MakeFile(repo.Id, "C.cs"),
+        ]).ConfigureAwait(false);
+        var files = await store.GetFilesByRepoAsync(repo.Id).ConfigureAwait(false);
+        var a = files.First(f => f.RelativePath == "A.cs");
+        var b = files.First(f => f.RelativePath == "B.cs");
+        var c = files.First(f => f.RelativePath == "C.cs");
+
+        await store.InsertDependenciesAsync([
+            MakeDep(b.Id, "A", a.Id),   // B depends on A
+            MakeDep(c.Id, "B", b.Id),   // C depends on B
+        ]).ConfigureAwait(false);
+
+        var graph = await store.GetDependencyGraphAsync(repo.Id, "B.cs", "both", 5).ConfigureAwait(false);
+
+        // Should include edges in both directions
+        var outgoing = graph.Edges.Where(e => e.From == "B.cs").ToList();
+        var incoming = graph.Edges.Where(e => e.To == "B.cs").ToList();
+        await Assert.That(outgoing).Count().IsGreaterThan(0);
+        await Assert.That(incoming).Count().IsGreaterThan(0);
+    }
+
+    // ── Cross-repo isolation ─────────────────────────────────────────
+
+    [Test]
+    public async Task BlastRadiusDoesNotLeakAcrossRepos()
+    {
+        using var conn = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(conn);
+        var repo1 = new Repository("repo1", "/root1", "Repo1", "csharp", 0, 0, 0);
+        var repo2 = new Repository("repo2", "/root2", "Repo2", "csharp", 0, 0, 0);
+        await store.UpsertRepositoryAsync(repo1).ConfigureAwait(false);
+        await store.UpsertRepositoryAsync(repo2).ConfigureAwait(false);
+
+        await store.InsertFilesAsync([MakeFile(repo1.Id, "Core.cs"), MakeFile(repo1.Id, "Service.cs")]).ConfigureAwait(false);
+        await store.InsertFilesAsync([MakeFile(repo2.Id, "Core.cs"), MakeFile(repo2.Id, "OtherService.cs")]).ConfigureAwait(false);
+
+        var repo1Files = await store.GetFilesByRepoAsync(repo1.Id).ConfigureAwait(false);
+        var repo2Files = await store.GetFilesByRepoAsync(repo2.Id).ConfigureAwait(false);
+        var core1 = repo1Files.First(f => f.RelativePath == "Core.cs");
+        var svc1 = repo1Files.First(f => f.RelativePath == "Service.cs");
+        var core2 = repo2Files.First(f => f.RelativePath == "Core.cs");
+        var otherSvc2 = repo2Files.First(f => f.RelativePath == "OtherService.cs");
+
+        await store.InsertDependenciesAsync([MakeDep(svc1.Id, "Core", core1.Id)]).ConfigureAwait(false);
+        await store.InsertDependenciesAsync([MakeDep(otherSvc2.Id, "Core", core2.Id)]).ConfigureAwait(false);
+
+        var result = await store.GetBlastRadiusAsync(repo1.Id, "Core.cs", null, 5).ConfigureAwait(false);
+
+        // Only repo1's Service.cs should be affected — OtherService.cs from repo2 must not appear
+        var allAffectedFiles = result.Depths.SelectMany(d => d.Files).ToList();
+        await Assert.That(allAffectedFiles).Contains("Service.cs");
+        await Assert.That(allAffectedFiles).DoesNotContain("OtherService.cs");
+    }
+
+    [Test]
+    public async Task GetDependencyGraphDependentsDoesNotLeakAcrossRepos()
+    {
+        using var conn = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(conn);
+        var repo1 = new Repository("repo1", "/root1", "Repo1", "csharp", 0, 0, 0);
+        var repo2 = new Repository("repo2", "/root2", "Repo2", "csharp", 0, 0, 0);
+        await store.UpsertRepositoryAsync(repo1).ConfigureAwait(false);
+        await store.UpsertRepositoryAsync(repo2).ConfigureAwait(false);
+
+        await store.InsertFilesAsync([MakeFile(repo1.Id, "Lib.cs"), MakeFile(repo1.Id, "Consumer.cs")]).ConfigureAwait(false);
+        await store.InsertFilesAsync([MakeFile(repo2.Id, "Lib.cs"), MakeFile(repo2.Id, "OtherConsumer.cs")]).ConfigureAwait(false);
+
+        var repo1Files = await store.GetFilesByRepoAsync(repo1.Id).ConfigureAwait(false);
+        var repo2Files = await store.GetFilesByRepoAsync(repo2.Id).ConfigureAwait(false);
+        var lib1 = repo1Files.First(f => f.RelativePath == "Lib.cs");
+        var consumer1 = repo1Files.First(f => f.RelativePath == "Consumer.cs");
+        var lib2 = repo2Files.First(f => f.RelativePath == "Lib.cs");
+        var otherConsumer2 = repo2Files.First(f => f.RelativePath == "OtherConsumer.cs");
+
+        await store.InsertDependenciesAsync([MakeDep(consumer1.Id, "Lib", lib1.Id)]).ConfigureAwait(false);
+        await store.InsertDependenciesAsync([MakeDep(otherConsumer2.Id, "Lib", lib2.Id)]).ConfigureAwait(false);
+
+        var graph = await store.GetDependencyGraphAsync(repo1.Id, "Lib.cs", "dependents", 5).ConfigureAwait(false);
+
+        var dependentFiles = graph.Nodes.Where(n => n != "Lib.cs").ToList();
+        await Assert.That(dependentFiles).Contains("Consumer.cs");
+        await Assert.That(graph.Nodes).DoesNotContain("OtherConsumer.cs");
+    }
+
+    // ── Schema migration (edge_kind column) ──────────────────────────
+
+    [Test]
+    public async Task MigrationAddsEdgeKindColumnToExistingDatabase()
+    {
+        using var conn = await CreateTestConnectionAsync().ConfigureAwait(false);
+
+        using var checkCmd = conn.CreateCommand();
+        checkCmd.CommandText = "SELECT sql FROM sqlite_master WHERE type='table' AND name='dependencies'";
+        var sql = (string?)await checkCmd.ExecuteScalarAsync().ConfigureAwait(false);
+
+        await Assert.That(sql).IsNotNull();
+        await Assert.That(sql!).Contains("edge_kind");
+    }
+
+    [Test]
+    public async Task ExistingDependencyRowsDefaultToImportsEdgeKind()
+    {
+        using var conn = await CreateTestConnectionAsync().ConfigureAwait(false);
+        var store = new SqliteSymbolStore(conn);
+        var repo = MakeRepo();
+        await store.UpsertRepositoryAsync(repo).ConfigureAwait(false);
+        await store.InsertFilesAsync([MakeFile(repo.Id, "A.cs")]).ConfigureAwait(false);
+        var files = await store.GetFilesByRepoAsync(repo.Id).ConfigureAwait(false);
+        var fileId = files[0].Id;
+
+        // Insert row without specifying edge_kind (uses default)
+        await store.InsertDependenciesAsync([new Dependency(0, fileId, "B", null, null)]).ConfigureAwait(false);
+
+        var deps = await store.GetDependenciesByFileAsync(fileId).ConfigureAwait(false);
+        await Assert.That(deps[0].EdgeKind).IsEqualTo("imports");
+    }
+}

--- a/tests/CodeCompress.Core.Tests/Storage/DependencyGraphQueryTests.cs
+++ b/tests/CodeCompress.Core.Tests/Storage/DependencyGraphQueryTests.cs
@@ -28,7 +28,7 @@ internal sealed class DependencyGraphQueryTests
     private static Dependency MakeDep(long fileId, string requiresPath, long? resolvedFileId, string edgeKind = "imports") =>
         new(0, fileId, requiresPath, resolvedFileId, null, edgeKind);
 
-    private static Symbol MakeSymbol(long fileId, string name, string kind = "method", string visibility = "public") =>
+    private static Symbol MakeSymbol(long fileId, string name, string kind = "method", string visibility = "Public") =>
         new(0, fileId, name, kind, $"{visibility} {kind} {name}()", null, 0, 10, 1, 5, visibility, null, null, null);
 
     // ── Dependency edge_kind roundtrip ───────────────────────────────
@@ -305,7 +305,7 @@ internal sealed class DependencyGraphQueryTests
         var fileId = files[0].Id;
 
         await store.InsertSymbolsAsync([
-            MakeSymbol(fileId, "LegacyHelper", "method", "public"),
+            MakeSymbol(fileId, "LegacyHelper", "method", "Public"),
         ]).ConfigureAwait(false);
 
         var result = await store.FindUnusedSymbolsAsync(repo.Id, 100).ConfigureAwait(false);
@@ -325,7 +325,7 @@ internal sealed class DependencyGraphQueryTests
         var fileId = files[0].Id;
 
         await store.InsertSymbolsAsync([
-            MakeSymbol(fileId, "PrivateHelper", "method", "private"),
+            MakeSymbol(fileId, "PrivateHelper", "method", "Private"),
         ]).ConfigureAwait(false);
 
         var result = await store.FindUnusedSymbolsAsync(repo.Id, 100).ConfigureAwait(false);
@@ -345,7 +345,7 @@ internal sealed class DependencyGraphQueryTests
         var fileId = files[0].Id;
 
         await store.InsertSymbolsAsync([
-            MakeSymbol(fileId, "TestMethod", "method", "public"),
+            MakeSymbol(fileId, "TestMethod", "method", "Public"),
         ]).ConfigureAwait(false);
 
         var result = await store.FindUnusedSymbolsAsync(repo.Id, 100).ConfigureAwait(false);
@@ -365,7 +365,7 @@ internal sealed class DependencyGraphQueryTests
         var fileId = files[0].Id;
 
         await store.InsertSymbolsAsync([
-            new Symbol(0, fileId, "Main", "method", "public static void Main()", null, 0, 10, 1, 5, "public", null, null, null),
+            new Symbol(0, fileId, "Main", "method", "public static void Main()", null, 0, 10, 1, 5, "Public", null, null, null),
         ]).ConfigureAwait(false);
 
         var result = await store.FindUnusedSymbolsAsync(repo.Id, 100).ConfigureAwait(false);
@@ -385,7 +385,7 @@ internal sealed class DependencyGraphQueryTests
         var fileId = files[0].Id;
 
         var symbols = Enumerable.Range(1, 10)
-            .Select(i => MakeSymbol(fileId, $"Helper{i}", "method", "public"))
+            .Select(i => MakeSymbol(fileId, $"Helper{i}", "method", "Public"))
             .ToList();
         await store.InsertSymbolsAsync(symbols).ConfigureAwait(false);
 

--- a/tests/CodeCompress.Core.Tests/Storage/SymbolStoreQueryTests.cs
+++ b/tests/CodeCompress.Core.Tests/Storage/SymbolStoreQueryTests.cs
@@ -384,8 +384,7 @@ internal sealed class SymbolStoreQueryTests
 
     // ── GetProjectOutlineAsync PathFilter Tests ─────────────────────────
 
-    private static string OsPath(string forwardSlashPath) =>
-        forwardSlashPath.Replace('/', Path.DirectorySeparatorChar);
+    private static string OsPath(string forwardSlashPath) => forwardSlashPath;
 
     private static async Task<SqliteSymbolStore> SeedMultiFileDataAsync(SqliteConnection connection)
     {

--- a/tests/CodeCompress.Integration.Tests/EndToEndTests.cs
+++ b/tests/CodeCompress.Integration.Tests/EndToEndTests.cs
@@ -638,8 +638,7 @@ internal sealed class EndToEndTests : IDisposable
     private string GetDirectoryPrefix(string fileName)
     {
         var relativePath = GetStoredRelativePath(fileName);
-        var separator = relativePath.Contains('/', StringComparison.Ordinal) ? '/' : '\\';
-        var lastSep = relativePath.LastIndexOf(separator);
+        var lastSep = relativePath.LastIndexOf('/');
         return lastSep >= 0 ? relativePath[..lastSep] : string.Empty;
     }
 


### PR DESCRIPTION
## Summary

- Adds `EdgeKind` enum (`imports`/`calls`/`implements`/`inherits`/`references`) to the dependency model with a non-breaking schema migration (`ALTER TABLE dependencies ADD COLUMN edge_kind TEXT NOT NULL DEFAULT 'imports'`)
- New `blast_radius` MCP tool + CLI command: reverse BFS traversal showing which files are affected if a given file/symbol changes, grouped by depth (max depth 1-20)
- New `find_unused_symbols` MCP tool + CLI command: dead-code detection returning public symbols with no incoming dependency edges (excludes test files, `Main`, HTTP controller attributes)
- `dependency_graph` updated: `edgeKind` filter parameter, `direction="both"` now correctly traverses outgoing **and** incoming edges simultaneously (was silently running dependents-only)
- Security fixes: added `repo_id` filter to dependents SQL and BFS queries to prevent cross-repo data leakage; sanitize `rootFile` path before echoing into freeform text output

## Test plan

- [x] All 1233 tests pass (`dotnet test --solution CodeCompress.slnx`)
- [x] Zero warnings (`dotnet build CodeCompress.slnx`)
- [x] 28 new tests: `EdgeKindTests`, `BlastRadiusResultTests`, `DependencyGraphQueryTests` (edge_kind roundtrip, direction=both, cross-repo isolation, blast radius BFS, find_unused_symbols exclusions)
- [x] Security: cross-repo isolation verified by new tests for both `GetBlastRadiusAsync` and `GetDependencyGraphAsync` dependents branch

Closes #178 

🤖 Generated with [Claude Code](https://claude.com/claude-code)