### PR TITLE
feat: add get_hot_path tool for surgical identifier search within symbols (#180)

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ CodeCompress is designed to stay current with minimal effort:
 | `get_symbols` | Batch retrieve multiple symbols in one call (up to 50) |
 | `get_module_api` | Complete public API of a single file/module |
 | `expand_symbol` | Extract a single method from a large class (~60% fewer tokens than `get_symbol`) |
+| `get_hot_path` | Return only the lines within a symbol that contain specific identifiers plus surrounding context (10–40x fewer tokens than the full body) |
 | `search_symbols` | Full-text search across symbol names, signatures, parent types, and docs. Auto-retries with contains-match when exact FTS5 returns zero results. |
 | `search_text` | Raw text search across file contents (with glob filtering) |
 | `topic_outline` | Topic-based search with results grouped in outline format |
@@ -406,6 +407,9 @@ codecompress search-text --path /path/to/project --query "TODO"
 # Retrieve a nested method without loading the whole class (~60% token savings)
 codecompress expand-symbol --path /path/to/project --name MyClass:MyMethod
 
+# Return only lines matching specific identifiers within a symbol (~10-40x fewer tokens)
+codecompress get-hot-path --path /path/to/project --name MyClass:MyMethod --identifiers "userId,status"
+
 # Batch retrieve multiple symbols at once
 codecompress get-symbols --path /path/to/project --names "Foo,Bar,Baz"
 
@@ -462,6 +466,7 @@ This outputs a markdown block you can paste into `CLAUDE.md`, system prompts, or
 | `outline` | `project_outline` | Compressed codebase overview |
 | `get-symbol` | `get_symbol` | Retrieve symbol source code |
 | `expand-symbol` | `expand_symbol` | Extract nested symbol (~60% fewer tokens) |
+| `get-hot-path` | `get_hot_path` | Return only lines matching identifiers within a symbol |
 | `get-symbols` | `get_symbols` | Batch retrieve multiple symbols |
 | `get-module-api` | `get_module_api` | Public API surface of a file |
 | `search` | `search_symbols` | FTS5 symbol search (auto contains-match fallback) |

--- a/src/CodeCompress.Cli/Program.cs
+++ b/src/CodeCompress.Cli/Program.cs
@@ -959,6 +959,179 @@ expandSymbolCommand.SetAction(async parseResult =>
 
 rootCommand.Subcommands.Add(expandSymbolCommand);
 
+// ── get-hot-path ─────────────────────────────────────────────
+
+var hotPathPathOption = CreatePathOption();
+var hotPathNameOption = new Option<string>("--name")
+{
+    Description = "Symbol name — accepts qualified 'Parent:Child' (e.g., OrderService:ProcessPayment) or unqualified names.",
+    Required = true,
+};
+var hotPathIdentifiersOption = new Option<string>("--identifiers")
+{
+    Description = "Comma-separated identifiers to search for within the symbol body (whole-word matching, e.g., 'userId,status').",
+    Required = true,
+};
+var hotPathContextLinesOption = new Option<int>("--context-lines")
+{
+    Description = "Lines of context before and after each match (0-10, default 3). Values outside range are clamped.",
+    DefaultValueFactory = _ => 3,
+};
+
+var hotPathCommand = new Command("get-hot-path",
+    "Return only the lines within a symbol that contain specific identifiers plus surrounding context. " +
+    "Use when tracing a variable or condition within a large function — costs ~50-100 tokens vs 500-2000 for the full body. " +
+    "Identifiers are matched as whole words only. Overlapping context windows are merged. Requires index.")
+{
+    hotPathPathOption,
+    hotPathNameOption,
+    hotPathIdentifiersOption,
+    hotPathContextLinesOption,
+};
+
+hotPathCommand.SetAction(async parseResult =>
+{
+    var path = parseResult.GetValue(hotPathPathOption)!;
+    var name = parseResult.GetValue(hotPathNameOption)!;
+    var identifiersRaw = parseResult.GetValue(hotPathIdentifiersOption)!;
+    var contextLines = Math.Clamp(parseResult.GetValue(hotPathContextLinesOption), 0, 10);
+    var json = parseResult.GetValue(jsonOption);
+
+    var identifiers = identifiersRaw
+        .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+    if (identifiers.Length == 0)
+    {
+        await WriteErrorAsync("No identifiers provided", "EMPTY_IDENTIFIERS", json, jsonSerializerOptions).ConfigureAwait(false);
+        return;
+    }
+
+    var scope = await CreateProjectScopeAsync(path, provider).ConfigureAwait(false);
+    await using (scope.ConfigureAwait(false))
+    {
+        var symbol = await scope.Store.GetSymbolByNameAsync(scope.RepoId, name).ConfigureAwait(false);
+        if (symbol is null)
+        {
+            var candidates = await scope.Store.GetSymbolCandidatesByNameAsync(scope.RepoId, name).ConfigureAwait(false);
+            if (candidates.Count == 1)
+            {
+                symbol = candidates[0];
+            }
+            else if (candidates.Count > 1)
+            {
+                var qualifiedNames = candidates.Select(c => c.ParentSymbol is not null ? $"{c.ParentSymbol}:{c.Name}" : c.Name);
+                await WriteErrorAsync("Multiple symbols match this name", "SYMBOL_NOT_FOUND", json, jsonSerializerOptions,
+                    $"Candidates: {string.Join(", ", qualifiedNames)}").ConfigureAwait(false);
+                return;
+            }
+            else
+            {
+                await WriteErrorAsync("Symbol not found", "SYMBOL_NOT_FOUND", json, jsonSerializerOptions,
+                    "Use 'codecompress search --path <path> --query <name>' to discover symbol names.").ConfigureAwait(false);
+                return;
+            }
+        }
+
+        var files = await scope.Store.GetFilesByRepoAsync(scope.RepoId).ConfigureAwait(false);
+        var file = files.FirstOrDefault(f => f.Id == symbol.FileId);
+        if (file is null)
+        {
+            await WriteErrorAsync("File not found for symbol", "FILE_NOT_FOUND", json, jsonSerializerOptions).ConfigureAwait(false);
+            return;
+        }
+
+        var pathValidator = provider.GetRequiredService<IPathValidator>();
+        string resolvedPath;
+        try
+        {
+            resolvedPath = pathValidator.ValidatePath(Path.Combine(path, file.RelativePath), path);
+        }
+        catch (ArgumentException)
+        {
+            await WriteErrorAsync("Path validation failed", "INVALID_PATH", json, jsonSerializerOptions).ConfigureAwait(false);
+            return;
+        }
+
+        // Determine scan range
+        int scanLineStart = symbol.BodyLineStart ?? symbol.LineStart;
+        int scanLineEnd = symbol.BodyLineEnd ?? symbol.LineEnd;
+        var totalLines = Math.Max(0, scanLineEnd - scanLineStart + 1);
+
+        // Read source and split into lines
+        var source = await ReadSourceCodeAsync(resolvedPath, symbol.ByteOffset, symbol.ByteLength).ConfigureAwait(false);
+        var rawLines = source.Split('\n');
+
+        // Build whole-word patterns
+        var patterns = identifiers
+            .Select(id => (Id: id, Pattern: new System.Text.RegularExpressions.Regex(
+                $@"\b{System.Text.RegularExpressions.Regex.Escape(id)}\b",
+                System.Text.RegularExpressions.RegexOptions.None,
+                TimeSpan.FromMilliseconds(100))))
+            .ToList();
+
+        // Find matches
+        var seenMatches = new HashSet<(string, int)>();
+        var rawMatches = new List<(string Identifier, int LineNumber)>();
+        for (var lineNum = scanLineStart; lineNum <= scanLineEnd; lineNum++)
+        {
+            var idx = lineNum - symbol.LineStart;
+            if (idx < 0 || idx >= rawLines.Length) continue;
+            var lineText = rawLines[idx].TrimEnd('\r');
+            foreach (var (id, pattern) in patterns)
+            {
+                if (pattern.IsMatch(lineText) && seenMatches.Add((id, lineNum)))
+                    rawMatches.Add((id, lineNum));
+            }
+        }
+
+        if (json)
+        {
+            var matchObjects = BuildHotPathMatchObjects(rawMatches, rawLines, symbol, scanLineStart, scanLineEnd, contextLines);
+            var returnedLines = matchObjects.Sum(m => m.Context.Count);
+            Console.WriteLine(JsonSerializer.Serialize(
+                new { Symbol = symbol.Name, File = file.RelativePath, TotalLines = totalLines, ReturnedLines = returnedLines, Matches = matchObjects },
+                jsonSerializerOptions));
+        }
+        else
+        {
+            if (rawMatches.Count == 0)
+            {
+                Console.WriteLine($"No matches found for {identifiers.Length} identifier(s) in '{symbol.Name}'.");
+                return;
+            }
+
+            Console.WriteLine($"// {symbol.Name} — {rawMatches.Count} match(es) for {identifiers.Length} identifier(s)");
+            Console.WriteLine($"// {file.RelativePath}  ({totalLines} total lines in scan range)");
+            Console.WriteLine();
+
+            var matchObjects = BuildHotPathMatchObjects(rawMatches, rawLines, symbol, scanLineStart, scanLineEnd, contextLines);
+            foreach (var m in matchObjects)
+            {
+                if (m.Context.Count > 0)
+                {
+                    foreach (var (lineNumber, text) in m.Context)
+                    {
+                        var marker = lineNumber == m.Line ? ">" : " ";
+                        Console.WriteLine($"  {marker} {lineNumber,6}: {text}");
+                    }
+
+                    Console.WriteLine();
+                }
+                else
+                {
+                    Console.WriteLine($"  > {m.Line,6}: (see context above — same window as previous match)");
+                    Console.WriteLine();
+                }
+            }
+
+            var uniqueLines = matchObjects.Sum(m => m.Context.Count);
+            await WriteHintAsync($"Returned {uniqueLines} unique line(s). Use 'get-symbol' to view the full body.", json).ConfigureAwait(false);
+        }
+    }
+});
+
+rootCommand.Subcommands.Add(hotPathCommand);
+
 // ── get-symbols (batch) ─────────────────────────────────────
 
 var getSymbolsPathOption = CreatePathOption();
@@ -1504,7 +1677,11 @@ agentInstructionsCommand.SetAction(_ =>
            code by symbol name. Accepts unqualified names (auto-resolved) or Parent:Child format.
         5. `codecompress expand-symbol --path <project-root> --name <Parent:Method>` — Get a single
            method without loading the parent class (~60% fewer tokens than get-symbol on parent).
-        6. `codecompress get-symbols --path <project-root> --names <N1,N2,N3>` — Batch retrieve
+        6. `codecompress get-hot-path --path <project-root> --name <Name> --identifiers <id1,id2>` — Return
+           only lines in a symbol that contain specific identifiers plus context. Use when tracing a variable
+           or condition within a large function — 10-40x fewer tokens than get-symbol. Identifiers matched
+           as whole words. Add `--context-lines N` to control surrounding line count (0-10, default 3).
+        7. `codecompress get-symbols --path <project-root> --names <N1,N2,N3>` — Batch retrieve
            multiple symbols in one call (max 50). Far more efficient than repeated get-symbol.
         7. `codecompress search-text --path <project-root> --query <term>` — Search raw file contents
            for string literals, comments, or non-symbol patterns.
@@ -1533,7 +1710,8 @@ agentInstructionsCommand.SetAction(_ =>
         `{error: "message", code: "ERROR_CODE", retryable: false}`
 
         Error codes: INVALID_PATH, SYMBOL_NOT_FOUND, DIRECTORY_NOT_FOUND, MODULE_NOT_FOUND,
-        SNAPSHOT_NOT_FOUND, EMPTY_QUERY, EMPTY_SYMBOL_NAMES, SYMBOL_LIMIT_EXCEEDED, NO_PROJECTS.
+        SNAPSHOT_NOT_FOUND, EMPTY_QUERY, EMPTY_SYMBOL_NAMES, SYMBOL_LIMIT_EXCEEDED, NO_PROJECTS,
+        EMPTY_IDENTIFIERS, FILE_NOT_FOUND.
 
         All current errors are permanent (retryable: false) — fix the input rather than retrying.
 
@@ -1541,6 +1719,7 @@ agentInstructionsCommand.SetAction(_ =>
 
         - Use `get-symbols` for batches — single call vs N separate get-symbol calls.
         - Use `expand-symbol` for one method in a large class — ~60% fewer tokens.
+        - Use `get-hot-path` to trace a specific variable or condition — 10-40x fewer tokens than expand-symbol.
         - Use `search` (not search-text) for finding classes/functions — structured results.
         - Use `outline --path-filter src/` to scope — faster than full outline + client filtering.
         - Symbol names accept unqualified names (e.g., 'MyMethod') — auto-resolved if unique.
@@ -1555,6 +1734,8 @@ agentInstructionsCommand.SetAction(_ =>
         - --group-by: 'file' (default), 'kind', 'directory'. Other values rejected.
         - --direction: 'dependencies', 'dependents', 'both' (default). Other values rejected.
         - --names: max 50 comma-separated. Applies to: get-symbols.
+        - --context-lines: 0-10 (default 3), clamped. Applies to: get-hot-path.
+        - --identifiers: comma-separated non-empty identifiers, required. Applies to: get-hot-path.
 
         ## General Tips
 
@@ -1626,6 +1807,65 @@ static async Task WriteErrorAsync(string error, string code, bool isJson, JsonSe
             await Console.Error.WriteLineAsync($"  Hint: {guidance}").ConfigureAwait(false);
         }
     }
+}
+
+static List<(string Identifier, int Line, List<(int LineNumber, string Text)> Context)> BuildHotPathMatchObjects(
+    List<(string Identifier, int LineNumber)> rawMatches,
+    string[] rawLines,
+    CodeCompress.Core.Models.Symbol symbol,
+    int scanLineStart,
+    int scanLineEnd,
+    int contextLines)
+{
+    var windowedMatches = rawMatches
+        .OrderBy(m => m.LineNumber)
+        .ThenBy(m => m.Identifier, StringComparer.Ordinal)
+        .Select(m => (
+            m.Identifier,
+            m.LineNumber,
+            WinStart: Math.Max(scanLineStart, m.LineNumber - contextLines),
+            WinEnd: Math.Min(scanLineEnd, m.LineNumber + contextLines)))
+        .ToList();
+
+    var mergedWindows = new List<(int Start, int End)>();
+    foreach (var (_, _, winStart, winEnd) in windowedMatches.OrderBy(m => m.WinStart))
+    {
+        if (mergedWindows.Count == 0 || winStart > mergedWindows[^1].End)
+            mergedWindows.Add((winStart, winEnd));
+        else
+        {
+            var last = mergedWindows[^1];
+            mergedWindows[^1] = (last.Start, Math.Max(last.End, winEnd));
+        }
+    }
+
+    var assignedWindows = new HashSet<int>();
+    var result = new List<(string Identifier, int Line, List<(int, string)> Context)>();
+
+    foreach (var (identifier, lineNumber, _, _) in windowedMatches)
+    {
+        var windowIdx = mergedWindows.FindIndex(w => w.Start <= lineNumber && lineNumber <= w.End);
+        List<(int, string)> context;
+        if (windowIdx >= 0 && assignedWindows.Add(windowIdx))
+        {
+            var (mStart, mEnd) = mergedWindows[windowIdx];
+            context = [];
+            for (var ln = mStart; ln <= mEnd; ln++)
+            {
+                var idx = ln - symbol.LineStart;
+                if (idx >= 0 && idx < rawLines.Length)
+                    context.Add((ln, rawLines[idx].TrimEnd('\r')));
+            }
+        }
+        else
+        {
+            context = [];
+        }
+
+        result.Add((identifier, lineNumber, context));
+    }
+
+    return result;
 }
 
 static async Task<string> ReadSourceCodeAsync(string filePath, int byteOffset, int byteLength)

--- a/src/CodeCompress.Core/Models/HotPathResult.cs
+++ b/src/CodeCompress.Core/Models/HotPathResult.cs
@@ -1,0 +1,15 @@
+namespace CodeCompress.Core.Models;
+
+public sealed record HotPathContextLine(int LineNumber, string Text);
+
+public sealed record HotPathMatch(
+    string Identifier,
+    int Line,
+    IReadOnlyList<HotPathContextLine> Context);
+
+public sealed record HotPathResult(
+    string Symbol,
+    string File,
+    int TotalLines,
+    int ReturnedLines,
+    IReadOnlyList<HotPathMatch> Matches);

--- a/src/CodeCompress.Server/Tools/QueryTools.cs
+++ b/src/CodeCompress.Server/Tools/QueryTools.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Globalization;
 using System.Text;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using CodeCompress.Core.Models;
 using CodeCompress.Core.Storage;
 using CodeCompress.Core.Validation;
@@ -805,6 +806,223 @@ internal sealed class QueryTools
 
             return JsonSerializer.Serialize(response, SerializerOptions);
         }
+    }
+
+    [McpServerTool(Name = "get_hot_path")]
+    [Description("Returns only the lines within a symbol that contain specific identifiers plus surrounding context — use when tracing a variable, assignment, or conditional branch within a large function. Costs ~50–100 tokens vs 500–2000 for the full body. Identifiers are matched as whole words only (Regex.Escaped \\b boundaries prevent partial-word false positives). Falls back to the full symbol range if body line ranges are not available. Requires index_project to have been called first. Returns JSON: {symbol, file, total_lines, returned_lines, matches: [{identifier, line, context: [{line_number, text}]}]}. No matches returns {symbol, file, total_lines, returned_lines: 0, matches: []}. Overlapping context windows are merged — lines 7–15 are returned once, not duplicated; the first match in a merged window carries the context, subsequent matches in the same window have an empty context array. Errors return JSON {error, code, retryable}. Codes: INVALID_PATH, SYMBOL_NOT_FOUND (includes 'symbol' field — use search_symbols to find the correct name), FILE_NOT_FOUND, EMPTY_IDENTIFIERS (supply at least one non-empty identifier string).")]
+    public async Task<string> GetHotPath(
+        [Description("ABSOLUTE path to the project root directory — the same root used with index_project (e.g., 'C:\\Projects\\MyGame' or '/home/user/my-project'). Must NOT be a subdirectory or relative path.")] string path,
+        [Description("Symbol name — accepts 'Parent:Child' qualified names (e.g., 'OrderService:ProcessPayment') or unqualified names (e.g., 'ProcessPayment'). Unqualified names are resolved automatically.")] string symbolName,
+        [Description("Identifiers to search for within the symbol body using whole-word matching. Each value is Regex.Escaped before use — agent-supplied metacharacters cannot cause injection.")] string[] identifiers,
+        [Description("Lines of context to include before and after each match (0–10, default 3). Values outside this range are clamped.")] int contextLines = 3,
+        CancellationToken cancellationToken = default)
+    {
+        string validatedPath;
+        try
+        {
+            validatedPath = _pathValidator.ValidatePath(path, path);
+        }
+        catch (ArgumentException)
+        {
+            return SerializeError("Path validation failed", "INVALID_PATH");
+        }
+
+        contextLines = Math.Clamp(contextLines, 0, 10);
+
+        var validIdentifiers = identifiers?.Where(id => !string.IsNullOrWhiteSpace(id)).ToArray() ?? [];
+        if (validIdentifiers.Length == 0)
+        {
+            return SerializeError("Identifiers array must contain at least one non-empty value", "EMPTY_IDENTIFIERS");
+        }
+
+        var scope = await _scopeFactory.CreateAsync(validatedPath, cancellationToken).ConfigureAwait(false);
+        await using (scope.ConfigureAwait(false))
+        {
+            var symbol = await scope.Store.GetSymbolByNameAsync(scope.RepoId, symbolName).ConfigureAwait(false);
+            if (symbol is null)
+            {
+                var candidates = await scope.Store.GetSymbolCandidatesByNameAsync(scope.RepoId, symbolName).ConfigureAwait(false);
+                if (candidates.Count == 1)
+                {
+                    symbol = candidates[0];
+                }
+                else if (candidates.Count > 1)
+                {
+                    return JsonSerializer.Serialize(
+                        new
+                        {
+                            Error = "Multiple symbols match this name",
+                            Code = "SYMBOL_NOT_FOUND",
+                            Retryable = false,
+                            Symbol = SanitizeSymbolName(symbolName),
+                            Candidates = candidates.Select(c => c.ParentSymbol is not null ? $"{c.ParentSymbol}:{c.Name}" : c.Name),
+                        },
+                        SerializerOptions);
+                }
+                else
+                {
+                    return JsonSerializer.Serialize(
+                        new { Error = "Symbol not found", Code = "SYMBOL_NOT_FOUND", Retryable = false, Symbol = SanitizeSymbolName(symbolName), Guidance = SymbolNotFoundGuidance },
+                        SerializerOptions);
+                }
+            }
+
+            var files = await scope.Store.GetFilesByRepoAsync(scope.RepoId).ConfigureAwait(false);
+            var file = files.FirstOrDefault(f => f.Id == symbol.FileId);
+            if (file is null)
+            {
+                return SerializeError("File not found for symbol", "FILE_NOT_FOUND");
+            }
+
+            string resolvedPath;
+            try
+            {
+                resolvedPath = _pathValidator.ValidatePath(
+                    Path.Combine(validatedPath, file.RelativePath), validatedPath);
+            }
+            catch (ArgumentException)
+            {
+                return SerializeError("Path validation failed", "INVALID_PATH");
+            }
+
+            var hotPath = await ExtractHotPathAsync(resolvedPath, symbol, file.RelativePath, validIdentifiers, contextLines).ConfigureAwait(false);
+
+            return JsonSerializer.Serialize(
+                new
+                {
+                    hotPath.Symbol,
+                    hotPath.File,
+                    hotPath.TotalLines,
+                    hotPath.ReturnedLines,
+                    hotPath.Matches,
+                },
+                SerializerOptions);
+        }
+    }
+
+    private static async Task<HotPathResult> ExtractHotPathAsync(
+        string filePath,
+        Symbol symbol,
+        string fileRelativePath,
+        string[] identifiers,
+        int contextLines)
+    {
+        var source = await ReadSourceCodeAsync(filePath, symbol.ByteOffset, symbol.ByteLength).ConfigureAwait(false);
+
+        // Split on \n; TrimEnd('\r') handles \r\n line endings
+        var rawLines = source.Split('\n');
+
+        // Determine 1-based scan range (absolute line numbers in the file)
+        int scanLineStart, scanLineEnd;
+        if (symbol.BodyLineStart.HasValue && symbol.BodyLineEnd.HasValue)
+        {
+            scanLineStart = symbol.BodyLineStart.Value;
+            scanLineEnd = symbol.BodyLineEnd.Value;
+        }
+        else
+        {
+            scanLineStart = symbol.LineStart;
+            scanLineEnd = symbol.LineEnd;
+        }
+
+        var totalLines = Math.Max(0, scanLineEnd - scanLineStart + 1);
+
+        // Build whole-word patterns — Regex.Escape prevents agent-supplied metacharacters from injecting patterns
+        var patterns = identifiers
+            .Select(id => (Id: id, Pattern: new Regex(
+                $@"\b{Regex.Escape(id)}\b",
+                RegexOptions.None,
+                TimeSpan.FromMilliseconds(100))))
+            .ToList();
+
+        // Find all (identifier, 1-based absolute line number) matches within scan range
+        var seenMatches = new HashSet<(string, int)>();
+        var rawMatches = new List<(string Identifier, int LineNumber)>();
+
+        for (var lineNum = scanLineStart; lineNum <= scanLineEnd; lineNum++)
+        {
+            var idx = lineNum - symbol.LineStart;
+            if (idx < 0 || idx >= rawLines.Length)
+            {
+                continue;
+            }
+
+            var lineText = rawLines[idx].TrimEnd('\r');
+            foreach (var (id, pattern) in patterns)
+            {
+                if (pattern.IsMatch(lineText) && seenMatches.Add((id, lineNum)))
+                {
+                    rawMatches.Add((id, lineNum));
+                }
+            }
+        }
+
+        if (rawMatches.Count == 0)
+        {
+            return new HotPathResult(symbol.Name, fileRelativePath, totalLines, 0, []);
+        }
+
+        // Compute per-match windows, clamped to scan range, sorted by line number
+        var windowedMatches = rawMatches
+            .OrderBy(m => m.LineNumber)
+            .ThenBy(m => m.Identifier, StringComparer.Ordinal)
+            .Select(m => (
+                m.Identifier,
+                m.LineNumber,
+                WinStart: Math.Max(scanLineStart, m.LineNumber - contextLines),
+                WinEnd: Math.Min(scanLineEnd, m.LineNumber + contextLines)))
+            .ToList();
+
+        // Merge overlapping windows (windows that share at least one line)
+        var mergedWindows = new List<(int Start, int End)>();
+        foreach (var (_, _, winStart, winEnd) in windowedMatches.OrderBy(m => m.WinStart))
+        {
+            if (mergedWindows.Count == 0 || winStart > mergedWindows[^1].End)
+            {
+                mergedWindows.Add((winStart, winEnd));
+            }
+            else
+            {
+                var last = mergedWindows[^1];
+                mergedWindows[^1] = (last.Start, Math.Max(last.End, winEnd));
+            }
+        }
+
+        var returnedLines = mergedWindows.Sum(w => w.End - w.Start + 1);
+
+        // Build matches: first match per merged window gets the context lines; subsequent get empty
+        var assignedWindowIndices = new HashSet<int>();
+        var matches = new List<HotPathMatch>();
+
+        foreach (var (identifier, lineNumber, _, _) in windowedMatches)
+        {
+            var windowIdx = mergedWindows.FindIndex(w => w.Start <= lineNumber && lineNumber <= w.End);
+
+            IReadOnlyList<HotPathContextLine> context;
+            if (windowIdx >= 0 && assignedWindowIndices.Add(windowIdx))
+            {
+                var (mStart, mEnd) = mergedWindows[windowIdx];
+                var contextLineList = new List<HotPathContextLine>();
+                for (var ln = mStart; ln <= mEnd; ln++)
+                {
+                    var idx = ln - symbol.LineStart;
+                    if (idx >= 0 && idx < rawLines.Length)
+                    {
+                        contextLineList.Add(new HotPathContextLine(ln, rawLines[idx].TrimEnd('\r')));
+                    }
+                }
+
+                context = contextLineList;
+            }
+            else
+            {
+                context = [];
+            }
+
+            matches.Add(new HotPathMatch(identifier, lineNumber, context));
+        }
+
+        return new HotPathResult(symbol.Name, fileRelativePath, totalLines, returnedLines, matches);
     }
 
     private static string FormatTopicOutline(Core.Models.ProjectOutline outline, string query, int maxResults)

--- a/tests/CodeCompress.Server.Tests/Tools/QueryToolsTests.cs
+++ b/tests/CodeCompress.Server.Tests/Tools/QueryToolsTests.cs
@@ -1797,6 +1797,355 @@ internal sealed class QueryToolsTests
         return tempPath;
     }
 
+    // ── GetHotPath Tests ─────────────────────────────────────────────
+
+    [Test]
+    public async Task GetHotPathSingleIdentifierMatchesWithContext()
+    {
+        var lines = new[] { "line1", "line2", "line3", "line4", "has userId here", "line6", "line7", "line8", "line9", "line10" };
+        var content = string.Join("\n", lines) + "\n";
+        var tempFile = CreateTempFile(content);
+        try
+        {
+            var dir = Path.GetDirectoryName(tempFile)!;
+            var fileName = Path.GetFileName(tempFile);
+            var symbol = new Symbol(1, 1, "ProcessPayment", "Method", "void ProcessPayment()",
+                null, 0, Encoding.UTF8.GetByteCount(content), 1, 10, "Public", null, null, null);
+
+            _store.GetSymbolByNameAsync("test-repo-id", "ProcessPayment").Returns(symbol);
+            _store.GetFilesByRepoAsync("test-repo-id")
+                .Returns(new List<FileRecord> { new(1, "test-repo-id", fileName, "hash1", 100, 10, 1000, 2000) });
+
+            var result = await _tools.GetHotPath(dir, "ProcessPayment", ["userId"], contextLines: 2).ConfigureAwait(false);
+
+            using var doc = JsonDocument.Parse(result);
+            var root = doc.RootElement;
+            await Assert.That(root.GetProperty("symbol").GetString()).IsEqualTo("ProcessPayment");
+            await Assert.That(root.GetProperty("total_lines").GetInt32()).IsEqualTo(10);
+            await Assert.That(root.GetProperty("returned_lines").GetInt32()).IsEqualTo(5); // lines 3-7
+
+            var matches = root.GetProperty("matches");
+            await Assert.That(matches.GetArrayLength()).IsEqualTo(1);
+            var match = matches[0];
+            await Assert.That(match.GetProperty("identifier").GetString()).IsEqualTo("userId");
+            await Assert.That(match.GetProperty("line").GetInt32()).IsEqualTo(5);
+            var context = match.GetProperty("context");
+            await Assert.That(context.GetArrayLength()).IsEqualTo(5);
+            await Assert.That(context[0].GetProperty("line_number").GetInt32()).IsEqualTo(3);
+            await Assert.That(context[4].GetProperty("line_number").GetInt32()).IsEqualTo(7);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Test]
+    public async Task GetHotPathMultipleIdentifiersReturnAllMatches()
+    {
+        var lines = new[] { "line1", "has userId here", "line3", "line4", "has status Pending here", "line6", "line7" };
+        var content = string.Join("\n", lines) + "\n";
+        var tempFile = CreateTempFile(content);
+        try
+        {
+            var dir = Path.GetDirectoryName(tempFile)!;
+            var fileName = Path.GetFileName(tempFile);
+            var symbol = new Symbol(1, 1, "Process", "Method", "void Process()",
+                null, 0, Encoding.UTF8.GetByteCount(content), 1, 7, "Public", null, null, null);
+
+            _store.GetSymbolByNameAsync("test-repo-id", "Process").Returns(symbol);
+            _store.GetFilesByRepoAsync("test-repo-id")
+                .Returns(new List<FileRecord> { new(1, "test-repo-id", fileName, "hash1", 100, 7, 1000, 2000) });
+
+            // userId at line 2 → window [1,3]; status at line 5 → window [4,6]; no overlap
+            var result = await _tools.GetHotPath(dir, "Process", ["userId", "status"], contextLines: 1).ConfigureAwait(false);
+
+            using var doc = JsonDocument.Parse(result);
+            var root = doc.RootElement;
+            await Assert.That(root.GetProperty("returned_lines").GetInt32()).IsEqualTo(6);
+
+            var matches = root.GetProperty("matches");
+            await Assert.That(matches.GetArrayLength()).IsEqualTo(2);
+
+            var match0 = matches[0];
+            await Assert.That(match0.GetProperty("identifier").GetString()).IsEqualTo("userId");
+            await Assert.That(match0.GetProperty("line").GetInt32()).IsEqualTo(2);
+            await Assert.That(match0.GetProperty("context").GetArrayLength()).IsEqualTo(3);
+
+            var match1 = matches[1];
+            await Assert.That(match1.GetProperty("identifier").GetString()).IsEqualTo("status");
+            await Assert.That(match1.GetProperty("line").GetInt32()).IsEqualTo(5);
+            await Assert.That(match1.GetProperty("context").GetArrayLength()).IsEqualTo(3);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Test]
+    public async Task GetHotPathOverlappingContextMergedNoDuplicateLines()
+    {
+        var lines = new[] { "line1", "line2", "line3", "line4", "has userId here", "line6", "has status Pending here", "line8", "line9", "line10" };
+        var content = string.Join("\n", lines) + "\n";
+        var tempFile = CreateTempFile(content);
+        try
+        {
+            var dir = Path.GetDirectoryName(tempFile)!;
+            var fileName = Path.GetFileName(tempFile);
+            var symbol = new Symbol(1, 1, "Process", "Method", "void Process()",
+                null, 0, Encoding.UTF8.GetByteCount(content), 1, 10, "Public", null, null, null);
+
+            _store.GetSymbolByNameAsync("test-repo-id", "Process").Returns(symbol);
+            _store.GetFilesByRepoAsync("test-repo-id")
+                .Returns(new List<FileRecord> { new(1, "test-repo-id", fileName, "hash1", 100, 10, 1000, 2000) });
+
+            // userId at line 5 → window [2,8]; status at line 7 → window [4,10]; merged [2,10] = 9 lines
+            var result = await _tools.GetHotPath(dir, "Process", ["userId", "status"], contextLines: 3).ConfigureAwait(false);
+
+            using var doc = JsonDocument.Parse(result);
+            var root = doc.RootElement;
+            await Assert.That(root.GetProperty("returned_lines").GetInt32()).IsEqualTo(9);
+
+            var matches = root.GetProperty("matches");
+            await Assert.That(matches.GetArrayLength()).IsEqualTo(2);
+
+            // First match (userId at line 5) gets the full merged context [2-10]
+            var firstMatch = matches[0];
+            await Assert.That(firstMatch.GetProperty("identifier").GetString()).IsEqualTo("userId");
+            await Assert.That(firstMatch.GetProperty("context").GetArrayLength()).IsEqualTo(9);
+
+            // Second match (status at line 7) gets empty context — already covered by merged window
+            var secondMatch = matches[1];
+            await Assert.That(secondMatch.GetProperty("identifier").GetString()).IsEqualTo("status");
+            await Assert.That(secondMatch.GetProperty("context").GetArrayLength()).IsEqualTo(0);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Test]
+    public async Task GetHotPathWholeWordMatchingOnly()
+    {
+        var lines = new[] { "has userIdHash here", "has userId here" };
+        var content = string.Join("\n", lines) + "\n";
+        var tempFile = CreateTempFile(content);
+        try
+        {
+            var dir = Path.GetDirectoryName(tempFile)!;
+            var fileName = Path.GetFileName(tempFile);
+            var symbol = new Symbol(1, 1, "Process", "Method", "void Process()",
+                null, 0, Encoding.UTF8.GetByteCount(content), 1, 2, "Public", null, null, null);
+
+            _store.GetSymbolByNameAsync("test-repo-id", "Process").Returns(symbol);
+            _store.GetFilesByRepoAsync("test-repo-id")
+                .Returns(new List<FileRecord> { new(1, "test-repo-id", fileName, "hash1", 100, 2, 1000, 2000) });
+
+            var result = await _tools.GetHotPath(dir, "Process", ["userId"], contextLines: 0).ConfigureAwait(false);
+
+            using var doc = JsonDocument.Parse(result);
+            var root = doc.RootElement;
+            var matches = root.GetProperty("matches");
+            await Assert.That(matches.GetArrayLength()).IsEqualTo(1); // line 1 (userIdHash) NOT matched
+            await Assert.That(matches[0].GetProperty("line").GetInt32()).IsEqualTo(2);
+            await Assert.That(root.GetProperty("returned_lines").GetInt32()).IsEqualTo(1);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Test]
+    public async Task GetHotPathNoMatchesReturnsEmptyMatches()
+    {
+        var content = "line1\nline2\nline3\n";
+        var tempFile = CreateTempFile(content);
+        try
+        {
+            var dir = Path.GetDirectoryName(tempFile)!;
+            var fileName = Path.GetFileName(tempFile);
+            var symbol = new Symbol(1, 1, "Process", "Method", "void Process()",
+                null, 0, Encoding.UTF8.GetByteCount(content), 1, 3, "Public", null, null, null);
+
+            _store.GetSymbolByNameAsync("test-repo-id", "Process").Returns(symbol);
+            _store.GetFilesByRepoAsync("test-repo-id")
+                .Returns(new List<FileRecord> { new(1, "test-repo-id", fileName, "hash1", 100, 3, 1000, 2000) });
+
+            var result = await _tools.GetHotPath(dir, "Process", ["userId"], contextLines: 3).ConfigureAwait(false);
+
+            using var doc = JsonDocument.Parse(result);
+            var root = doc.RootElement;
+            await Assert.That(root.GetProperty("matches").GetArrayLength()).IsEqualTo(0);
+            await Assert.That(root.GetProperty("returned_lines").GetInt32()).IsEqualTo(0);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Test]
+    public async Task GetHotPathContextLinesDefaultsToThree()
+    {
+        var lines = new[] { "line1", "line2", "line3", "line4", "has userId here", "line6", "line7", "line8", "line9", "line10" };
+        var content = string.Join("\n", lines) + "\n";
+        var tempFile = CreateTempFile(content);
+        try
+        {
+            var dir = Path.GetDirectoryName(tempFile)!;
+            var fileName = Path.GetFileName(tempFile);
+            var symbol = new Symbol(1, 1, "Process", "Method", "void Process()",
+                null, 0, Encoding.UTF8.GetByteCount(content), 1, 10, "Public", null, null, null);
+
+            _store.GetSymbolByNameAsync("test-repo-id", "Process").Returns(symbol);
+            _store.GetFilesByRepoAsync("test-repo-id")
+                .Returns(new List<FileRecord> { new(1, "test-repo-id", fileName, "hash1", 100, 10, 1000, 2000) });
+
+            // Default contextLines=3 → window [max(1,5-3), min(10,5+3)] = [2,8] = 7 lines
+            var result = await _tools.GetHotPath(dir, "Process", ["userId"]).ConfigureAwait(false);
+
+            using var doc = JsonDocument.Parse(result);
+            var root = doc.RootElement;
+            await Assert.That(root.GetProperty("returned_lines").GetInt32()).IsEqualTo(7);
+            var context = root.GetProperty("matches")[0].GetProperty("context");
+            await Assert.That(context.GetArrayLength()).IsEqualTo(7);
+            await Assert.That(context[0].GetProperty("line_number").GetInt32()).IsEqualTo(2);
+            await Assert.That(context[6].GetProperty("line_number").GetInt32()).IsEqualTo(8);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Test]
+    public async Task GetHotPathContextLinesClamped()
+    {
+        var content = "line1\nhas userId here\nline3\n";
+        var tempFile = CreateTempFile(content);
+        try
+        {
+            var dir = Path.GetDirectoryName(tempFile)!;
+            var fileName = Path.GetFileName(tempFile);
+            var symbol = new Symbol(1, 1, "Process", "Method", "void Process()",
+                null, 0, Encoding.UTF8.GetByteCount(content), 1, 3, "Public", null, null, null);
+
+            _store.GetSymbolByNameAsync("test-repo-id", "Process").Returns(symbol);
+            _store.GetFilesByRepoAsync("test-repo-id")
+                .Returns(new List<FileRecord> { new(1, "test-repo-id", fileName, "hash1", 100, 3, 1000, 2000) });
+
+            // contextLines=15 → clamped to 10 → window [max(1,2-10), min(3,2+10)] = [1,3] = 3 lines
+            var result = await _tools.GetHotPath(dir, "Process", ["userId"], contextLines: 15).ConfigureAwait(false);
+
+            using var doc = JsonDocument.Parse(result);
+            var root = doc.RootElement;
+            await Assert.That(root.GetProperty("returned_lines").GetInt32()).IsEqualTo(3);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Test]
+    public async Task GetHotPathSymbolNotFoundReturnsError()
+    {
+        _store.GetSymbolByNameAsync("test-repo-id", "NonExistentMethod").Returns((Symbol?)null);
+        _store.GetSymbolCandidatesByNameAsync("test-repo-id", "NonExistentMethod", Arg.Any<int>())
+            .Returns(new List<Symbol>());
+
+        var result = await _tools.GetHotPath("/valid/path", "NonExistentMethod", ["userId"]).ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        var root = doc.RootElement;
+        await Assert.That(root.GetProperty("code").GetString()).IsEqualTo("SYMBOL_NOT_FOUND");
+    }
+
+    [Test]
+    public async Task GetHotPathInvalidPathReturnsError()
+    {
+        _pathValidator.ValidatePath(Arg.Any<string>(), Arg.Any<string>())
+            .Throws(new ArgumentException("Path traversal"));
+
+        var result = await _tools.GetHotPath("../../etc/passwd", "Method", ["userId"]).ConfigureAwait(false);
+
+        using var doc = JsonDocument.Parse(result);
+        var root = doc.RootElement;
+        await Assert.That(root.GetProperty("code").GetString()).IsEqualTo("INVALID_PATH");
+    }
+
+    [Test]
+    public async Task GetHotPathRegexInjectionPrevented()
+    {
+        // "user.id" with unescaped regex (. = any char) would also match "user_id"
+        // Regex.Escape ensures only the literal "user.id" is matched
+        var lines = new[] { "user_id = 5", "user.id = 5" };
+        var content = string.Join("\n", lines) + "\n";
+        var tempFile = CreateTempFile(content);
+        try
+        {
+            var dir = Path.GetDirectoryName(tempFile)!;
+            var fileName = Path.GetFileName(tempFile);
+            var symbol = new Symbol(1, 1, "Process", "Method", "void Process()",
+                null, 0, Encoding.UTF8.GetByteCount(content), 1, 2, "Public", null, null, null);
+
+            _store.GetSymbolByNameAsync("test-repo-id", "Process").Returns(symbol);
+            _store.GetFilesByRepoAsync("test-repo-id")
+                .Returns(new List<FileRecord> { new(1, "test-repo-id", fileName, "hash1", 100, 2, 1000, 2000) });
+
+            var result = await _tools.GetHotPath(dir, "Process", ["user.id"], contextLines: 0).ConfigureAwait(false);
+
+            using var doc = JsonDocument.Parse(result);
+            var root = doc.RootElement;
+            var matches = root.GetProperty("matches");
+            // Without Regex.Escape, "user.id" as regex (. = any char) would match "user_id" too
+            // With Regex.Escape, only the literal "user.id" on line 2 matches
+            await Assert.That(matches.GetArrayLength()).IsEqualTo(1);
+            await Assert.That(matches[0].GetProperty("line").GetInt32()).IsEqualTo(2);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Test]
+    public async Task GetHotPathUsesBodyLineRangeWhenAvailable()
+    {
+        // Symbol spans lines 1-6; "userId" appears on line 1 (signature) and line 4 (body)
+        // BodyLineStart=2, BodyLineEnd=5 → only body lines scanned; line 1 excluded
+        var lines = new[] { "void userId()", "{", "line3", "has userId here", "line5", "}" };
+        var content = string.Join("\n", lines) + "\n";
+        var tempFile = CreateTempFile(content);
+        try
+        {
+            var dir = Path.GetDirectoryName(tempFile)!;
+            var fileName = Path.GetFileName(tempFile);
+            var symbol = new Symbol(1, 1, "UserId", "Method", "void userId()",
+                null, 0, Encoding.UTF8.GetByteCount(content), 1, 6, "Public", null, 2, 5);
+
+            _store.GetSymbolByNameAsync("test-repo-id", "UserId").Returns(symbol);
+            _store.GetFilesByRepoAsync("test-repo-id")
+                .Returns(new List<FileRecord> { new(1, "test-repo-id", fileName, "hash1", 100, 6, 1000, 2000) });
+
+            var result = await _tools.GetHotPath(dir, "UserId", ["userId"], contextLines: 0).ConfigureAwait(false);
+
+            using var doc = JsonDocument.Parse(result);
+            var root = doc.RootElement;
+            await Assert.That(root.GetProperty("total_lines").GetInt32()).IsEqualTo(4); // body is lines 2-5
+            var matches = root.GetProperty("matches");
+            await Assert.That(matches.GetArrayLength()).IsEqualTo(1);
+            await Assert.That(matches[0].GetProperty("line").GetInt32()).IsEqualTo(4); // body match only
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
     // ── Mixed strategy error tests ───────────────────────────────────
 
     [Test]


### PR DESCRIPTION
## Summary

- New `get_hot_path` MCP tool and `get-hot-path` CLI command that returns only the lines within a symbol containing specific identifiers plus surrounding context
- 10–40x fewer tokens than loading the full symbol body — ideal for tracing a variable, assignment, or condition within a large function
- Identifiers matched as whole words (`Regex.Escaped \b` boundaries), overlapping context windows merged (no duplicate lines)

## Changes

- **`src/CodeCompress.Core/Models/HotPathResult.cs`** — New model: `HotPathContextLine`, `HotPathMatch`, `HotPathResult` records
- **`src/CodeCompress.Server/Tools/QueryTools.cs`** — New `get_hot_path` MCP tool + `ExtractHotPathAsync` private helper
- **`src/CodeCompress.Cli/Program.cs`** — New `get-hot-path` CLI command + `BuildHotPathMatchObjects` helper; `agent-instructions` updated
- **`tests/CodeCompress.Server.Tests/Tools/QueryToolsTests.cs`** — 11 new tests covering happy path, no-match, overlap merging, clamping, regex escaping, and error cases
- **`README.md`** — Added to MCP tools table, CLI examples, and CLI-to-MCP equivalence table

## Security (reviewed by security-expert skill)

- Null/empty `identifiers` guard returns `EMPTY_IDENTIFIERS` error before any I/O
- `Regex.Escape()` + 100ms timeout on every identifier prevents regex injection and ReDoS
- Secondary `Path.Combine(root, relPath)` validation wrapped in try/catch (was unguarded)
- Identifier values not echoed in human-readable CLI output (count shown instead)
- All output via `JsonSerializer.Serialize(typed object)` — no raw string concatenation

## Test plan

- [ ] `dotnet test --solution CodeCompress.slnx` — 1272/1272 passing
- [ ] `dotnet build CodeCompress.slnx` — 0 warnings, 0 errors
- [ ] MCP battery: happy path, no-match, empty identifiers, symbol not found, context clamping, whole-word matching, large symbol (2313-line class), blank identifier filtering

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)