### PR TITLE
feat: Blazor Server web dashboard with BlazorBlueprint components (#185)

### DIFF
--- a/.claude/skills/playwright-cli/SKILL.md
+++ b/.claude/skills/playwright-cli/SKILL.md
@@ -1,0 +1,388 @@
+---
+name: playwright-cli
+description: Automate browser interactions, test web pages and work with Playwright tests.
+allowed-tools: Bash(playwright-cli:*) Bash(npx:*) Bash(npm:*)
+---
+
+# Browser Automation with playwright-cli
+
+## Quick start
+
+```bash
+# open new browser
+playwright-cli open
+# navigate to a page
+playwright-cli goto https://playwright.dev
+# interact with the page using refs from the snapshot
+playwright-cli click e15
+playwright-cli type "page.click"
+playwright-cli press Enter
+# take a screenshot (rarely used, as snapshot is more common)
+playwright-cli screenshot
+# close the browser
+playwright-cli close
+```
+
+## Commands
+
+### Core
+
+```bash
+playwright-cli open
+# open and navigate right away
+playwright-cli open https://example.com/
+playwright-cli goto https://playwright.dev
+playwright-cli type "search query"
+playwright-cli click e3
+playwright-cli dblclick e7
+# --submit presses Enter after filling the element
+playwright-cli fill e5 "user@example.com"  --submit
+playwright-cli drag e2 e8
+# drop files or data onto an element (from outside the page)
+playwright-cli drop e4 --path=./image.png
+playwright-cli drop e4 --data="text/plain=hello world"
+playwright-cli hover e4
+playwright-cli select e9 "option-value"
+playwright-cli upload ./document.pdf
+playwright-cli check e12
+playwright-cli uncheck e12
+playwright-cli snapshot
+playwright-cli eval "document.title"
+playwright-cli eval "el => el.textContent" e5
+# get element id, class, or any attribute not visible in the snapshot
+playwright-cli eval "el => el.id" e5
+playwright-cli eval "el => el.getAttribute('data-testid')" e5
+playwright-cli dialog-accept
+playwright-cli dialog-accept "confirmation text"
+playwright-cli dialog-dismiss
+playwright-cli resize 1920 1080
+playwright-cli close
+```
+
+### Navigation
+
+```bash
+playwright-cli go-back
+playwright-cli go-forward
+playwright-cli reload
+```
+
+### Keyboard
+
+```bash
+playwright-cli press Enter
+playwright-cli press ArrowDown
+playwright-cli keydown Shift
+playwright-cli keyup Shift
+```
+
+### Mouse
+
+```bash
+playwright-cli mousemove 150 300
+playwright-cli mousedown
+playwright-cli mousedown right
+playwright-cli mouseup
+playwright-cli mouseup right
+playwright-cli mousewheel 0 100
+```
+
+### Save as
+
+```bash
+playwright-cli screenshot
+playwright-cli screenshot e5
+playwright-cli screenshot --filename=page.png
+playwright-cli pdf --filename=page.pdf
+```
+
+### Tabs
+
+```bash
+playwright-cli tab-list
+playwright-cli tab-new
+playwright-cli tab-new https://example.com/page
+playwright-cli tab-close
+playwright-cli tab-close 2
+playwright-cli tab-select 0
+```
+
+### Storage
+
+```bash
+playwright-cli state-save
+playwright-cli state-save auth.json
+playwright-cli state-load auth.json
+
+# Cookies
+playwright-cli cookie-list
+playwright-cli cookie-list --domain=example.com
+playwright-cli cookie-get session_id
+playwright-cli cookie-set session_id abc123
+playwright-cli cookie-set session_id abc123 --domain=example.com --httpOnly --secure
+playwright-cli cookie-delete session_id
+playwright-cli cookie-clear
+
+# LocalStorage
+playwright-cli localstorage-list
+playwright-cli localstorage-get theme
+playwright-cli localstorage-set theme dark
+playwright-cli localstorage-delete theme
+playwright-cli localstorage-clear
+
+# SessionStorage
+playwright-cli sessionstorage-list
+playwright-cli sessionstorage-get step
+playwright-cli sessionstorage-set step 3
+playwright-cli sessionstorage-delete step
+playwright-cli sessionstorage-clear
+```
+
+### Network
+
+```bash
+playwright-cli route "**/*.jpg" --status=404
+playwright-cli route "https://api.example.com/**" --body='{"mock": true}'
+playwright-cli route-list
+playwright-cli unroute "**/*.jpg"
+playwright-cli unroute
+```
+
+### DevTools
+
+```bash
+playwright-cli console
+playwright-cli console warning
+playwright-cli requests
+playwright-cli request 5
+playwright-cli run-code "async page => await page.context().grantPermissions(['geolocation'])"
+playwright-cli run-code --filename=script.js
+playwright-cli tracing-start
+playwright-cli tracing-stop
+playwright-cli video-start video.webm
+playwright-cli video-chapter "Chapter Title" --description="Details" --duration=2000
+playwright-cli video-stop
+
+# launch the dashboard with annotation prompt to ask the user for input
+playwright-cli show --annotate
+
+# generate a Playwright locator for an element from its ref or selector
+playwright-cli generate-locator e5 --raw
+
+# show a persistent highlight overlay for an element, optionally with a custom style
+playwright-cli highlight e5
+playwright-cli highlight e5 --style="outline: 3px dashed red"
+# hide a single element highlight, or all page highlights when no target is given
+playwright-cli highlight e5 --hide
+playwright-cli highlight --hide
+```
+
+## Raw output
+
+The global `--raw` option strips page status, generated code, and snapshot sections from the output, returning only the result value. Use it to pipe command output into other tools. Commands that don't produce output return nothing.
+
+```bash
+playwright-cli --raw eval "JSON.stringify(performance.timing)" | jq '.loadEventEnd - .navigationStart'
+playwright-cli --raw eval "JSON.stringify([...document.querySelectorAll('a')].map(a => a.href))" > links.json
+playwright-cli --raw snapshot > before.yml
+playwright-cli click e5
+playwright-cli --raw snapshot > after.yml
+diff before.yml after.yml
+TOKEN=$(playwright-cli --raw cookie-get session_id)
+playwright-cli --raw localstorage-get theme
+```
+
+For structured output wrapping every reply as JSON, pass --json
+```bash
+playwright-cli list --json
+```
+
+## Open parameters
+```bash
+# Use specific browser when creating session
+playwright-cli open --browser=chrome
+playwright-cli open --browser=firefox
+playwright-cli open --browser=webkit
+playwright-cli open --browser=msedge
+
+# Use persistent profile (by default profile is in-memory)
+playwright-cli open --persistent
+# Use persistent profile with custom directory
+playwright-cli open --profile=/path/to/profile
+
+# Connect to browser via Playwright Extension
+playwright-cli attach --extension=chrome
+
+# Connect to a running Chrome or Edge by channel name
+playwright-cli attach --cdp=chrome
+playwright-cli attach --cdp=msedge
+
+# Connect to a running browser via CDP endpoint
+playwright-cli attach --cdp=http://localhost:9222
+
+# Start with config file
+playwright-cli open --config=my-config.json
+
+# Close the browser
+playwright-cli close
+# Detach from an attached browser (leaves the external browser running)
+playwright-cli -s=msedge detach
+# Delete user data for the default session
+playwright-cli delete-data
+```
+
+## Snapshots
+
+After each command, playwright-cli provides a snapshot of the current browser state.
+
+```bash
+> playwright-cli goto https://example.com
+### Page
+- Page URL: https://example.com/
+- Page Title: Example Domain
+### Snapshot
+[Snapshot](.playwright-cli/page-2026-02-14T19-22-42-679Z.yml)
+```
+
+You can also take a snapshot on demand using `playwright-cli snapshot` command. All the options below can be combined as needed.
+
+```bash
+# default - save to a file with timestamp-based name
+playwright-cli snapshot
+
+# save to file, use when snapshot is a part of the workflow result
+playwright-cli snapshot --filename=after-click.yaml
+
+# snapshot an element instead of the whole page
+playwright-cli snapshot "#main"
+
+# limit snapshot depth for efficiency, take a partial snapshot afterwards
+playwright-cli snapshot --depth=4
+playwright-cli snapshot e34
+
+# include each element's bounding box as [box=x,y,width,height]
+playwright-cli snapshot --boxes
+```
+
+## Targeting elements
+
+By default, use refs from the snapshot to interact with page elements.
+
+```bash
+# get snapshot with refs
+playwright-cli snapshot
+
+# interact using a ref
+playwright-cli click e15
+```
+
+You can also use css selectors or Playwright locators.
+
+```bash
+# css selector
+playwright-cli click "#main > button.submit"
+
+# role locator
+playwright-cli click "getByRole('button', { name: 'Submit' })"
+
+# test id
+playwright-cli click "getByTestId('submit-button')"
+```
+
+## Browser Sessions
+
+```bash
+# create new browser session named "mysession" with persistent profile
+playwright-cli -s=mysession open example.com --persistent
+# same with manually specified profile directory (use when requested explicitly)
+playwright-cli -s=mysession open example.com --profile=/path/to/profile
+playwright-cli -s=mysession click e6
+playwright-cli -s=mysession close  # stop a named browser
+playwright-cli -s=mysession delete-data  # delete user data for persistent session
+
+playwright-cli list
+# Close all browsers
+playwright-cli close-all
+# Forcefully kill all browser processes
+playwright-cli kill-all
+```
+
+## Installation
+
+If global `playwright-cli` command is not available, try a local version via `npx playwright-cli`:
+
+```bash
+npx --no-install playwright-cli --version
+```
+
+When local version is available, use `npx playwright-cli` in all commands. Otherwise, install `playwright-cli` as a global command:
+
+```bash
+npm install -g @playwright/cli@latest
+```
+
+## Example: Form submission
+
+```bash
+playwright-cli open https://example.com/form
+playwright-cli snapshot
+
+playwright-cli fill e1 "user@example.com"
+playwright-cli fill e2 "password123"
+playwright-cli click e3
+playwright-cli snapshot
+playwright-cli close
+```
+
+## Example: Multi-tab workflow
+
+```bash
+playwright-cli open https://example.com
+playwright-cli tab-new https://example.com/other
+playwright-cli tab-list
+playwright-cli tab-select 0
+playwright-cli snapshot
+playwright-cli close
+```
+
+## Example: Debugging with DevTools
+
+```bash
+playwright-cli open https://example.com
+playwright-cli click e4
+playwright-cli fill e7 "test"
+playwright-cli console
+playwright-cli requests
+playwright-cli close
+```
+
+```bash
+playwright-cli open https://example.com
+playwright-cli tracing-start
+playwright-cli click e4
+playwright-cli fill e7 "test"
+playwright-cli tracing-stop
+playwright-cli close
+```
+
+## Example: Interactive session
+
+Ask the user to annotate the UI. User can provide contextual tasks or ask contextual questions using annotations:
+
+```bash
+playwright-cli open https://example.com
+playwright-cli show --annotate
+```
+
+## Specific tasks
+
+* **Running and Debugging Playwright tests** [references/playwright-tests.md](references/playwright-tests.md)
+* **Request mocking** [references/request-mocking.md](references/request-mocking.md)
+* **Running Playwright code** [references/running-code.md](references/running-code.md)
+* **Browser session management** [references/session-management.md](references/session-management.md)
+* **Spec-driven testing (plan / generate / heal)** [references/spec-driven-testing.md](references/spec-driven-testing.md)
+* **Storage state (cookies, localStorage)** [references/storage-state.md](references/storage-state.md)
+* **Test generation** [references/test-generation.md](references/test-generation.md)
+* **Tracing** [references/tracing.md](references/tracing.md)
+* **Video recording** [references/video-recording.md](references/video-recording.md)
+* **Inspecting element attributes** [references/element-attributes.md](references/element-attributes.md)

--- a/.claude/skills/playwright-cli/references/element-attributes.md
+++ b/.claude/skills/playwright-cli/references/element-attributes.md
@@ -1,0 +1,23 @@
+# Inspecting Element Attributes
+
+When the snapshot doesn't show an element's `id`, `class`, `data-*` attributes, or other DOM properties, use `eval` to inspect them.
+
+## Examples
+
+```bash
+playwright-cli snapshot
+# snapshot shows a button as e7 but doesn't reveal its id or data attributes
+
+# get the element's id
+playwright-cli eval "el => el.id" e7
+
+# get all CSS classes
+playwright-cli eval "el => el.className" e7
+
+# get a specific attribute
+playwright-cli eval "el => el.getAttribute('data-testid')" e7
+playwright-cli eval "el => el.getAttribute('aria-label')" e7
+
+# get a computed style property
+playwright-cli eval "el => getComputedStyle(el).display" e7
+```

--- a/.claude/skills/playwright-cli/references/playwright-tests.md
+++ b/.claude/skills/playwright-cli/references/playwright-tests.md
@@ -1,0 +1,39 @@
+# Running Playwright Tests
+
+To run Playwright tests, use the `npx playwright test` command, or a package manager script. To avoid opening the interactive html report, use `PLAYWRIGHT_HTML_OPEN=never` environment variable.
+
+```bash
+# Run all tests
+PLAYWRIGHT_HTML_OPEN=never npx playwright test
+
+# Run all tests through a custom npm script
+PLAYWRIGHT_HTML_OPEN=never npm run special-test-command
+```
+
+# Debugging Playwright Tests
+
+To debug a failing Playwright test, run it with `--debug=cli` option. This command will pause the test at the start and print the debugging instructions.
+
+**IMPORTANT**: run the command in the background and check the output until "Debugging Instructions" is printed. Make sure to stop the command after you have finished.
+
+Once instructions containing a session name are printed, use `playwright-cli` to attach the session and explore the page.
+
+```bash
+# Run the test
+PLAYWRIGHT_HTML_OPEN=never npx playwright test --debug=cli
+# ...
+# ... debugging instructions for "tw-abcdef" session ...
+# ...
+
+# Attach to the test
+playwright-cli attach tw-abcdef
+```
+
+Keep the test running in the background while you explore and look for a fix.
+The test is paused at the start, so you should step over or pause at a particular location
+where the problem is most likely to be.
+
+Every action you perform with `playwright-cli` generates corresponding Playwright TypeScript code.
+This code appears in the output and can be copied directly into the test. Most of the time, a specific locator or an expectation should be updated, but it could also be a bug in the app. Use your judgement.
+
+After fixing the test, stop the background test run. Rerun to check that test passes.

--- a/.claude/skills/playwright-cli/references/request-mocking.md
+++ b/.claude/skills/playwright-cli/references/request-mocking.md
@@ -1,0 +1,87 @@
+# Request Mocking
+
+Intercept, mock, modify, and block network requests.
+
+## CLI Route Commands
+
+```bash
+# Mock with custom status
+playwright-cli route "**/*.jpg" --status=404
+
+# Mock with JSON body
+playwright-cli route "**/api/users" --body='[{"id":1,"name":"Alice"}]' --content-type=application/json
+
+# Mock with custom headers
+playwright-cli route "**/api/data" --body='{"ok":true}' --header="X-Custom: value"
+
+# Remove headers from requests
+playwright-cli route "**/*" --remove-header=cookie,authorization
+
+# List active routes
+playwright-cli route-list
+
+# Remove a route or all routes
+playwright-cli unroute "**/*.jpg"
+playwright-cli unroute
+```
+
+## URL Patterns
+
+```
+**/api/users           - Exact path match
+**/api/*/details       - Wildcard in path
+**/*.{png,jpg,jpeg}    - Match file extensions
+**/search?q=*          - Match query parameters
+```
+
+## Advanced Mocking with run-code
+
+For conditional responses, request body inspection, response modification, or delays:
+
+### Conditional Response Based on Request
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/login', route => {
+    const body = route.request().postDataJSON();
+    if (body.username === 'admin') {
+      route.fulfill({ body: JSON.stringify({ token: 'mock-token' }) });
+    } else {
+      route.fulfill({ status: 401, body: JSON.stringify({ error: 'Invalid' }) });
+    }
+  });
+}"
+```
+
+### Modify Real Response
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/user', async route => {
+    const response = await route.fetch();
+    const json = await response.json();
+    json.isPremium = true;
+    await route.fulfill({ response, json });
+  });
+}"
+```
+
+### Simulate Network Failures
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/offline', route => route.abort('internetdisconnected'));
+}"
+# Options: connectionrefused, timedout, connectionreset, internetdisconnected
+```
+
+### Delayed Response
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/slow', async route => {
+    await new Promise(r => setTimeout(r, 3000));
+    route.fulfill({ body: JSON.stringify({ data: 'loaded' }) });
+  });
+}"
+```

--- a/.claude/skills/playwright-cli/references/running-code.md
+++ b/.claude/skills/playwright-cli/references/running-code.md
@@ -1,0 +1,241 @@
+# Running Custom Playwright Code
+
+Use `run-code` to execute arbitrary Playwright code for advanced scenarios not covered by CLI commands.
+
+## Syntax
+
+```bash
+playwright-cli run-code "async page => {
+  // Your Playwright code here
+  // Access page.context() for browser context operations
+}"
+```
+
+You can also load the function from a file:
+
+```bash
+playwright-cli run-code --filename=./my-script.js
+```
+
+
+The code must be a single function expression, it is wrapped in `(...)` and evaluated.
+import/export/require syntax is not supported.
+
+## Geolocation
+
+```bash
+# Grant geolocation permission and set location
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['geolocation']);
+  await page.context().setGeolocation({ latitude: 37.7749, longitude: -122.4194 });
+}"
+
+# Set location to London
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['geolocation']);
+  await page.context().setGeolocation({ latitude: 51.5074, longitude: -0.1278 });
+}"
+
+# Clear geolocation override
+playwright-cli run-code "async page => {
+  await page.context().clearPermissions();
+}"
+```
+
+## Permissions
+
+```bash
+# Grant multiple permissions
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions([
+    'geolocation',
+    'notifications',
+    'camera',
+    'microphone'
+  ]);
+}"
+
+# Grant permissions for specific origin
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['clipboard-read'], {
+    origin: 'https://example.com'
+  });
+}"
+```
+
+## Media Emulation
+
+```bash
+# Emulate dark color scheme
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ colorScheme: 'dark' });
+}"
+
+# Emulate light color scheme
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ colorScheme: 'light' });
+}"
+
+# Emulate reduced motion
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+}"
+
+# Emulate print media
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ media: 'print' });
+}"
+```
+
+## Wait Strategies
+
+```bash
+# Wait for network idle
+playwright-cli run-code "async page => {
+  await page.waitForLoadState('networkidle');
+}"
+
+# Wait for specific element
+playwright-cli run-code "async page => {
+  await page.locator('.loading').waitFor({ state: 'hidden' });
+}"
+
+# Wait for function to return true
+playwright-cli run-code "async page => {
+  await page.waitForFunction(() => window.appReady === true);
+}"
+
+# Wait with timeout
+playwright-cli run-code "async page => {
+  await page.locator('.result').waitFor({ timeout: 10000 });
+}"
+```
+
+## Frames and Iframes
+
+```bash
+# Work with iframe
+playwright-cli run-code "async page => {
+  const frame = page.locator('iframe#my-iframe').contentFrame();
+  await frame.locator('button').click();
+}"
+
+# Get all frames
+playwright-cli run-code "async page => {
+  const frames = page.frames();
+  return frames.map(f => f.url());
+}"
+```
+
+## File Downloads
+
+```bash
+# Handle file download
+playwright-cli run-code "async page => {
+  const downloadPromise = page.waitForEvent('download');
+  await page.getByRole('link', { name: 'Download' }).click();
+  const download = await downloadPromise;
+  await download.saveAs('./downloaded-file.pdf');
+  return download.suggestedFilename();
+}"
+```
+
+## Clipboard
+
+```bash
+# Read clipboard (requires permission)
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['clipboard-read']);
+  return await page.evaluate(() => navigator.clipboard.readText());
+}"
+
+# Write to clipboard
+playwright-cli run-code "async page => {
+  await page.evaluate(text => navigator.clipboard.writeText(text), 'Hello clipboard!');
+}"
+```
+
+## Page Information
+
+```bash
+# Get page title
+playwright-cli run-code "async page => {
+  return await page.title();
+}"
+
+# Get current URL
+playwright-cli run-code "async page => {
+  return page.url();
+}"
+
+# Get page content
+playwright-cli run-code "async page => {
+  return await page.content();
+}"
+
+# Get viewport size
+playwright-cli run-code "async page => {
+  return page.viewportSize();
+}"
+```
+
+## JavaScript Execution
+
+```bash
+# Execute JavaScript and return result
+playwright-cli run-code "async page => {
+  return await page.evaluate(() => {
+    return {
+      userAgent: navigator.userAgent,
+      language: navigator.language,
+      cookiesEnabled: navigator.cookieEnabled
+    };
+  });
+}"
+
+# Pass arguments to evaluate
+playwright-cli run-code "async page => {
+  const multiplier = 5;
+  return await page.evaluate(m => document.querySelectorAll('li').length * m, multiplier);
+}"
+```
+
+## Error Handling
+
+```bash
+# Try-catch in run-code
+playwright-cli run-code "async page => {
+  try {
+    await page.getByRole('button', { name: 'Submit' }).click({ timeout: 1000 });
+    return 'clicked';
+  } catch (e) {
+    return 'element not found';
+  }
+}"
+```
+
+## Complex Workflows
+
+```bash
+# Login and save state
+playwright-cli run-code "async page => {
+  await page.goto('https://example.com/login');
+  await page.getByRole('textbox', { name: 'Email' }).fill('user@example.com');
+  await page.getByRole('textbox', { name: 'Password' }).fill('secret');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await page.waitForURL('**/dashboard');
+  await page.context().storageState({ path: 'auth.json' });
+  return 'Login successful';
+}"
+
+# Scrape data from multiple pages
+playwright-cli run-code "async page => {
+  const results = [];
+  for (let i = 1; i <= 3; i++) {
+    await page.goto(\`https://example.com/page/\${i}\`);
+    const items = await page.locator('.item').allTextContents();
+    results.push(...items);
+  }
+  return results;
+}"
+```

--- a/.claude/skills/playwright-cli/references/session-management.md
+++ b/.claude/skills/playwright-cli/references/session-management.md
@@ -1,0 +1,225 @@
+# Browser Session Management
+
+Run multiple isolated browser sessions concurrently with state persistence.
+
+## Named Browser Sessions
+
+Use `-s` flag to isolate browser contexts:
+
+```bash
+# Browser 1: Authentication flow
+playwright-cli -s=auth open https://app.example.com/login
+
+# Browser 2: Public browsing (separate cookies, storage)
+playwright-cli -s=public open https://example.com
+
+# Commands are isolated by browser session
+playwright-cli -s=auth fill e1 "user@example.com"
+playwright-cli -s=public snapshot
+```
+
+## Browser Session Isolation Properties
+
+Each browser session has independent:
+- Cookies
+- LocalStorage / SessionStorage
+- IndexedDB
+- Cache
+- Browsing history
+- Open tabs
+
+## Browser Session Commands
+
+```bash
+# List all browser sessions
+playwright-cli list
+
+# Stop a browser session (close the browser)
+playwright-cli close                # stop the default browser
+playwright-cli -s=mysession close   # stop a named browser
+
+# Stop all browser sessions
+playwright-cli close-all
+
+# Forcefully kill all daemon processes (for stale/zombie processes)
+playwright-cli kill-all
+
+# Delete browser session user data (profile directory)
+playwright-cli delete-data                # delete default browser data
+playwright-cli -s=mysession delete-data   # delete named browser data
+```
+
+## Environment Variable
+
+Set a default browser session name via environment variable:
+
+```bash
+export PLAYWRIGHT_CLI_SESSION="mysession"
+playwright-cli open example.com  # Uses "mysession" automatically
+```
+
+## Common Patterns
+
+### Concurrent Scraping
+
+```bash
+#!/bin/bash
+# Scrape multiple sites concurrently
+
+# Start all browsers
+playwright-cli -s=site1 open https://site1.com &
+playwright-cli -s=site2 open https://site2.com &
+playwright-cli -s=site3 open https://site3.com &
+wait
+
+# Take snapshots from each
+playwright-cli -s=site1 snapshot
+playwright-cli -s=site2 snapshot
+playwright-cli -s=site3 snapshot
+
+# Cleanup
+playwright-cli close-all
+```
+
+### A/B Testing Sessions
+
+```bash
+# Test different user experiences
+playwright-cli -s=variant-a open "https://app.com?variant=a"
+playwright-cli -s=variant-b open "https://app.com?variant=b"
+
+# Compare
+playwright-cli -s=variant-a screenshot
+playwright-cli -s=variant-b screenshot
+```
+
+### Persistent Profile
+
+By default, browser profile is kept in memory only. Use `--persistent` flag on `open` to persist the browser profile to disk:
+
+```bash
+# Use persistent profile (auto-generated location)
+playwright-cli open https://example.com --persistent
+
+# Use persistent profile with custom directory
+playwright-cli open https://example.com --profile=/path/to/profile
+```
+
+## Attaching to a Running Browser
+
+Use `attach` to connect to a browser that is already running, instead of launching a new one.
+
+### Attach by channel name
+
+Connect to a running Chrome or Edge instance by its channel name. The browser must have remote debugging enabled — navigate to `chrome://inspect/#remote-debugging` in the target browser and check "Allow remote debugging for this browser instance".
+
+```bash
+# Attach to Chrome
+playwright-cli attach --cdp=chrome
+
+# Attach to Chrome Canary
+playwright-cli attach --cdp=chrome-canary
+
+# Attach to Microsoft Edge
+playwright-cli attach --cdp=msedge
+
+# Attach to Edge Dev
+playwright-cli attach --cdp=msedge-dev
+```
+
+Supported channels: `chrome`, `chrome-beta`, `chrome-dev`, `chrome-canary`, `msedge`, `msedge-beta`, `msedge-dev`, `msedge-canary`.
+
+When `--session` is not provided, the session is named after the channel (e.g. `--cdp=msedge` creates a session called `msedge`), so parallel attaches to Chrome and Edge don't collide on `default`. Pass `--session=<name>` to override.
+
+### Attach via CDP endpoint
+
+Connect to a browser that exposes a Chrome DevTools Protocol endpoint:
+
+```bash
+playwright-cli attach --cdp=http://localhost:9222
+```
+
+### Attach via browser extension
+
+Connect to a browser with the Playwright extension installed:
+
+```bash
+playwright-cli attach --extension
+```
+
+### Detach
+
+Tear down an attached session without affecting the external browser:
+
+```bash
+# Detach the default attached session
+playwright-cli detach
+
+# Detach a specific attached session
+playwright-cli -s=msedge detach
+```
+
+`detach` only works on sessions created via `attach`. For sessions created via `open`, use `close`.
+
+## Default Browser Session
+
+When `-s` is omitted, commands use the default browser session:
+
+```bash
+# These use the same default browser session
+playwright-cli open https://example.com
+playwright-cli snapshot
+playwright-cli close  # Stops default browser
+```
+
+## Browser Session Configuration
+
+Configure a browser session with specific settings when opening:
+
+```bash
+# Open with config file
+playwright-cli open https://example.com --config=.playwright/my-cli.json
+
+# Open with specific browser
+playwright-cli open https://example.com --browser=firefox
+
+# Open in headed mode
+playwright-cli open https://example.com --headed
+
+# Open with persistent profile
+playwright-cli open https://example.com --persistent
+```
+
+## Best Practices
+
+### 1. Name Browser Sessions Semantically
+
+```bash
+# GOOD: Clear purpose
+playwright-cli -s=github-auth open https://github.com
+playwright-cli -s=docs-scrape open https://docs.example.com
+
+# AVOID: Generic names
+playwright-cli -s=s1 open https://github.com
+```
+
+### 2. Always Clean Up
+
+```bash
+# Stop browsers when done
+playwright-cli -s=auth close
+playwright-cli -s=scrape close
+
+# Or stop all at once
+playwright-cli close-all
+
+# If browsers become unresponsive or zombie processes remain
+playwright-cli kill-all
+```
+
+### 3. Delete Stale Browser Data
+
+```bash
+# Remove old browser data to free disk space
+playwright-cli -s=oldsession delete-data
+```

--- a/.claude/skills/playwright-cli/references/spec-driven-testing.md
+++ b/.claude/skills/playwright-cli/references/spec-driven-testing.md
@@ -1,0 +1,305 @@
+# Spec-driven testing (plan → generate → heal)
+
+End-to-end workflow for authoring and maintaining Playwright tests using `playwright-cli`. The three sections below can be used independently:
+
+- **Planning** — explore the app, produce a spec file describing what to test.
+- **Generate** — turn a spec into Playwright test files. Update the spec if it's vague or stale.
+- **Heal** — diagnose failing tests, fix the code, reconcile the spec with reality.
+
+All three lean on the same mechanic: run `npx playwright test --debug=cli` in the background, then `playwright-cli attach tw-XXXX` to drive the paused page interactively. See [playwright-tests.md](playwright-tests.md) for the debug/attach mechanics and [test-generation.md](test-generation.md) for how every `playwright-cli` action emits Playwright TypeScript.
+
+---
+
+## 1. Planning
+
+Goal: produce a spec file (e.g. `specs/<feature>.plan.md`) that enumerates the scenarios to test. **Always** write the spec to a file.
+
+### 1.1 Prerequisite: workspace
+
+Check the workspace has Playwright installed before anything else:
+
+```bash
+# Either of these confirms a workspace:
+test -f playwright.config.ts || test -f playwright.config.js
+npx --no-install playwright --version
+```
+
+If there is no Playwright install, bootstrap one and let the user pick the defaults:
+
+```bash
+npm init playwright@latest
+```
+
+### 1.2 Prerequisite: seed test
+
+A **seed test** is a minimal test that lands the page in the state every scenario starts from: navigation to the app, any required login, feature flags, etc. Scenarios assume a fresh start *after* the seed. `--debug=cli` pauses *inside* this test, so the seed is where every planning and generation session begins.
+
+Minimum viable seed:
+
+```ts
+// tests/seed.spec.ts
+import { test } from '@playwright/test';
+
+test('seed', async ({ page }) => {
+  await page.goto('https://example.com/');
+});
+```
+
+Preferred — push navigation into a fixture so scenario tests reuse it:
+
+```ts
+// tests/fixtures.ts
+import { test as baseTest } from '@playwright/test';
+export { expect } from '@playwright/test';
+
+export const test = baseTest.extend({
+  page: async ({ page }, use) => {
+    await page.goto('https://example.com/');
+    await use(page);
+  },
+});
+```
+
+```ts
+// tests/seed.spec.ts
+import { test } from './fixtures';
+
+test('seed', async ({ page }) => {
+  // Fixture already navigates. This empty body tells agents where to start.
+});
+```
+
+If no seed exists, create one that at least navigates to the app.
+
+### 1.3 Explore the app
+
+Launch the app via the seed in the background and attach:
+
+```bash
+PLAYWRIGHT_HTML_OPEN=never npx playwright test tests/seed.spec.ts --debug=cli
+# wait for "Debugging Instructions" and the session name tw-XXXX
+playwright-cli attach tw-XXXX
+```
+
+Resume so the seed runs, then probe the app:
+
+```bash
+playwright-cli resume                   # resume so that seed test runs fully
+playwright-cli snapshot                 # inventory of interactive elements
+playwright-cli click e5                 # follow a flow
+playwright-cli eval "location.href"     # read URL / state
+playwright-cli show --annotate          # ask the user to point at something
+```
+
+Map out:
+
+- Interactive surfaces (forms, buttons, lists, filters, modals).
+- Primary user journeys end-to-end.
+- Edge cases: empty states, validation errors, very long input, boundary values.
+- Persistence: reload, local/session storage, URL fragments.
+- Navigation: which controls change the URL, back/forward behaviour.
+
+**Important**: Do not just open the app url with playwright-cli, always go through the test to capture any custom setup done there.
+**Important**: Stop the background test when done exploring.
+
+### 1.4 Write the spec file
+
+Save under `specs/<feature>.plan.md`. Use this structure:
+
+```markdown
+# <Feature> Test Plan
+
+## Application Overview
+
+<One paragraph describing what the feature does and why it matters.>
+
+## Test Scenarios
+
+### 1. <Group Name>
+
+**Seed:** `tests/seed.spec.ts`
+
+#### 1.1. <kebab-case-scenario-name>
+
+**File:** `tests/<group>/<kebab-case-scenario-name>.spec.ts`
+
+**Steps:**
+  1. <Concrete user step>
+    - expect: <observable outcome>
+    - expect: <another observable outcome>
+  2. <Next step>
+    - expect: <outcome>
+
+#### 1.2. <next-scenario>
+...
+
+### 2. <Next Group>
+
+**Seed:** `tests/seed.spec.ts`
+...
+```
+
+Guidelines:
+
+- Each scenario is independent and starts from the seed's fresh state — never chain scenarios.
+- Scenario names are kebab-case and match the test file name (`should-add-single-todo` → `should-add-single-todo.spec.ts`).
+- Cover happy path, edge cases, validation, negative flows, persistence.
+- Write steps at the user level ("Type 'Buy milk' into the input"), not the API level ("call `fill`").
+- Put observable outcomes in `- expect:` bullets; each becomes an assertion during generation.
+
+---
+
+## 2. Generate
+
+Goal: take a spec file and produce Playwright test files. Optionally update the spec if it has drifted.
+
+### 2.1 Inputs
+
+- **Spec file**, e.g. `specs/basic-operations.plan.md`.
+- **Target**: either a single scenario (e.g. `1.2`), a whole group (`1`), or all.
+- **Seed file**, read from the `**Seed:**` line of the scenario's group.
+
+### 2.2 Generate one scenario
+
+For each target scenario, in sequence (never in parallel — scenarios share the seed session):
+
+```bash
+PLAYWRIGHT_HTML_OPEN=never npx playwright test <seed-file> --debug=cli   # background
+playwright-cli attach tw-XXXX
+# resume
+```
+
+**Do not** just open the app url with playwright-cli, always go through the test to capture any custom setup done there.
+
+Walk the scenario's `Steps:` one by one with `playwright-cli`, treating the spec as the plan and the live app as the source of truth. If a step is vague ("click the button" — which button?), references an element that no longer exists, or contradicts the app's actual behaviour, use your judgement: update the spec to match what the app really does, then keep going. Editing the spec mid-generation is expected.
+
+Every action prints the equivalent Playwright TypeScript (see [test-generation.md](test-generation.md)):
+
+```bash
+playwright-cli snapshot                         # find refs
+playwright-cli fill e3 "John Doe"               # -> page.getByRole('textbox', {...}).fill(...)
+playwright-cli press Enter
+playwright-cli click e7
+```
+
+For each `- expect:` bullet, add an explicit assertion. See [test-generation.md](test-generation.md) for details.
+
+Collect the generated code and write the test file at the path given in the spec:
+
+```ts
+// spec: specs/basic-operations.plan.md
+// seed: tests/seed.spec.ts
+import { test, expect } from './fixtures';   // or '@playwright/test' if no fixtures file
+
+test.describe('Singing in and out', () => {
+  test('should sign in', async ({ page }) => {
+    // 1. Navigate to the application
+    // (handled by the seed fixture)
+
+    // 2. Type 'John Doe' into the username field
+    await page.getByRole('textbox', { name: 'username' }).fill('John Doe');
+
+    // 3. Type password
+    await page.getByRole('textbox', { name: 'password' }).fill('TestPassword');
+
+    // 4. Press Enter to submit
+    await page.getByRole('textbox', { name: 'password' }).press('Enter');
+
+    await expect(page.getByRole('heading')).toContainText('Welcome, John Doe!');
+  });
+});
+```
+
+Rules:
+
+- **One test per file.** File path, describe name, and test name come verbatim from the spec (minus the ordinal).
+- Prefix each numbered step with a `// N. <step text>` comment before its actions.
+- Use the describe group name verbatim from the spec (no `1.` ordinal).
+- Import from `./fixtures` if the project has one; otherwise `@playwright/test`.
+- **Important**: close the CLI session and stop the background test before moving to the next scenario.
+
+### 2.3 Generate multiple scenarios
+
+Loop 2.2 over the targeted scenarios one at a time, restarting the seed between each so every test starts from a clean page. This is safe to parallelise due to unique generated session names - just make sure each test run is stopped.
+
+### 2.4 Run generated tests
+
+After generation, run the new tests once:
+
+```bash
+PLAYWRIGHT_HTML_OPEN=never npx playwright test tests/<group>/<scenario>.spec.ts
+```
+
+Any failure goes to Section 3.
+
+---
+
+## 3. Heal
+
+Goal: fix failing tests, and update the spec if the app's intended behaviour changed.
+
+### 3.1 Find failing tests
+
+```bash
+PLAYWRIGHT_HTML_OPEN=never npx playwright test
+```
+
+Record the list of failing `<file>:<line>` entries and process them one at a time. Do not attempt parallel fixes — shared state and the single CLI session make that fragile.
+
+### 3.2 Debug one failure
+
+Run the single failing test in debug mode in the background, then attach:
+
+```bash
+PLAYWRIGHT_HTML_OPEN=never npx playwright test tests/<group>/<scenario>.spec.ts:<line> --debug=cli
+# wait for "Debugging Instructions" and the tw-XXXX session name
+playwright-cli attach tw-XXXX
+```
+
+The test is paused at the start. Step forward or run to until just before the failing action or assertion, then diagnose:
+
+```bash
+playwright-cli snapshot                # did the element change / move / rename?
+playwright-cli console                 # app-side errors?
+playwright-cli network                 # failed request? wrong payload?
+playwright-cli show --annotate         # ask the user to point somewhere
+```
+
+Common causes: selector drift, new wrapper element, label/ARIA rename, timing (transition, async load), assertion text updated in the app, test data leaking between runs.
+
+Rehearse the corrected interaction with `playwright-cli` — the generated code in the output is what you paste back into the test.
+
+### 3.3 Apply the fix
+
+Edit the test file: update the locator, assertion, step order, or inputs to match the corrected behaviour. Stop the background debug run. Rerun the single test to confirm green.
+
+Never skip hooks or add sleeps as a fix. Never use `networkidle`.
+
+### 3.4 Reconcile with the spec
+
+Open the spec referenced by the `// spec:` header in the test file and locate the scenario that matches the test.
+
+- **Fix was purely technical** (locator drift, better assertion shape) and the spec's user-level behaviour still matches the app → leave the spec alone.
+- **Fix changed user-visible steps, inputs, order, or expected outcomes** that the spec describes → update the spec to match reality. Keep the scenario id and file path stable; only the step / expect lines change.
+- **Unclear whether the app change is intentional** (spec is stale) **or a regression** (test was right, app is wrong) → **stop and ask the user**. Provide:
+  - the scenario id (e.g. `2.3`),
+  - the spec lines that no longer match,
+  - the observed app behaviour (quote a snapshot excerpt or a concrete outcome).
+
+Only after the user answers, either update the spec (intentional change) or file/flag the test as covering a bug (regression).
+
+### 3.5 Iteration and giving up
+
+- Fix failures one at a time; rerun after each.
+- If after thorough investigation you are confident the test is correct but the app is wrong *and* the user has confirmed it's a bug: mark the test `test.fixme(...)` with a comment pointing at the user's decision or issue link. Never silently skip.
+
+---
+
+## Cross-references
+
+| For... | See |
+|---|---|
+| `--debug=cli` / attach mechanics | [playwright-tests.md](playwright-tests.md) |
+| How `playwright-cli` actions become TS | [test-generation.md](test-generation.md) |
+| Mocking requests during exploration/generation | [request-mocking.md](request-mocking.md) |
+| Managing the CLI browser session | [session-management.md](session-management.md) |

--- a/.claude/skills/playwright-cli/references/storage-state.md
+++ b/.claude/skills/playwright-cli/references/storage-state.md
@@ -1,0 +1,275 @@
+# Storage Management
+
+Manage cookies, localStorage, sessionStorage, and browser storage state.
+
+## Storage State
+
+Save and restore complete browser state including cookies and storage.
+
+### Save Storage State
+
+```bash
+# Save to auto-generated filename (storage-state-{timestamp}.json)
+playwright-cli state-save
+
+# Save to specific filename
+playwright-cli state-save my-auth-state.json
+```
+
+### Restore Storage State
+
+```bash
+# Load storage state from file
+playwright-cli state-load my-auth-state.json
+
+# Reload page to apply cookies
+playwright-cli open https://example.com
+```
+
+### Storage State File Format
+
+The saved file contains:
+
+```json
+{
+  "cookies": [
+    {
+      "name": "session_id",
+      "value": "abc123",
+      "domain": "example.com",
+      "path": "/",
+      "expires": 1735689600,
+      "httpOnly": true,
+      "secure": true,
+      "sameSite": "Lax"
+    }
+  ],
+  "origins": [
+    {
+      "origin": "https://example.com",
+      "localStorage": [
+        { "name": "theme", "value": "dark" },
+        { "name": "user_id", "value": "12345" }
+      ]
+    }
+  ]
+}
+```
+
+## Cookies
+
+### List All Cookies
+
+```bash
+playwright-cli cookie-list
+```
+
+### Filter Cookies by Domain
+
+```bash
+playwright-cli cookie-list --domain=example.com
+```
+
+### Filter Cookies by Path
+
+```bash
+playwright-cli cookie-list --path=/api
+```
+
+### Get Specific Cookie
+
+```bash
+playwright-cli cookie-get session_id
+```
+
+### Set a Cookie
+
+```bash
+# Basic cookie
+playwright-cli cookie-set session abc123
+
+# Cookie with options
+playwright-cli cookie-set session abc123 --domain=example.com --path=/ --httpOnly --secure --sameSite=Lax
+
+# Cookie with expiration (Unix timestamp)
+playwright-cli cookie-set remember_me token123 --expires=1735689600
+```
+
+### Delete a Cookie
+
+```bash
+playwright-cli cookie-delete session_id
+```
+
+### Clear All Cookies
+
+```bash
+playwright-cli cookie-clear
+```
+
+### Advanced: Multiple Cookies or Custom Options
+
+For complex scenarios like adding multiple cookies at once, use `run-code`:
+
+```bash
+playwright-cli run-code "async page => {
+  await page.context().addCookies([
+    { name: 'session_id', value: 'sess_abc123', domain: 'example.com', path: '/', httpOnly: true },
+    { name: 'preferences', value: JSON.stringify({ theme: 'dark' }), domain: 'example.com', path: '/' }
+  ]);
+}"
+```
+
+## Local Storage
+
+### List All localStorage Items
+
+```bash
+playwright-cli localstorage-list
+```
+
+### Get Single Value
+
+```bash
+playwright-cli localstorage-get token
+```
+
+### Set Value
+
+```bash
+playwright-cli localstorage-set theme dark
+```
+
+### Set JSON Value
+
+```bash
+playwright-cli localstorage-set user_settings '{"theme":"dark","language":"en"}'
+```
+
+### Delete Single Item
+
+```bash
+playwright-cli localstorage-delete token
+```
+
+### Clear All localStorage
+
+```bash
+playwright-cli localstorage-clear
+```
+
+### Advanced: Multiple Operations
+
+For complex scenarios like setting multiple values at once, use `run-code`:
+
+```bash
+playwright-cli run-code "async page => {
+  await page.evaluate(() => {
+    localStorage.setItem('token', 'jwt_abc123');
+    localStorage.setItem('user_id', '12345');
+    localStorage.setItem('expires_at', Date.now() + 3600000);
+  });
+}"
+```
+
+## Session Storage
+
+### List All sessionStorage Items
+
+```bash
+playwright-cli sessionstorage-list
+```
+
+### Get Single Value
+
+```bash
+playwright-cli sessionstorage-get form_data
+```
+
+### Set Value
+
+```bash
+playwright-cli sessionstorage-set step 3
+```
+
+### Delete Single Item
+
+```bash
+playwright-cli sessionstorage-delete step
+```
+
+### Clear sessionStorage
+
+```bash
+playwright-cli sessionstorage-clear
+```
+
+## IndexedDB
+
+### List Databases
+
+```bash
+playwright-cli run-code "async page => {
+  return await page.evaluate(async () => {
+    const databases = await indexedDB.databases();
+    return databases;
+  });
+}"
+```
+
+### Delete Database
+
+```bash
+playwright-cli run-code "async page => {
+  await page.evaluate(() => {
+    indexedDB.deleteDatabase('myDatabase');
+  });
+}"
+```
+
+## Common Patterns
+
+### Authentication State Reuse
+
+```bash
+# Step 1: Login and save state
+playwright-cli open https://app.example.com/login
+playwright-cli snapshot
+playwright-cli fill e1 "user@example.com"
+playwright-cli fill e2 "password123"
+playwright-cli click e3
+
+# Save the authenticated state
+playwright-cli state-save auth.json
+
+# Step 2: Later, restore state and skip login
+playwright-cli state-load auth.json
+playwright-cli open https://app.example.com/dashboard
+# Already logged in!
+```
+
+### Save and Restore Roundtrip
+
+```bash
+# Set up authentication state
+playwright-cli open https://example.com
+playwright-cli eval "() => { document.cookie = 'session=abc123'; localStorage.setItem('user', 'john'); }"
+
+# Save state to file
+playwright-cli state-save my-session.json
+
+# ... later, in a new session ...
+
+# Restore state
+playwright-cli state-load my-session.json
+playwright-cli open https://example.com
+# Cookies and localStorage are restored!
+```
+
+## Security Notes
+
+- Never commit storage state files containing auth tokens
+- Add `*.auth-state.json` to `.gitignore`
+- Delete state files after automation completes
+- Use environment variables for sensitive data
+- By default, sessions run in-memory mode which is safer for sensitive operations

--- a/.claude/skills/playwright-cli/references/test-generation.md
+++ b/.claude/skills/playwright-cli/references/test-generation.md
@@ -1,0 +1,134 @@
+# Test Generation
+
+Generate Playwright test code automatically as you interact with the browser.
+
+## How It Works
+
+Every action you perform with `playwright-cli` generates corresponding Playwright TypeScript code.
+This code appears in the output and can be copied directly into your test files.
+
+## Example Workflow
+
+```bash
+# Start a session
+playwright-cli open https://example.com/login
+
+# Take a snapshot to see elements
+playwright-cli snapshot
+# Output shows: e1 [textbox "Email"], e2 [textbox "Password"], e3 [button "Sign In"]
+
+# Fill form fields - generates code automatically
+playwright-cli fill e1 "user@example.com"
+# Ran Playwright code:
+# await page.getByRole('textbox', { name: 'Email' }).fill('user@example.com');
+
+playwright-cli fill e2 "password123"
+# Ran Playwright code:
+# await page.getByRole('textbox', { name: 'Password' }).fill('password123');
+
+playwright-cli click e3
+# Ran Playwright code:
+# await page.getByRole('button', { name: 'Sign In' }).click();
+```
+
+## Building a Test File
+
+Collect the generated code into a Playwright test:
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('login flow', async ({ page }) => {
+  // Generated code from playwright-cli session:
+  await page.goto('https://example.com/login');
+  await page.getByRole('textbox', { name: 'Email' }).fill('user@example.com');
+  await page.getByRole('textbox', { name: 'Password' }).fill('password123');
+  await page.getByRole('button', { name: 'Sign In' }).click();
+
+  // Add assertions
+  await expect(page).toHaveURL(/.*dashboard/);
+});
+```
+
+## Best Practices
+
+### 1. Use Semantic Locators
+
+The generated code uses role-based locators when possible, which are more resilient:
+
+```typescript
+// Generated (good - semantic)
+await page.getByRole('button', { name: 'Submit' }).click();
+
+// Avoid (fragile - CSS selectors)
+await page.locator('#submit-btn').click();
+```
+
+### 2. Explore Before Recording
+
+Take snapshots to understand the page structure before recording actions:
+
+```bash
+playwright-cli open https://example.com
+playwright-cli snapshot
+# Review the element structure
+playwright-cli click e5
+```
+
+### 3. Add Assertions Manually
+
+Generated code captures actions but not assertions. Add expectations in your test using one of the recommended matchers:
+
+- `toBeVisible()` — element is rendered and visible
+- `toHaveText(text)` — element text content matches
+- `toHaveValue(value) / toBeEmpty()` — input/select value matches
+- `toBeChecked() / toBeUnchecked()` — checkbox state matches
+- `toMatchAriaSnapshot(snapshot)` — page (or locator) matches a partial accessibility snapshot
+
+Use `playwright-cli generate-locator <target>` to produce the locator expression for the assertion, and the snapshot/eval commands to capture the expected value.
+
+When asserting text content, make sure that generated locator does not contain text from the element itself. `getByTestId()` or `getByLabel()` usually work well with asserting text. When locator is text-based, prefer `toBeVisible()` instead.
+
+Snapshot to be matched does not have to contain all the information - only capture what's necessary for the assertion. You can use regular expressions for unstable values.
+
+```bash
+# Get a stable locator for an element ref to use in the assertion
+playwright-cli --raw generate-locator e5
+# getByRole('button', { name: 'Submit' })
+
+# Capture expected text content for toHaveText
+playwright-cli --raw eval "el => el.textContent" e5
+
+# Capture expected input value for toHaveValue/toBeEmpty
+playwright-cli --raw eval "el => el.value" e5
+
+# Capture expected aria snapshot for toMatchAriaSnapshot/toBeChecked
+# (whole page, or use a ref to scope to a region)
+playwright-cli --raw snapshot
+playwright-cli --raw snapshot e5
+```
+
+```typescript
+// Generated action
+await page.getByRole('button', { name: 'Submit' }).click();
+
+// Manual assertions using the outputs above:
+await expect(page.getByRole('alert', { name: 'Success' })).toBeVisible();
+await expect(page.getByTestId('main-header')).toHaveText('Welcome, user');
+await expect(page.getByRole('textbox', { name: 'Email' })).toHaveValue('user@example.com');
+await expect(page.getByRole('checkbox', { name: 'Enable notifications' })).toBeChecked();
+
+// toMatchAriaSnapshot on the whole page, finds a matching region
+await expect(page).toMatchAriaSnapshot(`
+  - heading "Welcome, user"
+  - link /\\d+ new messages?/
+  - button "Sign out"
+`);
+
+// toMatchAriaSnapshot scoped to a region
+await expect(page.getByRole('navigation')).toMatchAriaSnapshot(`
+  - link "Home"
+  - link /\\d+ new messages?/
+  - link "Profile"
+`);
+```

--- a/.claude/skills/playwright-cli/references/tracing.md
+++ b/.claude/skills/playwright-cli/references/tracing.md
@@ -1,0 +1,139 @@
+# Tracing
+
+Capture detailed execution traces for debugging and analysis. Traces include DOM snapshots, screenshots, network activity, and console logs.
+
+## Basic Usage
+
+```bash
+# Start trace recording
+playwright-cli tracing-start
+
+# Perform actions
+playwright-cli open https://example.com
+playwright-cli click e1
+playwright-cli fill e2 "test"
+
+# Stop trace recording
+playwright-cli tracing-stop
+```
+
+## Trace Output Files
+
+When you start tracing, Playwright creates a `traces/` directory with several files:
+
+### `trace-{timestamp}.trace`
+
+**Action log** - The main trace file containing:
+- Every action performed (clicks, fills, navigations)
+- DOM snapshots before and after each action
+- Screenshots at each step
+- Timing information
+- Console messages
+- Source locations
+
+### `trace-{timestamp}.network`
+
+**Network log** - Complete network activity:
+- All HTTP requests and responses
+- Request headers and bodies
+- Response headers and bodies
+- Timing (DNS, connect, TLS, TTFB, download)
+- Resource sizes
+- Failed requests and errors
+
+### `resources/`
+
+**Resources directory** - Cached resources:
+- Images, fonts, stylesheets, scripts
+- Response bodies for replay
+- Assets needed to reconstruct page state
+
+## What Traces Capture
+
+| Category | Details |
+|----------|---------|
+| **Actions** | Clicks, fills, hovers, keyboard input, navigations |
+| **DOM** | Full DOM snapshot before/after each action |
+| **Screenshots** | Visual state at each step |
+| **Network** | All requests, responses, headers, bodies, timing |
+| **Console** | All console.log, warn, error messages |
+| **Timing** | Precise timing for each operation |
+
+## Use Cases
+
+### Debugging Failed Actions
+
+```bash
+playwright-cli tracing-start
+playwright-cli open https://app.example.com
+
+# This click fails - why?
+playwright-cli click e5
+
+playwright-cli tracing-stop
+# Open trace to see DOM state when click was attempted
+```
+
+### Analyzing Performance
+
+```bash
+playwright-cli tracing-start
+playwright-cli open https://slow-site.com
+playwright-cli tracing-stop
+
+# View network waterfall to identify slow resources
+```
+
+### Capturing Evidence
+
+```bash
+# Record a complete user flow for documentation
+playwright-cli tracing-start
+
+playwright-cli open https://app.example.com/checkout
+playwright-cli fill e1 "4111111111111111"
+playwright-cli fill e2 "12/25"
+playwright-cli fill e3 "123"
+playwright-cli click e4
+
+playwright-cli tracing-stop
+# Trace shows exact sequence of events
+```
+
+## Trace vs Video vs Screenshot
+
+| Feature | Trace | Video | Screenshot |
+|---------|-------|-------|------------|
+| **Format** | .trace file | .webm video | .png/.jpeg image |
+| **DOM inspection** | Yes | No | No |
+| **Network details** | Yes | No | No |
+| **Step-by-step replay** | Yes | Continuous | Single frame |
+| **File size** | Medium | Large | Small |
+| **Best for** | Debugging | Demos | Quick capture |
+
+## Best Practices
+
+### 1. Start Tracing Before the Problem
+
+```bash
+# Trace the entire flow, not just the failing step
+playwright-cli tracing-start
+playwright-cli open https://example.com
+# ... all steps leading to the issue ...
+playwright-cli tracing-stop
+```
+
+### 2. Clean Up Old Traces
+
+Traces can consume significant disk space:
+
+```bash
+# Remove traces older than 7 days
+find .playwright-cli/traces -mtime +7 -delete
+```
+
+## Limitations
+
+- Traces add overhead to automation
+- Large traces can consume significant disk space
+- Some dynamic content may not replay perfectly

--- a/.claude/skills/playwright-cli/references/video-recording.md
+++ b/.claude/skills/playwright-cli/references/video-recording.md
@@ -1,0 +1,143 @@
+# Video Recording
+
+Capture browser automation sessions as video for debugging, documentation, or verification. Produces WebM (VP8/VP9 codec).
+
+## Basic Recording
+
+```bash
+# Open browser first
+playwright-cli open
+
+# Start recording
+playwright-cli video-start demo.webm
+
+# Add a chapter marker for section transitions
+playwright-cli video-chapter "Getting Started" --description="Opening the homepage" --duration=2000
+
+# Navigate and perform actions
+playwright-cli goto https://example.com
+playwright-cli snapshot
+playwright-cli click e1
+
+# Add another chapter
+playwright-cli video-chapter "Filling Form" --description="Entering test data" --duration=2000
+playwright-cli fill e2 "test input"
+
+# Stop and save
+playwright-cli video-stop
+```
+
+## Best Practices
+
+### 1. Use Descriptive Filenames
+
+```bash
+# Include context in filename
+playwright-cli video-start recordings/login-flow-2024-01-15.webm
+playwright-cli video-start recordings/checkout-test-run-42.webm
+```
+
+### 2. Record entire hero scripts.
+
+When recording a video for the user or as a proof of work, it is best to create a code snippet and execute it with run-code.
+It allows pulling appropriate pauses between the actions and annotating the video. There are new Playwright APIs for that.
+
+1) Perform scenario using CLI and take note of all locators and actions. You'll need those locators to request their bounding boxes for highlight.
+2) Create a file with the intended script for video (below). Use pressSequentially w/ delay for nice typing, make reasonable pauses.
+3) Use playwright-cli run-code --filename your-script.js
+
+**Important**: Overlays are `pointer-events: none` — they do not interfere with page interactions. You can safely keep sticky overlays visible while clicking, filling, or performing any actions on the page.
+
+```js
+async page => {
+  await page.screencast.start({ path: 'video.webm', size: { width: 1280, height: 800 } });
+  await page.goto('https://demo.playwright.dev/todomvc');
+
+  // Show a chapter card — blurs the page and shows a dialog.
+  // Blocks until duration expires, then auto-removes.
+  // Use this for simple use cases, but always feel free to hand-craft your own beautiful
+  // overlay via await page.screencast.showOverlay().
+  await page.screencast.showChapter('Adding Todo Items', {
+    description: 'We will add several items to the todo list.',
+    duration: 2000,
+  });
+
+  // Perform action
+  await page.getByRole('textbox', { name: 'What needs to be done?' }).pressSequentially('Walk the dog', { delay: 60 });
+  await page.getByRole('textbox', { name: 'What needs to be done?' }).press('Enter');
+  await page.waitForTimeout(1000);
+
+  // Show next chapter
+  await page.screencast.showChapter('Verifying Results', {
+    description: 'Checking the item appeared in the list.',
+    duration: 2000,
+  });
+
+  // Add a sticky annotation that stays while you perform actions.
+  // Overlays are pointer-events: none, so they won't block clicks.
+  const annotation = await page.screencast.showOverlay(`
+    <div style="position: absolute; top: 8px; right: 8px;
+      padding: 6px 12px; background: rgba(0,0,0,0.7);
+      border-radius: 8px; font-size: 13px; color: white;">
+      ✓ Item added successfully
+    </div>
+  `);
+
+  // Perform more actions while the annotation is visible
+  await page.getByRole('textbox', { name: 'What needs to be done?' }).pressSequentially('Buy groceries', { delay: 60 });
+  await page.getByRole('textbox', { name: 'What needs to be done?' }).press('Enter');
+  await page.waitForTimeout(1500);
+
+  // Remove the annotation when done
+  await annotation.dispose();
+
+  // You can also highlight relevant locators and provide contextual annotations.
+  const bounds = await page.getByText('Walk the dog').boundingBox();
+  await page.screencast.showOverlay(`
+    <div style="position: absolute;
+      top: ${bounds.y}px;
+      left: ${bounds.x}px;
+      width: ${bounds.width}px;
+      height: ${bounds.height}px;
+      border: 1px solid red;">
+    </div>
+    <div style="position: absolute;
+      top: ${bounds.y + bounds.height + 5}px;
+      left: ${bounds.x + bounds.width / 2}px;
+      transform: translateX(-50%);
+      padding: 6px;
+      background: #808080;
+      border-radius: 10px;
+      font-size: 14px;
+      color: white;">Check it out, it is right above this text
+    </div>
+  `, { duration: 2000 });
+
+  await page.screencast.stop();
+}
+```
+
+Embrace creativity, overlays are powerful.
+
+### Overlay API Summary
+
+| Method | Use Case |
+|--------|----------|
+| `page.screencast.showChapter(title, { description?, duration?, styleSheet? })` | Full-screen chapter card with blurred backdrop — ideal for section transitions |
+| `page.screencast.showOverlay(html, { duration? })` | Custom HTML overlay — use for callouts, labels, highlights |
+| `disposable.dispose()` | Remove a sticky overlay added without duration |
+| `page.screencast.hideOverlays()` / `page.screencast.showOverlays()` | Temporarily hide/show all overlays |
+
+## Tracing vs Video
+
+| Feature | Video | Tracing |
+|---------|-------|---------|
+| Output | WebM file | Trace file (viewable in Trace Viewer) |
+| Shows | Visual recording | DOM snapshots, network, console, actions |
+| Use case | Demos, documentation | Debugging, analysis |
+| Size | Larger | Smaller |
+
+## Limitations
+
+- Recording adds slight overhead to automation
+- Large recordings can consume significant disk space

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,10 @@ Desktop.ini
 # Claude Code
 .claude/settings.local.json
 
+# Playwright CLI artifacts (browser automation tool output)
+.playwright-cli/
+.playwright/
+
 # Local plans / working files
 .local/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,6 +196,38 @@ MCP tool parameters (`path`, `query`) are **untrusted inputs** from AI agents.
 - **global.json:** Pins .NET SDK 10.0.100 with `rollForward: latestFeature`
 - **SonarAnalyzer.CSharp:** Applied to all projects via `Directory.Build.props`
 
+## Web Dashboard (CodeCompress.Web)
+
+The Blazor Server dashboard lives in `src/CodeCompress.Web/`. It uses **BlazorBlueprint v3** as the component library and **Catppuccin** (Macchiato dark / Latte light) for the color palette via `IThemeService`.
+
+### BlazorBlueprint Components — Mandatory
+
+**Always use BB components over raw HTML.** This is enforced during code review.
+
+| Need | Use | Do NOT use |
+|------|-----|------------|
+| Card / panel | `BbCard`, `BbCardHeader`, `BbCardTitle`, `BbCardDescription`, `BbCardContent`, `BbCardAction` | `<div class="card">` |
+| Data table | `BbDataGrid<TData>` + `BbDataGridPropertyColumn` / `BbDataGridTemplateColumn` | `<table>` |
+| Alert / banner | `BbAlert` + `BbAlertTitle` + `BbAlertDescription` (inside `<ChildContent>`) | `<div class="alert">` |
+| Empty state | `BbEmpty` | custom empty divs |
+| Search input | `BbInputGroup` + `BbInputGroupAddon` + `BbInputGroupInput` + `BbInputGroupButton` | raw `<input>` + `<button>` |
+| Breadcrumb | `BbBreadcrumb` → `BbBreadcrumbList` → `BbBreadcrumbItem` → `BbBreadcrumbLink` / `BbBreadcrumbPage` | `<nav>` with raw links |
+| Badge / tag | `BbBadge` | `<span class="badge">` |
+| Button | `BbButton` | `<button>` (except inside template columns or icon-only action rows) |
+
+**Known BB component constraints:**
+
+- `BbEmpty`, `BbAlert`, `BbCard`, `BbBreadcrumbPage` do **not** have `AdditionalAttributes` (CaptureUnmatchedValues) — passing `data-testid` or any unknown HTML attribute causes a runtime `InvalidOperationException`. Place `data-testid` only on native HTML elements (`<div>`, `<span>`, `<a>`, `<button>`).
+- `BbDataGrid` requires `TData : class` — use a `private sealed record` instead of a value tuple when the type would otherwise be a struct.
+- `BbAlert` child content: `BbAlertTitle` and `BbAlertDescription` must be inside `<ChildContent>...</ChildContent>`, not as bare children.
+- Razor `Class` attribute interpolation: use `Class="@($"base-class modifier--{method()}")"` — never mix C# and literal text like `Class="base modifier--@method()"`.
+- `BbInputGroupInput` uses `UpdateTiming` enum: `Immediate`, `OnChange`, `Debounced` — `OnInput` does not exist.
+- `BbBreadcrumbLink Href` with route params: use `Href="@($"/repo/{RepoId}")"` — not `Href="/repo/@RepoId"`.
+
+### Theme
+
+Theme toggling is handled by `IThemeService` (injected via DI). Do **not** use JSInterop for theme switching — BB's `ThemeService` handles it. The `ThemeToggle.razor` component calls `ThemeService.ToggleAsync()`.
+
 ## Code Style
 
 Enforced via `.editorconfig`:

--- a/CodeCompress.slnx
+++ b/CodeCompress.slnx
@@ -3,10 +3,12 @@
     <Project Path="src/CodeCompress.Core/CodeCompress.Core.csproj" />
     <Project Path="src/CodeCompress.Server/CodeCompress.Server.csproj" />
     <Project Path="src/CodeCompress.Cli/CodeCompress.Cli.csproj" />
+    <Project Path="src/CodeCompress.Web/CodeCompress.Web.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/CodeCompress.Core.Tests/CodeCompress.Core.Tests.csproj" />
     <Project Path="tests/CodeCompress.Server.Tests/CodeCompress.Server.Tests.csproj" />
     <Project Path="tests/CodeCompress.Integration.Tests/CodeCompress.Integration.Tests.csproj" />
+    <Project Path="tests/CodeCompress.Web.Tests/CodeCompress.Web.Tests.csproj" />
   </Folder>
 </Solution>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,6 +18,8 @@
     <PackageVersion Include="Verify" Version="31.13.2" />
     <PackageVersion Include="BlazorBlueprint.Components" Version="3.10.0" />
     <PackageVersion Include="BlazorBlueprint.Primitives" Version="3.10.0" />
+    <PackageVersion Include="Z.Blazor.Diagrams" Version="3.0.4.1" />
+    <PackageVersion Include="Z.Blazor.Diagrams.Algorithms" Version="3.0.4.1" />
     <PackageVersion Include="bunit" Version="2.7.2" />
   </ItemGroup>
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,6 +16,9 @@
     <PackageVersion Include="TUnit" Version="1.19.11" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="Verify" Version="31.13.2" />
+    <PackageVersion Include="BlazorBlueprint.Components" Version="3.10.0" />
+    <PackageVersion Include="BlazorBlueprint.Primitives" Version="3.10.0" />
+    <PackageVersion Include="bunit" Version="2.7.2" />
   </ItemGroup>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -165,6 +165,24 @@ codecompress search --path /path/to/project --query "MyClass"
 
 The CLI and MCP server share the same index database — you can use both interchangeably. Run `codecompress --help` for all commands, or `codecompress agent-instructions` to generate a ready-to-paste instruction block for AI agents.
 
+### Option C: Web Dashboard (local UI)
+
+Launch a dark-mode Blazor dashboard to browse indexed repositories, search symbols, and trigger re-indexes from a browser:
+
+```bash
+codecompress web
+```
+
+Opens on `http://localhost:7070` by default. Options:
+
+```bash
+codecompress web --port 8080        # custom port
+codecompress web --open             # open browser automatically
+codecompress web --bind 0.0.0.0    # bind to all interfaces (LAN access)
+```
+
+The dashboard reads the same global `~/.code-compress/index.db` as the MCP server and CLI — no separate setup required.
+
 To update: `dotnet tool update -g CodeCompress`
 
 ### 2. Index your project
@@ -460,6 +478,9 @@ codecompress changes --path /path/to/project --label before-refactor
 
 # Delete index to force full re-index
 codecompress invalidate-cache --path /path/to/project
+
+# Launch the web dashboard
+codecompress web [--port 7070] [--bind localhost] [--open]
 ```
 
 ### JSON Output
@@ -502,6 +523,7 @@ This outputs a markdown block you can paste into `CLAUDE.md`, system prompts, or
 | `deps` | `dependency_graph` | File-level dependency graph |
 | `project-deps` | `project_dependencies` | Inter-project dependencies (.NET) |
 | `invalidate-cache` | `invalidate_cache` | Force full re-index |
+| `web` | — | Launch the local Blazor web dashboard |
 
 ## License
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,0 +1,1160 @@
+# DESIGN.md — CodeCompress Dashboard
+
+**Project:** CodeCompress — MCP Symbol Index Manager
+**Frontend:** Blazor WebAssembly / Blazor Server
+**Component Framework:** [Blazor Blueprint (shadcn/ui for Blazor)](https://blazorblueprintui.com/)
+**Target:** Local-only developer dashboard (no auth/login screens required)
+**Default Theme:** Dark (Catppuccin Macchiato)
+**Alternate Theme:** Light (Catppuccin Latte)
+
+---
+
+## 1. Project Context
+
+CodeCompress is a stdio MCP server that crawls local code repositories and indexes symbols (functions, classes, interfaces, types, variables, etc.) into a SQLite database. The Blazor frontend provides a management UI for that database — letting developers view indexed repositories, browse symbols, inspect indexing health, and control what gets indexed.
+
+The interface is developer-facing, used locally, and should feel like a premium developer tool: precise, information-dense without being cluttered, and fast. Think VS Code meets a dark-mode analytics dashboard.
+
+---
+
+## 2. Color System
+
+### 2.1 Catppuccin Macchiato — Dark Theme (Default)
+
+All CSS custom properties map directly to Catppuccin Macchiato spec values.
+
+```css
+/* ── Catppuccin Macchiato ─────────────────────────────── */
+--ctp-base: #24273a; /* Page background               */
+--ctp-mantle: #1e2030; /* Sidebar, secondary surfaces   */
+--ctp-crust: #181926; /* Deepest chrome (nav underlay) */
+
+--ctp-surface0: #363a4f; /* Card backgrounds              */
+--ctp-surface1: #494d64; /* Hover surfaces, borders       */
+--ctp-surface2: #5b6078; /* Disabled states               */
+
+--ctp-overlay0: #6e738d; /* Muted borders                 */
+--ctp-overlay1: #8087a2; /* Placeholder text              */
+--ctp-overlay2: #939ab7; /* Secondary labels              */
+
+--ctp-subtext0: #a5adcb; /* Subtle body text              */
+--ctp-subtext1: #b8c0e0; /* Body text                     */
+--ctp-text: #cad3f5; /* Primary text                  */
+
+/* Accent / Semantic Colors */
+--ctp-lavender: #b7bdf8; /* Primary accent                */
+--ctp-blue: #8aadf4; /* Links, interactive elements   */
+--ctp-sapphire: #7dc4e4; /* Info states                   */
+--ctp-sky: #91d7e3; /* Secondary highlights          */
+--ctp-teal: #8bd5ca; /* Success / indexed             */
+--ctp-green: #a6da95; /* Positive metrics, growth      */
+--ctp-yellow: #eed49f; /* Warning states                */
+--ctp-peach: #f5a97f; /* Badges, callouts              */
+--ctp-maroon: #ee99a0; /* Error / degraded              */
+--ctp-red: #ed8796; /* Destructive actions           */
+--ctp-mauve: #c6a0f6; /* Featured / highlighted repo   */
+--ctp-pink: #f5bde6; /* Tag accents                   */
+--ctp-flamingo: #f0c6c6; /* Soft warnings                 */
+--ctp-rosewater: #f4dbd6; /* Subtle decorative             */
+```
+
+### 2.2 Catppuccin Latte — Light Theme
+
+```css
+/* ── Catppuccin Latte ─────────────────────────────────── */
+--ctp-base: #eff1f5;
+--ctp-mantle: #e6e9ef;
+--ctp-crust: #dce0e8;
+
+--ctp-surface0: #ccd0da;
+--ctp-surface1: #bcc0cc;
+--ctp-surface2: #acb0be;
+
+--ctp-overlay0: #9ca0b0;
+--ctp-overlay1: #8c8fa1;
+--ctp-overlay2: #7c7f93;
+
+--ctp-subtext0: #6c6f85;
+--ctp-subtext1: #5c5f77;
+--ctp-text: #4c4f69;
+
+--ctp-lavender: #7287fd;
+--ctp-blue: #1e66f5;
+--ctp-sapphire: #209fb5;
+--ctp-sky: #04a5e5;
+--ctp-teal: #179299;
+--ctp-green: #40a02b;
+--ctp-yellow: #df8e1d;
+--ctp-peach: #fe640b;
+--ctp-maroon: #e64553;
+--ctp-red: #d20f39;
+--ctp-mauve: #8839ef;
+--ctp-pink: #ea76cb;
+--ctp-flamingo: #dd7878;
+--ctp-rosewater: #dc8a78;
+```
+
+### 2.3 Semantic Token Mapping
+
+These semantic tokens abstract over the two themes so components reference roles, not raw palette values.
+
+| Token                  | Macchiato Value  | Latte Value      | Usage                              |
+| ---------------------- | ---------------- | ---------------- | ---------------------------------- |
+| `--bg-page`            | `--ctp-base`     | `--ctp-base`     | Root page background               |
+| `--bg-sidebar`         | `--ctp-mantle`   | `--ctp-mantle`   | Left navigation panel              |
+| `--bg-chrome`          | `--ctp-crust`    | `--ctp-crust`    | Topbar, modal scrim base           |
+| `--bg-card`            | `--ctp-surface0` | `--ctp-surface0` | Stat cards, table container        |
+| `--bg-card-hover`      | `--ctp-surface1` | `--ctp-surface1` | Card hover state                   |
+| `--bg-input`           | `--ctp-surface0` | `--ctp-mantle`   | Input fields                       |
+| `--border-subtle`      | `--ctp-overlay0` | `--ctp-surface1` | Hairline dividers, card borders    |
+| `--border-strong`      | `--ctp-overlay1` | `--ctp-overlay0` | Focus rings, active borders        |
+| `--text-primary`       | `--ctp-text`     | `--ctp-text`     | Headings, primary labels           |
+| `--text-secondary`     | `--ctp-subtext1` | `--ctp-subtext1` | Metadata, secondary labels         |
+| `--text-muted`         | `--ctp-overlay1` | `--ctp-subtext0` | Placeholders, disabled             |
+| `--text-inverse`       | `--ctp-crust`    | `--ctp-base`     | Text on accent-colored backgrounds |
+| `--accent-primary`     | `--ctp-lavender` | `--ctp-lavender` | Primary brand accent, CTA          |
+| `--accent-interactive` | `--ctp-blue`     | `--ctp-blue`     | Links, clickable elements          |
+| `--accent-success`     | `--ctp-teal`     | `--ctp-teal`     | Indexed / healthy status           |
+| `--accent-warning`     | `--ctp-yellow`   | `--ctp-yellow`   | Stale index, needs refresh         |
+| `--accent-error`       | `--ctp-red`      | `--ctp-red`      | Failed index, errors               |
+| `--accent-info`        | `--ctp-sapphire` | `--ctp-sapphire` | Informational badges               |
+| `--accent-feature`     | `--ctp-mauve`    | `--ctp-mauve`    | Featured repo highlight            |
+| `--chart-1`            | `--ctp-lavender` | `--ctp-lavender` | Chart series 1                     |
+| `--chart-2`            | `--ctp-teal`     | `--ctp-teal`     | Chart series 2                     |
+| `--chart-3`            | `--ctp-peach`    | `--ctp-peach`    | Chart series 3                     |
+| `--chart-4`            | `--ctp-mauve`    | `--ctp-mauve`    | Chart series 4                     |
+| `--chart-5`            | `--ctp-green`    | `--ctp-green`    | Chart series 5                     |
+
+### 2.4 WCAG Accessibility Compliance
+
+All text/background pairings below have been verified to meet **WCAG 2.1 AA** (minimum 4.5:1 for normal text, 3:1 for large/bold text ≥18px or ≥14px bold). Non-text interactive elements meet 3:1.
+
+**Macchiato verified pairs:**
+
+| Foreground           | Background           | Ratio  | Level |
+| -------------------- | -------------------- | ------ | ----- |
+| `#cad3f5` (Text)     | `#24273a` (Base)     | 10.4:1 | AAA   |
+| `#cad3f5` (Text)     | `#363a4f` (Surface0) | 7.1:1  | AAA   |
+| `#b8c0e0` (Sub1)     | `#24273a` (Base)     | 8.2:1  | AAA   |
+| `#b8c0e0` (Sub1)     | `#363a4f` (Surface0) | 5.6:1  | AA    |
+| `#a5adcb` (Sub0)     | `#24273a` (Base)     | 6.4:1  | AA    |
+| `#b7bdf8` (Lavender) | `#24273a` (Base)     | 7.8:1  | AAA   |
+| `#8aadf4` (Blue)     | `#24273a` (Base)     | 5.9:1  | AA    |
+| `#8bd5ca` (Teal)     | `#24273a` (Base)     | 6.3:1  | AA    |
+| `#a6da95` (Green)    | `#24273a` (Base)     | 6.1:1  | AA    |
+| `#1e2030` (Mantle)   | `#b7bdf8` (Lavender) | 8.1:1  | AAA   |
+
+**Latte verified pairs:**
+
+| Foreground           | Background           | Ratio | Level |
+| -------------------- | -------------------- | ----- | ----- |
+| `#4c4f69` (Text)     | `#eff1f5` (Base)     | 9.8:1 | AAA   |
+| `#4c4f69` (Text)     | `#ccd0da` (Surface0) | 5.4:1 | AA    |
+| `#5c5f77` (Sub1)     | `#eff1f5` (Base)     | 7.3:1 | AAA   |
+| `#1e66f5` (Blue)     | `#eff1f5` (Base)     | 5.1:1 | AA    |
+| `#7287fd` (Lavender) | `#eff1f5` (Base)     | 4.6:1 | AA    |
+| `#179299` (Teal)     | `#eff1f5` (Base)     | 4.7:1 | AA    |
+| `#40a02b` (Green)    | `#eff1f5` (Base)     | 5.8:1 | AA    |
+
+> **Note:** `--ctp-overlay1` (`#8087a2` / `#8c8fa1`) is used only for placeholder/muted text that is explicitly non-interactive and decorative. Never use it for content that carries meaning.
+
+---
+
+## 3. Typography
+
+### 3.1 Font Selection
+
+| Role                | Font Family      | Source                   | Notes                                                                   |
+| ------------------- | ---------------- | ------------------------ | ----------------------------------------------------------------------- |
+| **UI / Body**       | `DM Mono`        | Google Fonts             | Monospaced. Perfect for a code-tooling context; readable at small sizes |
+| **Headings**        | `Syne`           | Google Fonts             | Geometric, slightly condensed — modern and technical-feeling            |
+| **Code / Paths**    | `JetBrains Mono` | Google Fonts / JetBrains | File paths, symbol names, repo paths                                    |
+| **Numeric / Stats** | `DM Mono`        | Google Fonts             | Tabular figures; consistent column widths in data tables                |
+
+```css
+@import url("https://fonts.googleapis.com/css2?family=Syne:wght@400;500;600;700;800&family=DM+Mono:ital,wght@0,300;0,400;0,500;1,400&family=JetBrains+Mono:wght@300;400;500;700&display=swap");
+
+:root {
+    --font-heading: "Syne", sans-serif;
+    --font-body: "DM Mono", monospace;
+    --font-code: "JetBrains Mono", monospace;
+}
+```
+
+### 3.2 Type Scale
+
+| Token         | Size | Weight | Line Height | Usage                  |
+| ------------- | ---- | ------ | ----------- | ---------------------- |
+| `--text-xs`   | 11px | 400    | 1.4         | Table metadata, badges |
+| `--text-sm`   | 13px | 400    | 1.5         | Body copy, table cells |
+| `--text-base` | 14px | 400    | 1.6         | Default UI text        |
+| `--text-md`   | 16px | 500    | 1.5         | Card labels, nav items |
+| `--text-lg`   | 20px | 600    | 1.3         | Section headings       |
+| `--text-xl`   | 24px | 700    | 1.2         | Page titles            |
+| `--text-2xl`  | 32px | 700    | 1.1         | Hero stat numbers      |
+| `--text-3xl`  | 48px | 800    | 1.0         | Large metric callouts  |
+
+> **Heading font:** `Syne` for `--text-lg` and above.
+> **Body/UI font:** `DM Mono` for `--text-xs` through `--text-md`.
+> **Code/paths:** `JetBrains Mono` wherever file paths, symbol names, or code snippets appear.
+
+### 3.3 Letter Spacing
+
+```css
+--tracking-tight: -0.02em; /* Large headings (--text-2xl+)       */
+--tracking-normal: 0; /* Body text                           */
+--tracking-wide: 0.04em; /* Uppercase labels, badges, metadata  */
+--tracking-wider: 0.08em; /* Section divider labels              */
+```
+
+---
+
+## 4. Spacing & Layout
+
+### 4.1 Spacing Scale
+
+A base-4 scale:
+
+```css
+--space-1: 4px;
+--space-2: 8px;
+--space-3: 12px;
+--space-4: 16px;
+--space-5: 20px;
+--space-6: 24px;
+--space-8: 32px;
+--space-10: 40px;
+--space-12: 48px;
+--space-16: 64px;
+--space-20: 80px;
+```
+
+### 4.2 Application Shell Layout
+
+```
+┌───────────────────────────────────────────────────────────────┐
+│  TOPBAR  (48px height, --bg-chrome)                           │
+│  [Logo + App Name]         [Search]         [Theme Toggle]    │
+├──────────────┬────────────────────────────────────────────────┤
+│              │                                                 │
+│  SIDEBAR     │   MAIN CONTENT AREA                            │
+│  (220px)     │   (fluid, max-width: 1400px, centered)        │
+│  --bg-sidebar│   padding: 24px 32px                           │
+│              │                                                 │
+│  Navigation  │   Page Content                                  │
+│  items       │                                                 │
+│              │                                                 │
+│  (always     │                                                 │
+│   visible)   │                                                 │
+│              │                                                 │
+└──────────────┴────────────────────────────────────────────────┘
+```
+
+- **Topbar height:** 48px, `background: var(--bg-chrome)`, bottom border `1px solid var(--border-subtle)`
+- **Sidebar width:** 220px fixed, `background: var(--bg-sidebar)`, right border `1px solid var(--border-subtle)`
+- **Content area:** fluid width, max `1400px`, left-aligned within the remaining space
+- **Content padding:** `24px 32px` (top/bottom 24, left/right 32)
+- **Page title bar:** 56px tall strip at top of content area, contains the page heading and action buttons
+
+### 4.3 Grid System
+
+All dashboard grids use CSS Grid:
+
+```css
+/* Stat card row — 4 columns on large, 2 on medium, 1 on small */
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: var(--space-4);
+}
+
+/* Content sections — sidebar detail + main chart */
+.content-grid {
+    display: grid;
+    grid-template-columns: 1fr 320px;
+    gap: var(--space-6);
+}
+
+/* Repository cards — 3 columns on large */
+.repo-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: var(--space-4);
+}
+```
+
+### 4.4 Border Radius
+
+```css
+--radius-sm: 4px; /* Badges, tags, small chips               */
+--radius-md: 8px; /* Cards, inputs, dropdowns                */
+--radius-lg: 12px; /* Modals, panels, floating elements       */
+--radius-xl: 16px; /* Large feature cards                     */
+--radius-full: 9999px; /* Pills, avatars, toggle switches        */
+```
+
+### 4.5 Elevation / Shadow
+
+Shadows use the palette's crust as the shadow base to feel native:
+
+```css
+/* Dark theme */
+--shadow-sm: 0 1px 3px rgba(24, 25, 38, 0.4);
+--shadow-md: 0 4px 12px rgba(24, 25, 38, 0.5);
+--shadow-lg: 0 8px 24px rgba(24, 25, 38, 0.6);
+--shadow-xl: 0 16px 48px rgba(24, 25, 38, 0.7);
+
+/* Floating accent glow (applied to primary CTAs / featured cards) */
+--glow-accent: 0 0 20px rgba(183, 189, 248, 0.15); /* lavender glow */
+--glow-teal: 0 0 20px rgba(139, 213, 202, 0.12);
+```
+
+```css
+/* Light theme overrides */
+[data-theme="light"] {
+    --shadow-sm: 0 1px 3px rgba(76, 79, 105, 0.1);
+    --shadow-md: 0 4px 12px rgba(76, 79, 105, 0.15);
+    --shadow-lg: 0 8px 24px rgba(76, 79, 105, 0.18);
+    --shadow-xl: 0 16px 48px rgba(76, 79, 105, 0.22);
+    --glow-accent: 0 0 20px rgba(114, 135, 253, 0.12);
+}
+```
+
+---
+
+## 5. Component Specifications
+
+### 5.1 Sidebar Navigation
+
+**Structure:**
+
+```
+┌─────────────────────┐
+│  ⬡ CodeCompress     │  ← Logo mark + app name (16px Syne bold)
+│  ─────────────────  │  ← 1px border-subtle
+│                     │
+│  ◉ Dashboard        │  ← Active item
+│  ○ Repositories     │
+│  ○ Symbols          │
+│  ○ Files            │
+│  ○ Index Jobs       │
+│                     │
+│  ─────────────────  │
+│  SETTINGS           │  ← Section label (11px, tracking-wider, muted)
+│  ○ Configuration    │
+│                     │
+└─────────────────────┘
+```
+
+- **Nav item height:** 36px
+- **Nav item padding:** `8px 16px`
+- **Active state:** `background: var(--ctp-surface0)`, left border `3px solid var(--accent-primary)`, text `var(--text-primary)`
+- **Hover state:** `background: var(--ctp-surface0)` at 60% opacity, smooth 150ms transition
+- **Section labels:** uppercase, `--text-xs`, `letter-spacing: var(--tracking-wider)`, `color: var(--text-muted)`, `padding: 16px 16px 4px`
+- **Icons:** 16px, Lucide icon set, inline with text at 8px gap
+
+**Logo Mark:**
+A hexagonal shape (⬡) in `--ctp-lavender`, representing a compressed node/graph. The wordmark "CodeCompress" in Syne 600 weight, `--text-primary`.
+
+---
+
+### 5.2 Topbar
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  [≡]  CodeCompress         [🔍 Search symbols...]   [☀/🌙]  │
+└──────────────────────────────────────────────────────────────┘
+```
+
+- **Background:** `var(--bg-chrome)` — the darkest surface (Crust)
+- **Height:** 48px
+- **Bottom border:** `1px solid var(--border-subtle)`
+- **Search bar:** centered, 320px wide, `background: var(--bg-card)`, `border-radius: var(--radius-full)`, placeholder "Search symbols, files, repos…"
+- **Theme toggle:** icon button, 32×32px, `border-radius: var(--radius-full)`, subtle border, smooth icon swap animation (200ms fade)
+- **Mobile hamburger:** visible only below 768px breakpoint
+
+---
+
+### 5.3 Stat Cards
+
+Four stat cards displayed in a row at the top of the Dashboard. Each card floats above the page with `--shadow-md`.
+
+**Card anatomy:**
+
+```
+┌─────────────────────────────────┐
+│  TOTAL REPOSITORIES         [↗] │  ← Label (11px, tracking-wide, muted) + trend arrow
+│                                 │
+│  247                            │  ← Hero number (48px, Syne 800, --text-primary)
+│                                 │
+│  ████░░░░░░  +12 this week      │  ← Mini sparkline + delta (13px, --accent-success/error)
+└─────────────────────────────────┘
+```
+
+**Spec:**
+
+- **Background:** `var(--bg-card)` (`--ctp-surface0`)
+- **Border:** `1px solid var(--border-subtle)`
+- **Border-radius:** `var(--radius-lg)` (12px)
+- **Padding:** `20px 24px`
+- **Shadow:** `var(--shadow-md)`
+- **Label:** `DM Mono`, 11px, `letter-spacing: var(--tracking-wide)`, `color: var(--text-muted)`, uppercase
+- **Metric number:** `Syne`, 48px, weight 800, `color: var(--text-primary)`, `letter-spacing: var(--tracking-tight)`
+- **Delta text:** 13px, `DM Mono`, colored by direction (`--accent-success` green for positive, `--accent-error` red for negative, `--text-muted` for neutral)
+- **Accent strip:** A 3px horizontal line at the bottom of each card, unique color per card type:
+    - Repositories → `--ctp-lavender`
+    - Files indexed → `--ctp-teal`
+    - Symbols → `--ctp-peach`
+    - Last indexed → `--ctp-blue`
+- **Hover:** subtle lift via `transform: translateY(-2px)`, `--shadow-lg`, 200ms ease
+
+**Four dashboard stat cards:**
+
+1. **Total Repositories** — Count of indexed repos
+2. **Files Indexed** — Total file count across all repos
+3. **Symbols Extracted** — Total symbol count (functions, classes, etc.)
+4. **Last Index Run** — Relative time (e.g., "3 minutes ago"), status dot (green/yellow/red)
+
+---
+
+### 5.4 Charts
+
+#### Symbol Type Distribution — Donut Chart
+
+Displayed in the right column of the Dashboard overview.
+
+- **Library:** Use a Blazor-compatible chart library (e.g., Blazorise Charts or ApexCharts.Blazor)
+- **Type:** Donut / Pie
+- **Colors:** Use `--chart-1` through `--chart-5` in sequence (lavender, teal, peach, mauve, green)
+- **Center label:** Total symbol count, large Syne numeral
+- **Legend:** Below chart, horizontal pills per symbol type (Function, Class, Interface, Enum, Variable, Property)
+- **Background:** Transparent (inherits card background)
+- **Tooltip:** Custom styled to match theme — `background: var(--bg-chrome)`, `border: 1px solid var(--border-subtle)`, `color: var(--text-primary)`, `border-radius: var(--radius-md)`, `box-shadow: var(--shadow-lg)`
+
+#### Repository Size Over Time — Area Chart
+
+Shown in the main content area, full width.
+
+- **Type:** Stacked area or line chart
+- **X-axis:** Indexed dates (time series)
+- **Y-axis:** Symbol count
+- **Series:** One line per repository (up to 8; overflow uses color cycling)
+- **Fill:** Gradient fill from series color at 30% opacity down to 0% at the bottom
+- **Grid lines:** `1px solid var(--border-subtle)` at 40% opacity
+- **Axis labels:** `DM Mono` 11px, `--text-muted`
+- **Background:** Transparent
+
+#### Symbol Growth Trend — Bar Chart
+
+- **Type:** Grouped vertical bar chart
+- **Bars:** Rounded tops, `border-radius: 4px 4px 0 0`
+- **Colors:** Two series — new symbols (`--ctp-lavender`) vs removed symbols (`--ctp-maroon`)
+- **Spacing:** 2px gap between grouped bars, 12px gap between groups
+
+---
+
+### 5.5 Data Tables
+
+Used on the Repositories, Symbols, and Files pages.
+
+**Table container:**
+
+- `background: var(--bg-card)`, `border: 1px solid var(--border-subtle)`, `border-radius: var(--radius-lg)`
+- Overflow hidden to respect the rounded corners
+- Full width
+
+**Table header row:**
+
+- `background: var(--bg-chrome)` (slightly darker than card)
+- `border-bottom: 1px solid var(--border-subtle)`
+- `padding: 0 16px`, height 40px
+- Column labels: `DM Mono`, 11px, `letter-spacing: var(--tracking-wide)`, uppercase, `color: var(--text-muted)`
+- Sortable columns show a sort indicator (↑↓) in `--accent-primary` when active
+
+**Table body rows:**
+
+- Row height: 48px
+- `padding: 0 16px`
+- `border-bottom: 1px solid var(--border-subtle)` (not on last row)
+- **Hover:** `background: var(--bg-card-hover)`, 150ms transition
+- Text: `DM Mono` 13px, `--text-secondary`
+- Primary cell (name/identifier): `color: var(--text-primary)`, weight 500
+
+**Pagination:**
+
+- Sits below the table, right-aligned
+- "Showing X–Y of Z" label in `--text-muted`
+- Previous/Next buttons as Blazor Blueprint ghost Button components
+
+**Repository table columns:**
+| # | Column | Notes |
+|---|--------|-------|
+| 1 | Name | Repo name, JetBrains Mono, --accent-interactive color, clickable |
+| 2 | Path | Full local path, JetBrains Mono 12px, --text-muted, truncated with ellipsis |
+| 3 | Files | Right-aligned numeric, DM Mono |
+| 4 | Symbols | Right-aligned numeric, DM Mono |
+| 5 | Status | Badge (see §5.7) |
+| 6 | Last Indexed | Relative time, --text-muted |
+| 7 | Actions | Icon buttons: Re-index, View Details, Remove |
+
+**Symbols table columns:**
+| # | Column | Notes |
+|---|--------|-------|
+| 1 | Symbol Name | JetBrains Mono, --text-primary |
+| 2 | Kind | Badge (Function, Class, Interface, Enum, etc.) |
+| 3 | File | JetBrains Mono 12px, clickable, truncated |
+| 4 | Line | Right-aligned, DM Mono, --text-muted |
+| 5 | Repository | --accent-interactive, link |
+| 6 | Signature | JetBrains Mono 11px, --text-muted, truncated |
+
+---
+
+### 5.6 Repository Cards (Card Grid View)
+
+An alternative view to the table — a grid of rich cards, toggled by a view switcher (list/grid icon buttons).
+
+```
+┌──────────────────────────────────────┐
+│  ● INDEXED          [Re-index] [···] │  ← Status badge + actions
+│                                      │
+│  my-api-project                      │  ← Repo name (Syne 600, 18px)
+│  /Users/marco/repos/my-api-project   │  ← Path (JetBrains Mono 11px, muted)
+│                                      │
+│  ─────────────────────────────────   │
+│                                      │
+│  312 symbols    │ 48 files           │
+│  ██████████ 78% C#                   │  ← Language bar
+│  ████░░░░░░ 22% Razor                │
+│                                      │
+│  Indexed 5 minutes ago               │  ← --text-muted, 12px
+└──────────────────────────────────────┘
+```
+
+- **Background:** `var(--bg-card)`
+- **Border:** `1px solid var(--border-subtle)`
+- **Hover:** border changes to `var(--border-strong)`, `var(--shadow-md)` added, `translateY(-2px)` lift
+- **Border-radius:** `var(--radius-xl)` (16px)
+- **Padding:** `20px`
+- **Language bar:** thin (6px tall) segmented bar, each segment a different chart color, `border-radius: var(--radius-full)`
+- **Featured repo:** top border replaced with 2px gradient: `--ctp-mauve → --ctp-lavender`, and `--glow-accent` shadow
+
+---
+
+### 5.7 Badges & Status Indicators
+
+#### Status Badges (Pill style)
+
+```css
+.badge {
+    font-family: var(--font-body);
+    font-size: 11px;
+    font-weight: 500;
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+    padding: 2px 8px;
+    border-radius: var(--radius-full);
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+}
+```
+
+| Variant     | Background            | Text           | Border                | Dot Color                     | Usage              |
+| ----------- | --------------------- | -------------- | --------------------- | ----------------------------- | ------------------ |
+| `indexed`   | `--ctp-teal` at 15%   | `--ctp-teal`   | `--ctp-teal` at 40%   | `--ctp-teal`                  | Repo fully indexed |
+| `stale`     | `--ctp-yellow` at 15% | `--ctp-yellow` | `--ctp-yellow` at 40% | `--ctp-yellow`                | Index out of date  |
+| `indexing`  | `--ctp-blue` at 15%   | `--ctp-blue`   | `--ctp-blue` at 40%   | `--ctp-blue` (animated pulse) | Currently indexing |
+| `error`     | `--ctp-red` at 15%    | `--ctp-red`    | `--ctp-red` at 40%    | `--ctp-red`                   | Index failed       |
+| `untracked` | `--ctp-surface1`      | `--text-muted` | `--border-subtle`     | `--text-muted`                | Not yet indexed    |
+
+#### Symbol Kind Badges
+
+Compact, no dot, slightly smaller:
+
+| Kind            | Color            | Abbreviation displayed |
+| --------------- | ---------------- | ---------------------- |
+| Function/Method | `--ctp-blue`     | `fn`                   |
+| Class           | `--ctp-peach`    | `cls`                  |
+| Interface       | `--ctp-lavender` | `ifc`                  |
+| Enum            | `--ctp-green`    | `enm`                  |
+| Variable        | `--ctp-teal`     | `var`                  |
+| Property        | `--ctp-mauve`    | `prop`                 |
+| Type Alias      | `--ctp-sky`      | `type`                 |
+| Namespace       | `--ctp-overlay2` | `ns`                   |
+
+---
+
+### 5.8 Search & Filter Bar
+
+Appears above data tables on list pages.
+
+```
+[ 🔍 Search symbols...          ] [ Kind ▾ ] [ Repository ▾ ] [ Status ▾ ] [ Reset ]
+```
+
+- **Search input:** full `border-radius: var(--radius-full)`, `height: 36px`, `background: var(--bg-card)`, `border: 1px solid var(--border-subtle)`, focus state: `border-color: var(--accent-primary)`, `box-shadow: 0 0 0 3px rgba(183,189,248,0.2)` — accessible focus ring
+- **Dropdown filters:** Blazor Blueprint `Select` components, matching border and radius
+- **Filter chips:** When active filters are applied, they appear as dismissible chips between the filter bar and the table
+
+---
+
+### 5.9 Floating Detail Panel (Slide-over / Drawer)
+
+When a symbol or repository row is clicked, a detail panel slides in from the right (not a full modal, preserving table context).
+
+```
+┌─────────────────────────────────────┐
+│ ← Back           my_function()  [✕] │
+├─────────────────────────────────────┤
+│ Function · my-api-project           │
+│ /src/Services/MyService.cs:142      │
+│                                     │
+│ SIGNATURE                           │
+│ ┌─────────────────────────────────┐ │
+│ │ public async Task<Result>       │ │
+│ │   MyFunction(string id,         │ │
+│ │              CancellationToken) │ │
+│ └─────────────────────────────────┘ │
+│                                     │
+│ REFERENCES                          │
+│  · MyController.cs:89               │
+│  · MyTests.cs:14, 27                │
+│                                     │
+│ RELATED SYMBOLS                     │
+│  · Result (class)                   │
+│  · MyService (class)                │
+└─────────────────────────────────────┘
+```
+
+- **Width:** 400px
+- **Background:** `var(--bg-card)`, left border `1px solid var(--border-subtle)`
+- **Box-shadow:** `var(--shadow-xl)` on the left edge
+- **Animation:** slides in from right, 250ms `cubic-bezier(0.16, 1, 0.3, 1)` — fast in, smooth settle
+- **Backdrop:** `var(--bg-page)` at 40% opacity overlay on the content area (not full screen)
+- **Code block:** `background: var(--bg-chrome)`, `border: 1px solid var(--border-subtle)`, `border-radius: var(--radius-md)`, `padding: 12px`, `font-family: var(--font-code)`, `font-size: 12px`
+- **Section labels:** 11px, uppercase, `letter-spacing: var(--tracking-wider)`, `--text-muted`, with `border-bottom: 1px solid var(--border-subtle)` and 16px bottom padding
+
+---
+
+### 5.10 Buttons
+
+Follow Blazor Blueprint Button component variants, styled with Catppuccin tokens:
+
+| Variant     | Background                    | Text               | Border                            | Hover                                   |
+| ----------- | ----------------------------- | ------------------ | --------------------------------- | --------------------------------------- |
+| Primary     | `--accent-primary` (lavender) | `--ctp-crust`      | none                              | darken 10%, `--glow-accent`             |
+| Secondary   | `--bg-card`                   | `--text-primary`   | `1px solid --border-subtle`       | `--bg-card-hover`                       |
+| Ghost       | transparent                   | `--text-secondary` | none                              | `--bg-card` background                  |
+| Destructive | `--accent-error` (red) at 15% | `--accent-error`   | `1px solid --accent-error` at 40% | `--accent-error` bg, `--ctp-crust` text |
+| Icon-only   | transparent                   | `--text-muted`     | none                              | `--bg-card`, `--text-primary`           |
+
+- **Border-radius:** `var(--radius-md)` for text buttons, `var(--radius-full)` for icon-only round buttons
+- **Height:** 32px (default), 36px (medium), 40px (large)
+- **Padding:** `0 16px` for text buttons, `0 8px` for icon-only
+- **Focus ring:** `box-shadow: 0 0 0 3px rgba(183,189,248,0.35)` (lavender at 35%) — 3:1 contrast on all backgrounds, WCAG AA
+
+---
+
+### 5.11 Toast Notifications
+
+Non-blocking notifications floating at bottom-right.
+
+- **Width:** 340px
+- **Padding:** `14px 16px`
+- **Border-radius:** `var(--radius-lg)`
+- **Border:** `1px solid var(--border-subtle)` with left edge: `4px solid` in status color
+- **Background:** `var(--bg-card)`, `var(--shadow-xl)`
+- **Animation:** slide up from bottom + fade in (200ms), auto-dismiss after 4s with fade out
+- **Max stack:** 3 toasts visible simultaneously, older ones compress upward
+
+Variants: Success (teal), Warning (yellow), Error (red), Info (sapphire)
+
+---
+
+### 5.12 Empty States
+
+When a table or page section has no data:
+
+```
+        ⬡
+  No repositories indexed yet
+
+  Add a repository path to get started
+  with symbol indexing.
+
+        [ Index a Repository ]
+```
+
+- Centered in the container
+- Icon: 48px, `--text-muted`
+- Heading: `Syne` 18px, `--text-secondary`
+- Subtext: `DM Mono` 13px, `--text-muted`
+- CTA: Primary button
+
+---
+
+## 6. Pages
+
+### 6.1 Dashboard (Overview)
+
+**Route:** `/` or `/dashboard`
+
+**Purpose:** At-a-glance health and metrics for the entire CodeCompress index.
+
+**Layout:**
+
+```
+┌─ Page Title ──────────────────────────────────── [Re-index All] ─┐
+
+  [ Stat Card: Repos ] [ Stat Card: Files ] [ Stat Card: Symbols ] [ Stat Card: Last Run ]
+
+┌─ Symbol Growth (area chart, full width) ──────────────────────────┐
+│  Time series of symbols indexed per repo over past 30 days        │
+└───────────────────────────────────────────────────────────────────┘
+
+┌─ Recent Repos (left, 2/3 width) ─────┐ ┌─ By Type (right, 1/3) ──┐
+│  Last 5 indexed repos mini-table     │ │  Donut chart             │
+│  Name / Symbols / Last Indexed / Sts │ │  Symbol type breakdown   │
+└──────────────────────────────────────┘ └──────────────────────────┘
+
+┌─ Index Activity (bar chart, full width) ──────────────────────────┐
+│  New vs removed symbols per day, last 14 days                     │
+└───────────────────────────────────────────────────────────────────┘
+```
+
+**Key interactions:**
+
+- Stat cards are clickable — navigate to the respective list page
+- "Re-index All" button triggers a confirmation dialog then fires re-index for all repositories
+- Recent repos table rows navigate to the Repository detail page
+- Charts have hover tooltips with exact values
+
+---
+
+### 6.2 Repositories Page
+
+**Route:** `/repositories`
+
+**Purpose:** Full list management of all indexed repositories.
+
+**Layout:**
+
+```
+┌─ Repositories ──────────────────── [+ Add Repository] [⊞ Grid] [≡ List] ─┐
+
+  [ 🔍 Search... ] [ Status ▾ ] [ Sort: Last Indexed ▾ ]
+
+┌─ Table / Grid ────────────────────────────────────────────────────────────┐
+│  (see §5.5 and §5.6 for table and card specs)                            │
+└───────────────────────────────────────────────────────────────────────────┘
+
+  Pagination
+```
+
+**Add Repository dialog:**
+
+A modal (Blazor Blueprint `Dialog` component):
+
+- Title: "Add Repository"
+- Field: "Repository Path" — full path text input with folder icon, auto-complete from filesystem if available
+- Field: "Display Name" — optional override
+- Checkbox: "Index on add"
+- Actions: [Cancel] [Add Repository]
+- Modal background: `var(--bg-card)`, centered, `var(--shadow-xl)`, `border-radius: var(--radius-xl)`, backdrop blur scrim
+
+---
+
+### 6.3 Repository Detail Page
+
+**Route:** `/repositories/{id}`
+
+**Purpose:** Deep dive into a single repository's index state.
+
+**Layout:**
+
+```
+┌─ ← Repositories    my-api-project                    [Re-index] [···] ─┐
+
+  [ Badge: INDEXED ] /Users/marco/repos/my-api-project
+  Last indexed: 3 minutes ago · 312 symbols · 48 files
+
+┌─ Symbols by Type (bar chart) ──┐ ┌─ File Tree Summary ─────────────────┐
+│  Horizontal bar per kind        │ │  Expandable directory listing        │
+│  Shows count per symbol type    │ │  Showing file counts and symbols     │
+└─────────────────────────────────┘ └─────────────────────────────────────┘
+
+┌─ Symbols Table ───────────────────────────────────────────────────────────┐
+│  (pre-filtered to this repository)                                        │
+│  Columns: Symbol Name / Kind / File / Line / Signature                    │
+└───────────────────────────────────────────────────────────────────────────┘
+```
+
+**Overflow menu (`···`):**
+
+- Re-index Now
+- Remove from Index (destructive, red)
+- Copy Path
+
+---
+
+### 6.4 Symbols Page
+
+**Route:** `/symbols`
+
+**Purpose:** Global search and browse for all indexed symbols.
+
+**Layout:**
+
+```
+┌─ Symbols ──────────────────────────────────────────────────── [Export] ─┐
+
+  [ 🔍 Search symbols... ] [ Kind ▾ ] [ Repository ▾ ]
+
+  Active filters: [Kind: Function ✕] [Repo: my-api ✕]
+
+┌─ Symbols Table ───────────────────────────────────────────────────────────┐
+│  (see §5.5 Symbols table spec)                                            │
+│  Click row → Slide-over detail panel (see §5.9)                          │
+└───────────────────────────────────────────────────────────────────────────┘
+
+  Pagination
+```
+
+**Symbol count summary bar:**
+
+Between the filter chips and the table, a single line:
+`312 functions · 48 classes · 12 interfaces · 6 enums · 91 variables`
+
+Each number is colored with its corresponding badge color.
+
+---
+
+### 6.5 Files Page
+
+**Route:** `/files`
+
+**Purpose:** Browse all indexed files across all repositories.
+
+**Layout:**
+
+```
+┌─ Files ──────────────────────────────────────────────────────────────────┐
+
+  [ 🔍 Search files... ] [ Extension ▾ ] [ Repository ▾ ]
+
+┌─ Files Table ─────────────────────────────────────────────────────────────┐
+│  Columns: File Path / Extension / Symbols / Repository / Last Modified    │
+└────────────────────────────────────────────────────────────────────────────┘
+```
+
+File path column uses JetBrains Mono 12px. Extension shown as a small badge (language color-coded: `.cs` → blue, `.razor` → mauve, `.ts` → yellow, etc.).
+
+---
+
+### 6.6 Index Jobs Page
+
+**Route:** `/index-jobs`
+
+**Purpose:** History and live status of indexing operations.
+
+**Layout:**
+
+```
+┌─ Index Jobs ─────────────────────────────────────────────────────────────┐
+
+┌─ Active Jobs ──────────────────────────────────────────────────────────── ┐
+│  [●] my-api-project — Indexing... 72%  ██████████░░░░░              [✕]  │
+└─────────────────────────────────────────────────────────────────────────── ┘
+
+┌─ Job History Table ────────────────────────────────────────────────────────┐
+│  Repository / Status / Started / Duration / Symbols Added / Files Scanned  │
+└────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Progress bar:**
+
+- Height: 6px
+- Background: `var(--bg-card)`
+- Fill: `var(--accent-primary)` gradient `→ var(--ctp-teal)`
+- Animated shimmer on active jobs
+- `border-radius: var(--radius-full)`
+
+---
+
+### 6.7 Configuration Page
+
+**Route:** `/configuration`
+
+**Purpose:** Manage CodeCompress settings stored in the database or config file.
+
+**Layout:**
+
+```
+┌─ Configuration ──────────────────────────────────────────────────────────┐
+
+┌─ Section: Indexing ──────────────────────────────────────────────────────┐
+│  Auto-index on file change         [Toggle: ON]                          │
+│  File extensions to include        [Tag input: .cs .ts .razor ...]       │
+│  Directories to exclude            [Tag input: bin/ obj/ node_modules/]  │
+│  Max file size (KB)                [Number input: 512]                   │
+└──────────────────────────────────────────────────────────────────────────┘
+
+┌─ Section: Display ───────────────────────────────────────────────────────┐
+│  Default theme                     [Select: Dark / Light]                │
+│  Rows per page                     [Select: 25 / 50 / 100]              │
+└──────────────────────────────────────────────────────────────────────────┘
+
+                                          [Reset to Defaults]  [Save Changes]
+```
+
+Section containers: `background: var(--bg-card)`, `border: 1px solid var(--border-subtle)`, `border-radius: var(--radius-lg)`, `padding: 20px 24px`, rows are 48px-tall form rows with a `border-bottom: 1px solid var(--border-subtle)` between them.
+
+---
+
+## 7. Motion & Transitions
+
+All transitions should respect `prefers-reduced-motion`:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        transition-duration: 0.01ms !important;
+    }
+}
+```
+
+**Standard transitions:**
+
+| Element            | Property               | Duration | Easing                     |
+| ------------------ | ---------------------- | -------- | -------------------------- |
+| Nav item hover     | background             | 150ms    | ease                       |
+| Card hover lift    | transform, box-shadow  | 200ms    | ease-out                   |
+| Button hover       | background, box-shadow | 150ms    | ease                       |
+| Badge color        | background, color      | 200ms    | ease                       |
+| Table row hover    | background             | 100ms    | linear                     |
+| Slide-over panel   | transform              | 250ms    | cubic-bezier(0.16,1,0.3,1) |
+| Toast notification | transform, opacity     | 200ms    | ease-out                   |
+| Chart tooltip      | opacity                | 100ms    | ease                       |
+| Theme toggle       | all colors             | 300ms    | ease                       |
+| Progress bar fill  | width                  | 400ms    | ease-in-out                |
+| Modal open         | opacity, scale         | 200ms    | ease-out                   |
+
+**Micro-animation — indexing spinner:**
+The status dot for "Indexing" state pulses with a scale animation: `scale(1) → scale(1.4) → scale(1)`, 1.2s infinite, `ease-in-out`. The dot itself glows softly: `box-shadow: 0 0 0 4px rgba(138, 173, 244, 0.2)`.
+
+---
+
+## 8. Blazor Blueprint Component Mapping
+
+Mapping of UI elements to their Blazor Blueprint (shadcn/ui for Blazor) equivalents:
+
+| UI Element             | Blazor Blueprint Component                                   |
+| ---------------------- | ------------------------------------------------------------ |
+| Data tables            | `DataTable` / `Table`                                        |
+| Stat cards             | `Card`, `CardHeader`, `CardContent`                          |
+| Navigation             | `NavigationMenu` or custom `NavLink` wrapper                 |
+| Buttons                | `Button` (variant: default, outline, ghost, destructive)     |
+| Dropdowns/Select       | `Select`, `SelectTrigger`, `SelectContent`, `SelectItem`     |
+| Search input           | `Input` with `InputAdornment`                                |
+| Badges                 | `Badge` (variant mapped to status)                           |
+| Modal dialogs          | `Dialog`, `DialogContent`, `DialogHeader`                    |
+| Slide-over / Drawer    | `Sheet`, `SheetContent` (side="right")                       |
+| Toast notifications    | `Toaster` / `Toast`                                          |
+| Toggle switch          | `Switch`                                                     |
+| Tag input              | Custom `TagInput` built on `Input` + `Badge`                 |
+| Progress bars          | `Progress`                                                   |
+| Tooltips               | `Tooltip`, `TooltipContent`                                  |
+| Separator / Divider    | `Separator`                                                  |
+| Dropdown menus (`···`) | `DropdownMenu`, `DropdownMenuTrigger`, `DropdownMenuContent` |
+| Tabs (view switchers)  | `Tabs`, `TabsList`, `TabsTrigger`, `TabsContent`             |
+| Number input           | `Input` with `type="number"`                                 |
+
+---
+
+## 9. Responsive Behavior
+
+This is a local developer tool, primarily used on desktop. Mobile is a nice-to-have, not required, but the layout should gracefully handle narrow windows.
+
+| Breakpoint  | Behavior                                                               |
+| ----------- | ---------------------------------------------------------------------- |
+| > 1280px    | Full layout: sidebar visible, 4-column stat grid                       |
+| 1024–1280px | Sidebar visible, 2-column stat grid                                    |
+| 768–1024px  | Sidebar collapses to icon-only (48px), 2-column stat grid              |
+| < 768px     | Sidebar hidden behind hamburger, 1-column stat grid, simplified charts |
+
+---
+
+## 10. Iconography
+
+**Library:** [Lucide Icons](https://lucide.dev/) — consistent 24×24 (or 16×16 for inline) stroke icons.
+
+| Action / Concept     | Icon Name                    |
+| -------------------- | ---------------------------- |
+| Repository           | `folder-git-2`               |
+| Symbol / function    | `braces`                     |
+| File                 | `file-code`                  |
+| Index / refresh      | `refresh-cw`                 |
+| Add                  | `plus`                       |
+| Remove / delete      | `trash-2`                    |
+| Settings / config    | `settings`                   |
+| Search               | `search`                     |
+| Dashboard / overview | `layout-dashboard`           |
+| Index jobs           | `activity`                   |
+| Status: indexed      | `check-circle`               |
+| Status: error        | `alert-circle`               |
+| Status: stale        | `clock`                      |
+| Status: indexing     | `loader-2` (animated rotate) |
+| Export               | `download`                   |
+| More options         | `ellipsis`                   |
+| Theme: dark          | `moon`                       |
+| Theme: light         | `sun`                        |
+| Expand detail        | `arrow-right`                |
+| Back                 | `chevron-left`               |
+| Dismiss / close      | `x`                          |
+| Sort ascending       | `chevron-up`                 |
+| Sort descending      | `chevron-down`               |
+
+---
+
+## 11. CSS Custom Property Reference (Complete)
+
+```css
+:root {
+    /* ── Catppuccin Macchiato (dark default) ── */
+    --ctp-base: #24273a;
+    --ctp-mantle: #1e2030;
+    --ctp-crust: #181926;
+    --ctp-surface0: #363a4f;
+    --ctp-surface1: #494d64;
+    --ctp-surface2: #5b6078;
+    --ctp-overlay0: #6e738d;
+    --ctp-overlay1: #8087a2;
+    --ctp-overlay2: #939ab7;
+    --ctp-subtext0: #a5adcb;
+    --ctp-subtext1: #b8c0e0;
+    --ctp-text: #cad3f5;
+    --ctp-lavender: #b7bdf8;
+    --ctp-blue: #8aadf4;
+    --ctp-sapphire: #7dc4e4;
+    --ctp-sky: #91d7e3;
+    --ctp-teal: #8bd5ca;
+    --ctp-green: #a6da95;
+    --ctp-yellow: #eed49f;
+    --ctp-peach: #f5a97f;
+    --ctp-maroon: #ee99a0;
+    --ctp-red: #ed8796;
+    --ctp-mauve: #c6a0f6;
+    --ctp-pink: #f5bde6;
+    --ctp-flamingo: #f0c6c6;
+    --ctp-rosewater: #f4dbd6;
+
+    /* ── Semantic tokens (dark) ── */
+    --bg-page: var(--ctp-base);
+    --bg-sidebar: var(--ctp-mantle);
+    --bg-chrome: var(--ctp-crust);
+    --bg-card: var(--ctp-surface0);
+    --bg-card-hover: var(--ctp-surface1);
+    --bg-input: var(--ctp-surface0);
+    --border-subtle: var(--ctp-overlay0);
+    --border-strong: var(--ctp-overlay1);
+    --text-primary: var(--ctp-text);
+    --text-secondary: var(--ctp-subtext1);
+    --text-muted: var(--ctp-overlay1);
+    --text-inverse: var(--ctp-crust);
+    --accent-primary: var(--ctp-lavender);
+    --accent-interactive: var(--ctp-blue);
+    --accent-success: var(--ctp-teal);
+    --accent-warning: var(--ctp-yellow);
+    --accent-error: var(--ctp-red);
+    --accent-info: var(--ctp-sapphire);
+    --accent-feature: var(--ctp-mauve);
+    --chart-1: var(--ctp-lavender);
+    --chart-2: var(--ctp-teal);
+    --chart-3: var(--ctp-peach);
+    --chart-4: var(--ctp-mauve);
+    --chart-5: var(--ctp-green);
+    --shadow-sm: 0 1px 3px rgba(24, 25, 38, 0.4);
+    --shadow-md: 0 4px 12px rgba(24, 25, 38, 0.5);
+    --shadow-lg: 0 8px 24px rgba(24, 25, 38, 0.6);
+    --shadow-xl: 0 16px 48px rgba(24, 25, 38, 0.7);
+    --glow-accent: 0 0 20px rgba(183, 189, 248, 0.15);
+    --font-heading: "Syne", sans-serif;
+    --font-body: "DM Mono", monospace;
+    --font-code: "JetBrains Mono", monospace;
+    --radius-sm: 4px;
+    --radius-md: 8px;
+    --radius-lg: 12px;
+    --radius-xl: 16px;
+    --radius-full: 9999px;
+    --space-1: 4px;
+    --space-2: 8px;
+    --space-3: 12px;
+    --space-4: 16px;
+    --space-5: 20px;
+    --space-6: 24px;
+    --space-8: 32px;
+    --space-10: 40px;
+    --space-12: 48px;
+    --space-16: 64px;
+    --space-20: 80px;
+}
+
+[data-theme="light"] {
+    /* ── Catppuccin Latte overrides ── */
+    --ctp-base: #eff1f5;
+    --ctp-mantle: #e6e9ef;
+    --ctp-crust: #dce0e8;
+    --ctp-surface0: #ccd0da;
+    --ctp-surface1: #bcc0cc;
+    --ctp-surface2: #acb0be;
+    --ctp-overlay0: #9ca0b0;
+    --ctp-overlay1: #8c8fa1;
+    --ctp-overlay2: #7c7f93;
+    --ctp-subtext0: #6c6f85;
+    --ctp-subtext1: #5c5f77;
+    --ctp-text: #4c4f69;
+    --ctp-lavender: #7287fd;
+    --ctp-blue: #1e66f5;
+    --ctp-sapphire: #209fb5;
+    --ctp-sky: #04a5e5;
+    --ctp-teal: #179299;
+    --ctp-green: #40a02b;
+    --ctp-yellow: #df8e1d;
+    --ctp-peach: #fe640b;
+    --ctp-maroon: #e64553;
+    --ctp-red: #d20f39;
+    --ctp-mauve: #8839ef;
+    --ctp-pink: #ea76cb;
+    --ctp-flamingo: #dd7878;
+    --ctp-rosewater: #dc8a78;
+
+    /* ── Semantic overrides where light needs different treatment ── */
+    --bg-input: var(--ctp-mantle);
+    --shadow-sm: 0 1px 3px rgba(76, 79, 105, 0.1);
+    --shadow-md: 0 4px 12px rgba(76, 79, 105, 0.15);
+    --shadow-lg: 0 8px 24px rgba(76, 79, 105, 0.18);
+    --shadow-xl: 0 16px 48px rgba(76, 79, 105, 0.22);
+    --glow-accent: 0 0 20px rgba(114, 135, 253, 0.12);
+}
+```
+
+---
+
+## 12. Design Principles Summary
+
+1. **Information density with breathing room.** Developer tools need to show a lot at once, but every element earns its space. Use the spacing scale consistently and let `--bg-page` breathe between cards.
+
+2. **Monospace-first typography.** The primary audience is developers. `DM Mono` for the UI and `JetBrains Mono` for code/paths signal precision and feel native to the tool.
+
+3. **Color is semantic, not decorative.** Every color usage has a defined meaning (status, type, series). Avoid using accent colors for purely decorative purposes — it dilutes the signal.
+
+4. **Floating surfaces with defined lines.** Cards lift off the page via `box-shadow`, not background-color contrast alone. Borders (`--border-subtle`) define containment. The hierarchy is: page background → cards → chrome → modals.
+
+5. **Dark by default, light by choice.** Macchiato is the canonical theme. Latte is a first-class peer, not an afterthought — every component must look polished in both.
+
+6. **WCAG AA minimum, AAA where free.** Primary text combinations exceed AAA. Interactive elements maintain 3:1 non-text contrast. Focus rings are always visible (high-contrast lavender glow on dark, blue glow on light).
+
+7. **Micro-interactions communicate state.** The indexing spinner, card hover lift, and toast animations tell the user what's happening without requiring them to read status text.

--- a/src/CodeCompress.Cli/CodeCompress.Cli.csproj
+++ b/src/CodeCompress.Cli/CodeCompress.Cli.csproj
@@ -21,7 +21,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\CodeCompress.Core\CodeCompress.Core.csproj" />
+    <ProjectReference Include="..\CodeCompress.Web\CodeCompress.Web.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CodeCompress.Cli/Program.cs
+++ b/src/CodeCompress.Cli/Program.cs
@@ -1858,6 +1858,72 @@ agentInstructionsCommand.SetAction(_ =>
 
 rootCommand.Subcommands.Add(agentInstructionsCommand);
 
+// ── web ──────────────────────────────────────────────────────
+
+var webPortOption = new Option<int>("--port")
+{
+    Description = "Port to listen on",
+    DefaultValueFactory = _ => 7070,
+};
+var webOpenOption = new Option<bool>("--open")
+{
+    Description = "Open the browser automatically after starting",
+};
+var webBindOption = new Option<string>("--bind")
+{
+    Description = "Address to bind to (default: localhost). Use 0.0.0.0 to expose on all interfaces.",
+    DefaultValueFactory = _ => "localhost",
+};
+
+var webCommand = new Command("web", "Start the CodeCompress web dashboard")
+{
+    webPortOption,
+    webOpenOption,
+    webBindOption,
+};
+
+webCommand.SetAction(async parseResult =>
+{
+    var port = parseResult.GetValue(webPortOption);
+    var open = parseResult.GetValue(webOpenOption);
+    var bind = parseResult.GetValue(webBindOption)!;
+
+    if (!string.Equals(bind, "localhost", StringComparison.OrdinalIgnoreCase)
+        && bind != "127.0.0.1")
+    {
+        await Console.Error.WriteLineAsync(
+            $"Warning: binding to {bind} exposes the dashboard beyond localhost.").ConfigureAwait(false);
+    }
+
+    var app = CodeCompress.Web.WebHostFactory.Build(port, bind);
+    var url = $"http://localhost:{port}";
+    await Console.Out.WriteLineAsync($"CodeCompress dashboard running at {url}").ConfigureAwait(false);
+
+    if (open)
+    {
+        try
+        {
+            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = url,
+                UseShellExecute = true,
+            });
+        }
+        catch (System.ComponentModel.Win32Exception)
+        {
+            // Ignore if browser launch fails (no default browser, OS restriction, etc.)
+        }
+        catch (ObjectDisposedException)
+        {
+            // Ignore on process dispose
+        }
+    }
+
+    await app.RunAsync().ConfigureAwait(false);
+});
+
+rootCommand.Subcommands.Add(webCommand);
+
 // ── Execute ─────────────────────────────────────────────────
 
 return await rootCommand.Parse(args).InvokeAsync().ConfigureAwait(false);

--- a/src/CodeCompress.Core/Registry/RegistryService.cs
+++ b/src/CodeCompress.Core/Registry/RegistryService.cs
@@ -76,6 +76,7 @@ internal sealed class RegistryService : IRegistryService
 
     private static RepositoryRecord MapToRecord(Repository repo) =>
         new(
+            repo.Id,
             SanitizePath(repo.RootPath),
             SanitizePath(Path.GetFileName(repo.RootPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar))),
             repo.FileCount,

--- a/src/CodeCompress.Core/Registry/RepositoryRecord.cs
+++ b/src/CodeCompress.Core/Registry/RepositoryRecord.cs
@@ -1,6 +1,7 @@
 namespace CodeCompress.Core.Registry;
 
 public sealed record RepositoryRecord(
+    string RepoId,
     string ProjectRoot,
     string DisplayName,
     int FileCount,

--- a/src/CodeCompress.Core/ServiceCollectionExtensions.cs
+++ b/src/CodeCompress.Core/ServiceCollectionExtensions.cs
@@ -34,7 +34,6 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IFileHasher, FileHasher>();
         services.AddSingleton<IChangeTracker, ChangeTracker>();
         services.AddSingleton<IGitIgnoreFilter, GitIgnoreFilter>();
-        services.AddSingleton<IIndexEngine, IndexEngine>();
         services.AddSingleton<IProjectRootResolver, ProjectRootResolver>();
 
         // Storage

--- a/src/CodeCompress.Web/CodeCompress.Web.csproj
+++ b/src/CodeCompress.Web/CodeCompress.Web.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <!-- Types are referenced externally by CodeCompress.Cli -->
+    <NoWarn>CA1515</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\CodeCompress.Core\CodeCompress.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BlazorBlueprint.Components" />
+    <PackageReference Include="BlazorBlueprint.Primitives" />
+  </ItemGroup>
+
+</Project>

--- a/src/CodeCompress.Web/Components/App.razor
+++ b/src/CodeCompress.Web/Components/App.razor
@@ -5,7 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CodeCompress</title>
     <base href="/" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Syne:wght@400;500;600;700;800&family=DM+Mono:ital,wght@0,300;0,400;0,500;1,400&family=JetBrains+Mono:wght@300;400;500;700&display=swap" />
     <link rel="stylesheet" href="_content/BlazorBlueprint.Components/blazorblueprint.css" />
+    <link rel="stylesheet" href="_content/BlazorBlueprint.Components/css/themes.css" />
     <link rel="stylesheet" href="app.css" />
     <HeadOutlet />
 </head>

--- a/src/CodeCompress.Web/Components/App.razor
+++ b/src/CodeCompress.Web/Components/App.razor
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en" class="dark">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CodeCompress</title>
+    <base href="/" />
+    <link rel="stylesheet" href="_content/BlazorBlueprint.Components/blazorblueprint.css" />
+    <link rel="stylesheet" href="app.css" />
+    <HeadOutlet />
+</head>
+<body>
+    <Routes />
+    <script src="_framework/blazor.web.js"></script>
+</body>
+</html>

--- a/src/CodeCompress.Web/Components/Layout/MainLayout.razor
+++ b/src/CodeCompress.Web/Components/Layout/MainLayout.razor
@@ -1,0 +1,25 @@
+@inherits LayoutComponentBase
+@using BlazorBlueprint.Primitives.Services
+
+<div class="cc-shell">
+    <header class="cc-topbar">
+        <a href="/" class="cc-brand">
+            <span class="cc-brand-icon">⬡</span>
+            <span class="cc-brand-name">CodeCompress</span>
+        </a>
+    </header>
+
+    <div class="cc-body">
+        <nav class="cc-sidebar">
+            <NavMenu />
+        </nav>
+
+        <main class="cc-content">
+            @Body
+        </main>
+    </div>
+</div>
+
+<BbPortalHost />
+<BbToastProvider />
+<BbDialogProvider />

--- a/src/CodeCompress.Web/Components/Layout/MainLayout.razor
+++ b/src/CodeCompress.Web/Components/Layout/MainLayout.razor
@@ -1,5 +1,4 @@
 @inherits LayoutComponentBase
-@using BlazorBlueprint.Primitives.Services
 
 <div class="cc-shell">
     <header class="cc-topbar">
@@ -7,6 +6,22 @@
             <span class="cc-brand-icon">⬡</span>
             <span class="cc-brand-name">CodeCompress</span>
         </a>
+
+        <div class="cc-topbar-center">
+            <div class="cc-topbar-search">
+                <span class="cc-topbar-search-icon">
+                    <LucideIcon Name="search" Size="14" />
+                </span>
+                <input class="cc-topbar-search-input"
+                       type="search"
+                       placeholder="Search symbols, files, repos…"
+                       aria-label="Global search" />
+            </div>
+        </div>
+
+        <div class="cc-topbar-right">
+            <ThemeToggle />
+        </div>
     </header>
 
     <div class="cc-body">
@@ -23,3 +38,4 @@
 <BbPortalHost />
 <BbToastProvider />
 <BbDialogProvider />
+

--- a/src/CodeCompress.Web/Components/Layout/NavMenu.razor
+++ b/src/CodeCompress.Web/Components/Layout/NavMenu.razor
@@ -1,0 +1,6 @@
+<nav class="cc-nav">
+    <NavLink href="/" Match="NavLinkMatch.All" class="cc-nav-item">
+        <LucideIcon Name="LucideIcons.LayoutDashboard" Size="16" />
+        <span>Dashboard</span>
+    </NavLink>
+</nav>

--- a/src/CodeCompress.Web/Components/Layout/NavMenu.razor
+++ b/src/CodeCompress.Web/Components/Layout/NavMenu.razor
@@ -1,6 +1,29 @@
 <nav class="cc-nav">
     <NavLink href="/" Match="NavLinkMatch.All" class="cc-nav-item">
-        <LucideIcon Name="LucideIcons.LayoutDashboard" Size="16" />
+        <LucideIcon Name="layout-dashboard" Size="16" />
         <span>Dashboard</span>
+    </NavLink>
+    <NavLink href="/repositories" class="cc-nav-item">
+        <LucideIcon Name="folder-git-2" Size="16" />
+        <span>Repositories</span>
+    </NavLink>
+    <NavLink href="/symbols" class="cc-nav-item">
+        <LucideIcon Name="braces" Size="16" />
+        <span>Symbols</span>
+    </NavLink>
+    <NavLink href="/files" class="cc-nav-item">
+        <LucideIcon Name="file-code" Size="16" />
+        <span>Files</span>
+    </NavLink>
+    <NavLink href="/index-jobs" class="cc-nav-item">
+        <LucideIcon Name="activity" Size="16" />
+        <span>Index Jobs</span>
+    </NavLink>
+
+    <p class="cc-nav-section-label">Settings</p>
+
+    <NavLink href="/configuration" class="cc-nav-item">
+        <LucideIcon Name="settings" Size="16" />
+        <span>Configuration</span>
     </NavLink>
 </nav>

--- a/src/CodeCompress.Web/Components/Layout/ThemeToggle.razor
+++ b/src/CodeCompress.Web/Components/Layout/ThemeToggle.razor
@@ -1,0 +1,36 @@
+@rendermode InteractiveServer
+@implements IDisposable
+@inject ThemeService ThemeService
+
+<button class="cc-theme-toggle"
+        title="@(ThemeService.IsDarkMode ? "Switch to light theme" : "Switch to dark theme")"
+        aria-label="Toggle theme"
+        @onclick="ToggleAsync">
+    @if (ThemeService.IsDarkMode)
+    {
+        <LucideIcon Name="sun" Size="16" />
+    }
+    else
+    {
+        <LucideIcon Name="moon" Size="16" />
+    }
+</button>
+
+@code {
+    protected override void OnInitialized()
+    {
+        ThemeService.OnThemeChanged += OnThemeChanged;
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+            await ThemeService.InitializeAsync();
+    }
+
+    private void OnThemeChanged() => InvokeAsync(StateHasChanged);
+
+    private async Task ToggleAsync() => await ThemeService.ToggleDarkModeAsync();
+
+    public void Dispose() => ThemeService.OnThemeChanged -= OnThemeChanged;
+}

--- a/src/CodeCompress.Web/Components/Pages/Configuration.razor
+++ b/src/CodeCompress.Web/Components/Pages/Configuration.razor
@@ -1,0 +1,22 @@
+@page "/configuration"
+
+<PageTitle>Configuration — CodeCompress</PageTitle>
+
+<div class="cc-page">
+    <div class="cc-page-header">
+        <div class="cc-page-header-left">
+            <h1>Configuration</h1>
+            <p class="cc-page-subtitle">Manage CodeCompress settings</p>
+        </div>
+    </div>
+
+    <BbCard>
+        <BbCardContent>
+            <BbEmpty Title="Configuration coming soon"
+                     Description="Settings for indexing behavior, file extensions, excluded directories, and display preferences will be available here."
+                     Size="EmptySize.Large">
+                <Icon><LucideIcon Name="settings" Size="40" /></Icon>
+            </BbEmpty>
+        </BbCardContent>
+    </BbCard>
+</div>

--- a/src/CodeCompress.Web/Components/Pages/Dashboard.razor
+++ b/src/CodeCompress.Web/Components/Pages/Dashboard.razor
@@ -1,0 +1,106 @@
+@page "/"
+@rendermode InteractiveServer
+@inject IIndexFacade Facade
+
+<PageTitle>Dashboard — CodeCompress</PageTitle>
+
+<div class="cc-page">
+    <div class="cc-page-header">
+        <h1>Dashboard</h1>
+        <p class="cc-page-subtitle">Indexed repositories</p>
+    </div>
+
+    @if (_loading)
+    {
+        <div class="cc-loading" data-testid="loading">Loading repositories…</div>
+    }
+    else if (_repos.Count == 0)
+    {
+        <div class="cc-empty" data-testid="empty-state">
+            <p>No repositories indexed yet.</p>
+            <p>Run <code>codecompress index --path &lt;path&gt;</code> to add one.</p>
+        </div>
+    }
+    else
+    {
+        <div class="cc-repo-grid">
+            @foreach (var repo in _repos)
+            {
+                <div class="cc-repo-card" data-testid="repo-card">
+                    <div class="cc-repo-card-header">
+                        <a href="/repo/@repo.RepoId"
+                           class="cc-repo-name" data-testid="repo-name">@repo.DisplayName</a>
+                        <BbBadge>Active</BbBadge>
+                    </div>
+                    <p class="cc-repo-path" title="@repo.ProjectRoot">@repo.ProjectRoot</p>
+                    <div class="cc-repo-stats">
+                        <span data-testid="file-count"><b>@repo.FileCount</b> files</span>
+                        <span data-testid="symbol-count"><b>@repo.SymbolCount</b> symbols</span>
+                        <span data-testid="last-indexed">@FormatAge(repo.LastIndexed)</span>
+                    </div>
+                    @if (repo.LastError is not null)
+                    {
+                        <p class="cc-repo-error" data-testid="repo-error">@repo.LastError</p>
+                    }
+                    <div class="cc-repo-actions">
+                        <BbButton Variant="ButtonVariant.Outline" OnClick="() => ReIndexAsync(repo.ProjectRoot)"
+                                  Disabled="_reindexing.Contains(repo.ProjectRoot)">
+                            @if (_reindexing.Contains(repo.ProjectRoot))
+                            {
+                                <span>Indexing…</span>
+                            }
+                            else
+                            {
+                                <LucideIcon Name="LucideIcons.RefreshCw" Size="14" />
+                                <span>Re-index</span>
+                            }
+                        </BbButton>
+                        <a href="/repo/@repo.RepoId" class="cc-link-btn">
+                            <LucideIcon Name="LucideIcons.ArrowRight" Size="14" />
+                            <span>Details</span>
+                        </a>
+                    </div>
+                </div>
+            }
+        </div>
+    }
+</div>
+
+@code {
+    private IReadOnlyList<CodeCompress.Core.Registry.RepositoryRecord> _repos = [];
+    private bool _loading = true;
+    private readonly HashSet<string> _reindexing = [];
+
+    protected override async Task OnInitializedAsync()
+    {
+        _repos = await Facade.GetRepositoriesAsync();
+        _loading = false;
+    }
+
+    private async Task ReIndexAsync(string projectRoot)
+    {
+        _reindexing.Add(projectRoot);
+        try
+        {
+            await Facade.ReIndexAsync(projectRoot);
+            _repos = await Facade.GetRepositoriesAsync();
+        }
+        finally
+        {
+            _reindexing.Remove(projectRoot);
+        }
+    }
+
+    private static string FormatAge(DateTimeOffset dt)
+    {
+        var age = DateTimeOffset.UtcNow - dt;
+        return age switch
+        {
+            { TotalSeconds: < 60 } => "just now",
+            { TotalMinutes: < 60 } a => $"{(int)a.TotalMinutes}m ago",
+            { TotalHours: < 24 } a => $"{(int)a.TotalHours}h ago",
+            { TotalDays: < 2 } => "yesterday",
+            var a => $"{(int)a.TotalDays}d ago",
+        };
+    }
+}

--- a/src/CodeCompress.Web/Components/Pages/Dashboard.razor
+++ b/src/CodeCompress.Web/Components/Pages/Dashboard.razor
@@ -6,70 +6,175 @@
 
 <div class="cc-page">
     <div class="cc-page-header">
-        <h1>Dashboard</h1>
-        <p class="cc-page-subtitle">Indexed repositories</p>
+        <div class="cc-page-header-left">
+            <h1>Dashboard</h1>
+            <p class="cc-page-subtitle">Symbol index overview</p>
+        </div>
+        <div class="cc-page-actions">
+            <BbButton Variant="ButtonVariant.Outline"
+                      OnClick="ReIndexAllAsync"
+                      Disabled="_reindexingAll || _loading">
+                @if (_reindexingAll)
+                {
+                    <LucideIcon Name="loader-circle" Size="14" />
+                    <span>Indexing…</span>
+                }
+                else
+                {
+                    <LucideIcon Name="refresh-cw" Size="14" />
+                    <span>Re-index All</span>
+                }
+            </BbButton>
+        </div>
     </div>
 
-    @if (_loading)
+    @if (!_loading)
     {
-        <div class="cc-loading" data-testid="loading">Loading repositories…</div>
-    }
-    else if (_repos.Count == 0)
-    {
-        <div class="cc-empty" data-testid="empty-state">
-            <p>No repositories indexed yet.</p>
-            <p>Run <code>codecompress index --path &lt;path&gt;</code> to add one.</p>
+        <div class="cc-stats-grid" data-testid="stats-grid">
+            <BbCard Class="cc-stat-card cc-stat-card--repos">
+                <BbCardHeader>
+                    <BbCardDescription>Total Repositories</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <p class="cc-stat-card-value" data-testid="stat-repos">@_repos.Count</p>
+                    <p class="cc-stat-card-delta">@(_repos.Count == 1 ? "1 project" : $"{_repos.Count} projects")</p>
+                </BbCardContent>
+            </BbCard>
+            <BbCard Class="cc-stat-card cc-stat-card--files">
+                <BbCardHeader>
+                    <BbCardDescription>Files Indexed</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <p class="cc-stat-card-value" data-testid="stat-files">@TotalFiles</p>
+                    <p class="cc-stat-card-delta">across all repositories</p>
+                </BbCardContent>
+            </BbCard>
+            <BbCard Class="cc-stat-card cc-stat-card--symbols">
+                <BbCardHeader>
+                    <BbCardDescription>Symbols Extracted</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <p class="cc-stat-card-value" data-testid="stat-symbols">@TotalSymbols</p>
+                    <p class="cc-stat-card-delta">functions, classes, types…</p>
+                </BbCardContent>
+            </BbCard>
+            <BbCard Class="cc-stat-card cc-stat-card--lastrun">
+                <BbCardHeader>
+                    <BbCardDescription>Last Index Run</BbCardDescription>
+                </BbCardHeader>
+                <BbCardContent>
+                    <p class="cc-stat-card-value" data-testid="stat-lastrun" style="font-size: var(--text-2xl)">@LastIndexed</p>
+                    <p class="cc-stat-card-delta">
+                        @if (HasErrors)
+                        {
+                            <span class="cc-status-dot cc-status-dot--error"></span><span>@ErrorCount repo(s) with errors</span>
+                        }
+                        else if (_repos.Count > 0)
+                        {
+                            <span class="cc-status-dot cc-status-dot--success"></span><span>All healthy</span>
+                        }
+                        else
+                        {
+                            <span>No repos yet</span>
+                        }
+                    </p>
+                </BbCardContent>
+            </BbCard>
         </div>
+
+        <BbCard>
+            <BbCardHeader>
+                <BbCardTitle>Repositories</BbCardTitle>
+                <BbCardAction>
+                    <a href="/repositories" class="cc-link-btn">
+                        <LucideIcon Name="arrow-right" Size="12" />
+                        <span>View all</span>
+                    </a>
+                </BbCardAction>
+            </BbCardHeader>
+            <BbCardContent>
+                <BbDataGrid TData="RepositoryRecord"
+                            Items="_repos"
+                            ShowPagination="false"
+                            AriaLabel="Indexed repositories"
+                            ItemKey="@(r => r.RepoId)">
+                    <Columns>
+                        <BbDataGridTemplateColumn Title="Name" Sortable="true" SortBy="@(r => (object)r.DisplayName)">
+                            <ChildContent Context="repo">
+                                <a href="/repo/@repo.RepoId" class="cc-table-name" data-testid="repo-name">@repo.DisplayName</a>
+                            </ChildContent>
+                        </BbDataGridTemplateColumn>
+                        <BbDataGridPropertyColumn Property="@(r => r.ProjectRoot)" Title="Path" NoWrap="true" />
+                        <BbDataGridPropertyColumn Property="@(r => r.FileCount)" Title="Files" Sortable="true" CellClass="cc-col-right" HeaderClass="cc-col-right" />
+                        <BbDataGridPropertyColumn Property="@(r => r.SymbolCount)" Title="Symbols" Sortable="true" CellClass="cc-col-right" HeaderClass="cc-col-right" />
+                        <BbDataGridTemplateColumn Title="Status">
+                            <ChildContent Context="repo">
+                                @{ var status = GetStatus(repo, _reindexing.Contains(repo.ProjectRoot)); }
+                                <span class="cc-badge cc-badge--@status" data-testid="repo-status">
+                                    <span class="cc-badge-dot"></span>
+                                    @status
+                                </span>
+                            </ChildContent>
+                        </BbDataGridTemplateColumn>
+                        <BbDataGridTemplateColumn Title="Last Indexed" Sortable="true" SortBy="@(r => (object)r.LastIndexed)">
+                            <ChildContent Context="repo">
+                                <span data-testid="last-indexed">@FormatAge(repo.LastIndexed)</span>
+                            </ChildContent>
+                        </BbDataGridTemplateColumn>
+                        <BbDataGridTemplateColumn Title="Actions" Width="120px">
+                            <ChildContent Context="repo">
+                                <div class="cc-table-actions">
+                                    <button class="cc-icon-btn"
+                                            title="Re-index"
+                                            disabled="@_reindexing.Contains(repo.ProjectRoot)"
+                                            @onclick="() => ReIndexAsync(repo.ProjectRoot)"
+                                            data-testid="reindex-btn">
+                                        <LucideIcon Name="refresh-cw" Size="14" />
+                                    </button>
+                                    <a href="/repo/@repo.RepoId/graph" class="cc-icon-btn" title="View Graph" data-testid="view-graph-btn">
+                                        <LucideIcon Name="git-graph" Size="14" />
+                                    </a>
+                                    <a href="/repo/@repo.RepoId" class="cc-icon-btn" title="View Details" data-testid="details-btn">
+                                        <LucideIcon Name="arrow-right" Size="14" />
+                                    </a>
+                                </div>
+                            </ChildContent>
+                        </BbDataGridTemplateColumn>
+                    </Columns>
+                    <EmptyTemplate>
+                        <div class="cc-empty-state" data-testid="empty-state">
+                            <span class="cc-empty-state-icon">
+                                <LucideIcon Name="folder-git-2" Size="48" />
+                            </span>
+                            <h3>No repositories indexed yet</h3>
+                            <p>Run <code>codecompress index --path &lt;path&gt;</code> to add a repository to the index.</p>
+                        </div>
+                    </EmptyTemplate>
+                </BbDataGrid>
+            </BbCardContent>
+        </BbCard>
     }
     else
     {
-        <div class="cc-repo-grid">
-            @foreach (var repo in _repos)
-            {
-                <div class="cc-repo-card" data-testid="repo-card">
-                    <div class="cc-repo-card-header">
-                        <a href="/repo/@repo.RepoId"
-                           class="cc-repo-name" data-testid="repo-name">@repo.DisplayName</a>
-                        <BbBadge>Active</BbBadge>
-                    </div>
-                    <p class="cc-repo-path" title="@repo.ProjectRoot">@repo.ProjectRoot</p>
-                    <div class="cc-repo-stats">
-                        <span data-testid="file-count"><b>@repo.FileCount</b> files</span>
-                        <span data-testid="symbol-count"><b>@repo.SymbolCount</b> symbols</span>
-                        <span data-testid="last-indexed">@FormatAge(repo.LastIndexed)</span>
-                    </div>
-                    @if (repo.LastError is not null)
-                    {
-                        <p class="cc-repo-error" data-testid="repo-error">@repo.LastError</p>
-                    }
-                    <div class="cc-repo-actions">
-                        <BbButton Variant="ButtonVariant.Outline" OnClick="() => ReIndexAsync(repo.ProjectRoot)"
-                                  Disabled="_reindexing.Contains(repo.ProjectRoot)">
-                            @if (_reindexing.Contains(repo.ProjectRoot))
-                            {
-                                <span>Indexing…</span>
-                            }
-                            else
-                            {
-                                <LucideIcon Name="LucideIcons.RefreshCw" Size="14" />
-                                <span>Re-index</span>
-                            }
-                        </BbButton>
-                        <a href="/repo/@repo.RepoId" class="cc-link-btn">
-                            <LucideIcon Name="LucideIcons.ArrowRight" Size="14" />
-                            <span>Details</span>
-                        </a>
-                    </div>
-                </div>
-            }
-        </div>
+        <div class="cc-loading" data-testid="loading">Loading…</div>
     }
 </div>
 
 @code {
-    private IReadOnlyList<CodeCompress.Core.Registry.RepositoryRecord> _repos = [];
+    private IReadOnlyList<RepositoryRecord> _repos = [];
     private bool _loading = true;
+    private bool _reindexingAll;
     private readonly HashSet<string> _reindexing = [];
+
+    private int TotalFiles   => _repos.Sum(r => r.FileCount);
+    private int TotalSymbols => _repos.Sum(r => r.SymbolCount);
+    private int ErrorCount   => _repos.Count(r => r.LastError is not null);
+    private bool HasErrors   => ErrorCount > 0;
+
+    private string LastIndexed =>
+        _repos.Count == 0
+            ? "Never"
+            : FormatAge(_repos.Max(r => r.LastIndexed));
 
     protected override async Task OnInitializedAsync()
     {
@@ -89,6 +194,37 @@
         {
             _reindexing.Remove(projectRoot);
         }
+    }
+
+    private async Task ReIndexAllAsync()
+    {
+        _reindexingAll = true;
+        try
+        {
+            _reindexing.UnionWith(_repos.Select(r => r.ProjectRoot));
+
+            foreach (var root in _repos.Select(r => r.ProjectRoot))
+            {
+                await Facade.ReIndexAsync(root);
+                _reindexing.Remove(root);
+            }
+
+            _repos = await Facade.GetRepositoriesAsync();
+        }
+        finally
+        {
+            _reindexingAll = false;
+            _reindexing.Clear();
+        }
+    }
+
+    private static string GetStatus(RepositoryRecord repo, bool indexing)
+    {
+        if (indexing) return "indexing";
+        if (repo.LastError is not null) return "error";
+        var age = DateTimeOffset.UtcNow - repo.LastIndexed;
+        if (age.TotalDays > 7) return "stale";
+        return "indexed";
     }
 
     private static string FormatAge(DateTimeOffset dt)

--- a/src/CodeCompress.Web/Components/Pages/Files.razor
+++ b/src/CodeCompress.Web/Components/Pages/Files.razor
@@ -1,0 +1,73 @@
+@page "/files"
+@rendermode InteractiveServer
+@inject IIndexFacade Facade
+
+<PageTitle>Files — CodeCompress</PageTitle>
+
+<div class="cc-page">
+    <div class="cc-page-header">
+        <div class="cc-page-header-left">
+            <h1>Files</h1>
+            <p class="cc-page-subtitle">All indexed source files across all repositories</p>
+        </div>
+    </div>
+
+    <BbDataGrid TData="FileEntry"
+                Items="_files"
+                IsLoading="_loading"
+                ShowSearch="true"
+                SearchPlaceholder="Filter files…"
+                InitialPageSize="25"
+                AriaLabel="All indexed files"
+                ItemKey="@(e => e.RepoName + e.File.RelativePath)">
+        <Columns>
+            <BbDataGridTemplateColumn Title="File Path" Sortable="true" SortBy="@(e => (object)e.File.RelativePath)"
+                                      Filterable="true" FilterBy="@(e => (object)e.File.RelativePath)">
+                <ChildContent Context="entry">
+                    <span class="cc-table-path" title="@entry.File.RelativePath" data-testid="file-row">@entry.File.RelativePath</span>
+                </ChildContent>
+            </BbDataGridTemplateColumn>
+            <BbDataGridTemplateColumn Title="Ext" Width="72px">
+                <ChildContent Context="entry">
+                    <BbBadge Variant="BadgeVariant.Outline">@ExtensionOf(entry.File.RelativePath)</BbBadge>
+                </ChildContent>
+            </BbDataGridTemplateColumn>
+            <BbDataGridPropertyColumn Property="@(e => e.File.LineCount)" Title="Lines" Sortable="true"
+                                      CellClass="cc-col-right" HeaderClass="cc-col-right" Width="80px" />
+            <BbDataGridPropertyColumn Property="@(e => e.RepoName)" Title="Repository" Sortable="true" Filterable="true" />
+        </Columns>
+        <EmptyTemplate>
+            <BbEmpty Title="No files indexed yet"
+                     Description="Index a repository first to browse its files here."
+                     Size="EmptySize.Default">
+                <Icon><LucideIcon Name="file-code" Size="40" /></Icon>
+            </BbEmpty>
+        </EmptyTemplate>
+    </BbDataGrid>
+</div>
+
+@code {
+    private sealed record FileEntry(FileRecord File, string RepoName);
+
+    private IReadOnlyList<FileEntry> _files = [];
+    private bool _loading = true;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var repos = await Facade.GetRepositoriesAsync();
+        var all = new List<FileEntry>();
+        foreach (var repo in repos)
+        {
+            var files = await Facade.GetFilesAsync(repo.ProjectRoot);
+            all.AddRange(files.Select(f => new FileEntry(f, repo.DisplayName)));
+        }
+        _files = all;
+        _loading = false;
+    }
+
+    private static string ExtensionOf(string path)
+    {
+        var ext = System.IO.Path.GetExtension(path);
+        return string.IsNullOrEmpty(ext) ? "–" : ext;
+    }
+}

--- a/src/CodeCompress.Web/Components/Pages/Graph.razor
+++ b/src/CodeCompress.Web/Components/Pages/Graph.razor
@@ -1,0 +1,95 @@
+@page "/repo/{RepoId}/graph"
+@rendermode InteractiveServer
+@inject IIndexFacade Facade
+
+<PageTitle>@(_repoName is not null ? $"{_repoName} — Graph" : "Graph") — CodeCompress</PageTitle>
+
+@if (_pathError)
+{
+    <div class="cc-page">
+        <BbAlert Variant="AlertVariant.Danger" AccentBorder>
+            <Icon><LucideIcon Name="alert-circle" Size="16" /></Icon>
+            <ChildContent>
+                <BbAlertTitle>Invalid repository</BbAlertTitle>
+                <BbAlertDescription>The repository ID is invalid or not found in the index.</BbAlertDescription>
+            </ChildContent>
+        </BbAlert>
+    </div>
+}
+else
+{
+    <div class="cc-page" style="height: 100%">
+        <div class="cc-page-header">
+            <div class="cc-page-header-left">
+                <BbBreadcrumb>
+                    <BbBreadcrumbList AutoSeparator>
+                        <BbBreadcrumbItem>
+                            <BbBreadcrumbLink Href="@($"/repo/{RepoId}")">@(_repoName ?? RepoId)</BbBreadcrumbLink>
+                        </BbBreadcrumbItem>
+                        <BbBreadcrumbItem>
+                            <BbBreadcrumbPage>Dependency Graph</BbBreadcrumbPage>
+                        </BbBreadcrumbItem>
+                    </BbBreadcrumbList>
+                </BbBreadcrumb>
+                <h1>Dependency Graph</h1>
+                @if (_repoPath is not null)
+                {
+                    <p class="cc-page-subtitle"><span class="cc-repo-path-display">@_repoPath</span></p>
+                }
+            </div>
+        </div>
+
+        @if (_loading)
+        {
+            <div class="cc-loading" data-testid="loading">Loading graph data…</div>
+        }
+        else
+        {
+            <BbCard Class="cc-graph-canvas-placeholder">
+                <BbCardContent>
+                    <BbEmpty Title="Interactive graph coming in GH-193"
+                             Description="@GraphDescription"
+                             Size="EmptySize.Large">
+                        <Icon><LucideIcon Name="git-graph" Size="48" /></Icon>
+                    </BbEmpty>
+                </BbCardContent>
+            </BbCard>
+        }
+    </div>
+}
+
+@code {
+    [Parameter] public string RepoId { get; set; } = string.Empty;
+
+    private string? _repoName;
+    private string? _repoPath;
+    private bool _loading = true;
+    private bool _pathError;
+    private int _fileCount;
+
+    private string GraphDescription =>
+        _fileCount > 0
+            ? $"File-level dependency canvas with pan, zoom, and drag will be implemented here. This repository has {_fileCount} files to visualize."
+            : "File-level dependency canvas with pan, zoom, and drag will be implemented here.";
+
+    protected override async Task OnParametersSetAsync()
+    {
+        _pathError = false;
+        _loading = true;
+
+        var repos = await Facade.GetRepositoriesAsync();
+        var repo = repos.FirstOrDefault(r => string.Equals(r.RepoId, RepoId, StringComparison.Ordinal));
+
+        if (repo is null)
+        {
+            _pathError = true;
+            _loading = false;
+            return;
+        }
+
+        _repoName = repo.DisplayName;
+        _repoPath = repo.ProjectRoot;
+        _fileCount = repo.FileCount;
+        _loading = false;
+    }
+}

--- a/src/CodeCompress.Web/Components/Pages/IndexJobs.razor
+++ b/src/CodeCompress.Web/Components/Pages/IndexJobs.razor
@@ -1,0 +1,22 @@
+@page "/index-jobs"
+
+<PageTitle>Index Jobs — CodeCompress</PageTitle>
+
+<div class="cc-page">
+    <div class="cc-page-header">
+        <div class="cc-page-header-left">
+            <h1>Index Jobs</h1>
+            <p class="cc-page-subtitle">History and live status of indexing operations</p>
+        </div>
+    </div>
+
+    <BbCard>
+        <BbCardContent>
+            <BbEmpty Title="Index Jobs coming soon"
+                     Description="Live progress tracking and job history will be available here once background indexing is implemented."
+                     Size="EmptySize.Large">
+                <Icon><LucideIcon Name="activity" Size="40" /></Icon>
+            </BbEmpty>
+        </BbCardContent>
+    </BbCard>
+</div>

--- a/src/CodeCompress.Web/Components/Pages/RepoDetail.razor
+++ b/src/CodeCompress.Web/Components/Pages/RepoDetail.razor
@@ -1,113 +1,172 @@
 @page "/repo/{RepoId}"
 @rendermode InteractiveServer
 @inject IIndexFacade Facade
-@inject NavigationManager Nav
 
 <PageTitle>@(_repoName ?? "Repository") — CodeCompress</PageTitle>
 
 @if (_pathError)
 {
     <div class="cc-page">
-        <div class="cc-error" data-testid="path-error">
-            <h2>Invalid path</h2>
-            <p>The repository path is invalid or outside an allowed root.</p>
-        </div>
+        <BbAlert Variant="AlertVariant.Danger" AccentBorder>
+            <Icon><LucideIcon Name="alert-circle" Size="16" /></Icon>
+            <ChildContent>
+                <BbAlertTitle>Invalid repository</BbAlertTitle>
+                <BbAlertDescription>The repository ID is invalid or not found in the index.</BbAlertDescription>
+            </ChildContent>
+        </BbAlert>
     </div>
 }
 else
 {
     <div class="cc-page">
         <div class="cc-page-header">
-            <a href="/" class="cc-breadcrumb">Dashboard</a>
-            <span class="cc-breadcrumb-sep">/</span>
-            <h1 data-testid="repo-detail-name">@(_repoName ?? RepoId)</h1>
+            <div class="cc-page-header-left">
+                <BbBreadcrumb>
+                    <BbBreadcrumbList AutoSeparator>
+                        <BbBreadcrumbItem>
+                            <BbBreadcrumbLink Href="/">Dashboard</BbBreadcrumbLink>
+                        </BbBreadcrumbItem>
+                        <BbBreadcrumbItem>
+                            <BbBreadcrumbPage>@(_repoName ?? RepoId)</BbBreadcrumbPage>
+                        </BbBreadcrumbItem>
+                    </BbBreadcrumbList>
+                </BbBreadcrumb>
+            </div>
+
+            @if (_repo is not null)
+            {
+                <div class="cc-page-actions">
+                    <BbButton Variant="ButtonVariant.Outline" OnClick="ReIndexAsync" Disabled="_reindexing">
+                        @if (_reindexing)
+                        {
+                            <LucideIcon Name="loader-circle" Size="14" />
+                            <span>Indexing…</span>
+                        }
+                        else
+                        {
+                            <LucideIcon Name="refresh-cw" Size="14" />
+                            <span>Re-index</span>
+                        }
+                    </BbButton>
+                    <a href="/repo/@RepoId/graph" class="cc-link-btn" title="Open interactive dependency graph">
+                        <LucideIcon Name="git-graph" Size="14" />
+                        <span>View Graph</span>
+                    </a>
+                </div>
+            }
         </div>
 
         @if (_repo is not null)
         {
-            <div class="cc-stat-row">
-                <div class="cc-stat" data-testid="detail-file-count">
-                    <span class="cc-stat-value">@_repo.FileCount</span>
-                    <span class="cc-stat-label">Files</span>
-                </div>
-                <div class="cc-stat" data-testid="detail-symbol-count">
-                    <span class="cc-stat-value">@_repo.SymbolCount</span>
-                    <span class="cc-stat-label">Symbols</span>
-                </div>
-                <div class="cc-stat" data-testid="detail-last-indexed">
-                    <span class="cc-stat-value">@FormatAge(_repo.LastIndexed)</span>
-                    <span class="cc-stat-label">Last indexed</span>
-                </div>
-            </div>
-
-            <div class="cc-section-actions">
-                <BbButton Variant="ButtonVariant.Outline" OnClick="ReIndexAsync" Disabled="_reindexing">
-                    @if (_reindexing)
-                    {
-                        <span>Indexing…</span>
-                    }
-                    else
-                    {
-                        <LucideIcon Name="LucideIcons.RefreshCw" Size="14" />
-                        <span>Re-index</span>
-                    }
-                </BbButton>
-            </div>
+            <BbCard>
+                <BbCardContent>
+                    <div class="cc-stat-row">
+                        <div class="cc-stat" data-testid="detail-file-count">
+                            <span class="cc-stat-value">@_repo.FileCount</span>
+                            <span class="cc-stat-label">Files</span>
+                        </div>
+                        <div class="cc-stat" data-testid="detail-symbol-count">
+                            <span class="cc-stat-value">@_repo.SymbolCount</span>
+                            <span class="cc-stat-label">Symbols</span>
+                        </div>
+                        <div class="cc-stat" data-testid="detail-last-indexed">
+                            <span class="cc-stat-value">@FormatAge(_repo.LastIndexed)</span>
+                            <span class="cc-stat-label">Last indexed</span>
+                        </div>
+                    </div>
+                </BbCardContent>
+            </BbCard>
         }
 
-        <div class="cc-section">
-            <h2>Symbol search</h2>
-            <div class="cc-search-bar">
-                <input class="cc-search-input" type="search" placeholder="Search symbols…"
-                       @bind="_query" @bind:event="oninput" @onkeydown="OnSearchKeyDown"
-                       data-testid="symbol-search-input" />
-                <BbButton OnClick="SearchAsync">
-                    <LucideIcon Name="LucideIcons.Search" Size="14" />
-                    <span>Search</span>
-                </BbButton>
-            </div>
+        <BbCard>
+            <BbCardHeader>
+                <BbCardTitle>Symbol search</BbCardTitle>
+            </BbCardHeader>
+            <BbCardContent>
+                <BbInputGroup>
+                    <BbInputGroupAddon>
+                        <LucideIcon Name="search" Size="14" />
+                    </BbInputGroupAddon>
+                    <BbInputGroupInput @bind-Value="_query"
+                                       Placeholder="Search symbols…"
+                                       UpdateTiming="UpdateTiming.Immediate"
+                                       @onkeydown="OnSearchKeyDown"
+                                       AriaLabel="Symbol search"
+                                       data-testid="symbol-search-input" />
+                    <BbInputGroupAddon Align="InputGroupAlign.InlineEnd">
+                        <BbInputGroupButton OnClick="SearchAsync"
+                                            Disabled="_searching || string.IsNullOrWhiteSpace(_query)"
+                                            AriaLabel="Search">
+                            <LucideIcon Name="search" Size="14" />
+                            Search
+                        </BbInputGroupButton>
+                    </BbInputGroupAddon>
+                </BbInputGroup>
 
-            @if (_searching)
-            {
-                <div class="cc-loading" data-testid="search-loading">Searching…</div>
-            }
-            else if (_searchResults is not null)
-            {
-                @if (_searchResults.Count == 0)
-                {
-                    <p class="cc-empty-inline" data-testid="search-empty">No symbols found.</p>
-                }
-                else
-                {
-                    <div class="cc-symbol-list">
-                        @foreach (var r in _searchResults)
-                        {
-                            <div class="cc-symbol-row" data-testid="symbol-result">
-                                <BbBadge class="cc-kind-badge">@r.Symbol.Kind</BbBadge>
+                <BbDataGrid TData="SymbolSearchResult"
+                            Items="_searchResults ?? []"
+                            IsLoading="_searching"
+                            ShowPagination="false"
+                            Class="mt-4"
+                            AriaLabel="Symbol search results">
+                    <Columns>
+                        <BbDataGridTemplateColumn Title="Kind" Width="72px">
+                            <ChildContent Context="r">
+                                <BbBadge Variant="BadgeVariant.Outline" Class="@($"cc-kind-badge cc-kind-badge--{KindCss(r.Symbol.Kind)}")">@KindAbbr(r.Symbol.Kind)</BbBadge>
+                            </ChildContent>
+                        </BbDataGridTemplateColumn>
+                        <BbDataGridTemplateColumn Title="Symbol" Sortable="true" SortBy="@(r => (object)r.Symbol.Name)">
+                            <ChildContent Context="r">
                                 <span class="cc-symbol-name" data-testid="symbol-name">@r.Symbol.Name</span>
+                            </ChildContent>
+                        </BbDataGridTemplateColumn>
+                        <BbDataGridTemplateColumn Title="Signature">
+                            <ChildContent Context="r">
                                 <span class="cc-symbol-sig" title="@r.Symbol.Signature">@TruncateSig(r.Symbol.Signature)</span>
-                                <span class="cc-symbol-path" title="@r.FilePath">@Path.GetFileName(r.FilePath)</span>
+                            </ChildContent>
+                        </BbDataGridTemplateColumn>
+                        <BbDataGridTemplateColumn Title="File" Sortable="true" SortBy="@(r => (object)Path.GetFileName(r.FilePath))">
+                            <ChildContent Context="r">
+                                <span class="cc-table-path" title="@r.FilePath">@Path.GetFileName(r.FilePath)</span>
+                            </ChildContent>
+                        </BbDataGridTemplateColumn>
+                    </Columns>
+                    <EmptyTemplate>
+                        @if (_searchResults is null)
+                        {
+                            <BbEmpty Title="Search for symbols"
+                                     Description="Enter a name above to search symbols in this repository."
+                                     Size="EmptySize.Small" />
+                        }
+                        else
+                        {
+                            <BbEmpty Title="No symbols found"
+                                     Description="Try a different search term."
+                                     Size="EmptySize.Small" />
+                        }
+                    </EmptyTemplate>
+                </BbDataGrid>
+            </BbCardContent>
+        </BbCard>
+
+        @if (_snapshots is { Count: > 0 })
+        {
+            <BbCard>
+                <BbCardHeader>
+                    <BbCardTitle>Snapshots</BbCardTitle>
+                </BbCardHeader>
+                <BbCardContent>
+                    <div class="cc-snapshot-list">
+                        @foreach (var snap in _snapshots)
+                        {
+                            <div class="cc-snapshot-row" data-testid="snapshot-row">
+                                <span class="cc-snapshot-label" data-testid="snapshot-label">@snap.SnapshotLabel</span>
+                                <span class="cc-snapshot-date">@DateTimeOffset.FromUnixTimeSeconds(snap.CreatedAt).ToString("g")</span>
                             </div>
                         }
                     </div>
-                }
-            }
-        </div>
-
-        @if (_snapshots is not null && _snapshots.Count > 0)
-        {
-            <div class="cc-section">
-                <h2>Snapshots</h2>
-                <div class="cc-snapshot-list">
-                    @foreach (var snap in _snapshots)
-                    {
-                        <div class="cc-snapshot-row" data-testid="snapshot-row">
-                            <span class="cc-snapshot-label" data-testid="snapshot-label">@snap.SnapshotLabel</span>
-                            <span class="cc-snapshot-date">@DateTimeOffset.FromUnixTimeSeconds(snap.CreatedAt).ToString("g")</span>
-                        </div>
-                    }
-                </div>
-            </div>
+                </BbCardContent>
+            </BbCard>
         }
     </div>
 }
@@ -117,9 +176,9 @@ else
 
     private string? _projectRoot;
     private string? _repoName;
-    private CodeCompress.Core.Registry.RepositoryRecord? _repo;
-    private IReadOnlyList<CodeCompress.Core.Models.IndexSnapshot>? _snapshots;
-    private IReadOnlyList<CodeCompress.Core.Models.SymbolSearchResult>? _searchResults;
+    private RepositoryRecord? _repo;
+    private IReadOnlyList<IndexSnapshot>? _snapshots;
+    private IReadOnlyList<SymbolSearchResult>? _searchResults;
     private string _query = string.Empty;
     private bool _searching;
     private bool _reindexing;
@@ -153,10 +212,7 @@ else
 
     private async Task SearchAsync()
     {
-        if (_projectRoot is null || string.IsNullOrWhiteSpace(_query))
-        {
-            return;
-        }
+        if (_projectRoot is null || string.IsNullOrWhiteSpace(_query)) return;
 
         _searching = true;
         try
@@ -171,18 +227,12 @@ else
 
     private async Task OnSearchKeyDown(KeyboardEventArgs e)
     {
-        if (e.Key == "Enter")
-        {
-            await SearchAsync();
-        }
+        if (e.Key == "Enter") await SearchAsync();
     }
 
     private async Task ReIndexAsync()
     {
-        if (_projectRoot is null)
-        {
-            return;
-        }
+        if (_projectRoot is null) return;
 
         _reindexing = true;
         try
@@ -196,6 +246,28 @@ else
             _reindexing = false;
         }
     }
+
+    private static string KindCss(string kind) => kind.ToLowerInvariant() switch
+    {
+        "function" or "method" => "fn",
+        "class"                => "cls",
+        "interface"            => "ifc",
+        "enum"                 => "enm",
+        "variable"             => "var",
+        "property"             => "prop",
+        _                      => "fn",
+    };
+
+    private static string KindAbbr(string kind) => kind.ToLowerInvariant() switch
+    {
+        "function" or "method" => "fn",
+        "class"                => "cls",
+        "interface"            => "ifc",
+        "enum"                 => "enm",
+        "variable"             => "var",
+        "property"             => "prop",
+        _                      => kind[..Math.Min(3, kind.Length)],
+    };
 
     private static string FormatAge(DateTimeOffset dt)
     {

--- a/src/CodeCompress.Web/Components/Pages/RepoDetail.razor
+++ b/src/CodeCompress.Web/Components/Pages/RepoDetail.razor
@@ -1,0 +1,215 @@
+@page "/repo/{RepoId}"
+@rendermode InteractiveServer
+@inject IIndexFacade Facade
+@inject NavigationManager Nav
+
+<PageTitle>@(_repoName ?? "Repository") — CodeCompress</PageTitle>
+
+@if (_pathError)
+{
+    <div class="cc-page">
+        <div class="cc-error" data-testid="path-error">
+            <h2>Invalid path</h2>
+            <p>The repository path is invalid or outside an allowed root.</p>
+        </div>
+    </div>
+}
+else
+{
+    <div class="cc-page">
+        <div class="cc-page-header">
+            <a href="/" class="cc-breadcrumb">Dashboard</a>
+            <span class="cc-breadcrumb-sep">/</span>
+            <h1 data-testid="repo-detail-name">@(_repoName ?? RepoId)</h1>
+        </div>
+
+        @if (_repo is not null)
+        {
+            <div class="cc-stat-row">
+                <div class="cc-stat" data-testid="detail-file-count">
+                    <span class="cc-stat-value">@_repo.FileCount</span>
+                    <span class="cc-stat-label">Files</span>
+                </div>
+                <div class="cc-stat" data-testid="detail-symbol-count">
+                    <span class="cc-stat-value">@_repo.SymbolCount</span>
+                    <span class="cc-stat-label">Symbols</span>
+                </div>
+                <div class="cc-stat" data-testid="detail-last-indexed">
+                    <span class="cc-stat-value">@FormatAge(_repo.LastIndexed)</span>
+                    <span class="cc-stat-label">Last indexed</span>
+                </div>
+            </div>
+
+            <div class="cc-section-actions">
+                <BbButton Variant="ButtonVariant.Outline" OnClick="ReIndexAsync" Disabled="_reindexing">
+                    @if (_reindexing)
+                    {
+                        <span>Indexing…</span>
+                    }
+                    else
+                    {
+                        <LucideIcon Name="LucideIcons.RefreshCw" Size="14" />
+                        <span>Re-index</span>
+                    }
+                </BbButton>
+            </div>
+        }
+
+        <div class="cc-section">
+            <h2>Symbol search</h2>
+            <div class="cc-search-bar">
+                <input class="cc-search-input" type="search" placeholder="Search symbols…"
+                       @bind="_query" @bind:event="oninput" @onkeydown="OnSearchKeyDown"
+                       data-testid="symbol-search-input" />
+                <BbButton OnClick="SearchAsync">
+                    <LucideIcon Name="LucideIcons.Search" Size="14" />
+                    <span>Search</span>
+                </BbButton>
+            </div>
+
+            @if (_searching)
+            {
+                <div class="cc-loading" data-testid="search-loading">Searching…</div>
+            }
+            else if (_searchResults is not null)
+            {
+                @if (_searchResults.Count == 0)
+                {
+                    <p class="cc-empty-inline" data-testid="search-empty">No symbols found.</p>
+                }
+                else
+                {
+                    <div class="cc-symbol-list">
+                        @foreach (var r in _searchResults)
+                        {
+                            <div class="cc-symbol-row" data-testid="symbol-result">
+                                <BbBadge class="cc-kind-badge">@r.Symbol.Kind</BbBadge>
+                                <span class="cc-symbol-name" data-testid="symbol-name">@r.Symbol.Name</span>
+                                <span class="cc-symbol-sig" title="@r.Symbol.Signature">@TruncateSig(r.Symbol.Signature)</span>
+                                <span class="cc-symbol-path" title="@r.FilePath">@Path.GetFileName(r.FilePath)</span>
+                            </div>
+                        }
+                    </div>
+                }
+            }
+        </div>
+
+        @if (_snapshots is not null && _snapshots.Count > 0)
+        {
+            <div class="cc-section">
+                <h2>Snapshots</h2>
+                <div class="cc-snapshot-list">
+                    @foreach (var snap in _snapshots)
+                    {
+                        <div class="cc-snapshot-row" data-testid="snapshot-row">
+                            <span class="cc-snapshot-label" data-testid="snapshot-label">@snap.SnapshotLabel</span>
+                            <span class="cc-snapshot-date">@DateTimeOffset.FromUnixTimeSeconds(snap.CreatedAt).ToString("g")</span>
+                        </div>
+                    }
+                </div>
+            </div>
+        }
+    </div>
+}
+
+@code {
+    [Parameter] public string RepoId { get; set; } = string.Empty;
+
+    private string? _projectRoot;
+    private string? _repoName;
+    private CodeCompress.Core.Registry.RepositoryRecord? _repo;
+    private IReadOnlyList<CodeCompress.Core.Models.IndexSnapshot>? _snapshots;
+    private IReadOnlyList<CodeCompress.Core.Models.SymbolSearchResult>? _searchResults;
+    private string _query = string.Empty;
+    private bool _searching;
+    private bool _reindexing;
+    private bool _pathError;
+
+    protected override async Task OnParametersSetAsync()
+    {
+        _pathError = false;
+        _projectRoot = null;
+
+        var repos = await Facade.GetRepositoriesAsync();
+        _repo = repos.FirstOrDefault(r => string.Equals(r.RepoId, RepoId, StringComparison.Ordinal));
+        if (_repo is null)
+        {
+            _pathError = true;
+            return;
+        }
+
+        _projectRoot = _repo.ProjectRoot;
+        _repoName = _repo.DisplayName;
+
+        try
+        {
+            _snapshots = await Facade.GetSnapshotsAsync(_projectRoot);
+        }
+        catch (ArgumentException)
+        {
+            _snapshots = [];
+        }
+    }
+
+    private async Task SearchAsync()
+    {
+        if (_projectRoot is null || string.IsNullOrWhiteSpace(_query))
+        {
+            return;
+        }
+
+        _searching = true;
+        try
+        {
+            _searchResults = await Facade.SearchSymbolsAsync(_projectRoot, _query, null, 50);
+        }
+        finally
+        {
+            _searching = false;
+        }
+    }
+
+    private async Task OnSearchKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Enter")
+        {
+            await SearchAsync();
+        }
+    }
+
+    private async Task ReIndexAsync()
+    {
+        if (_projectRoot is null)
+        {
+            return;
+        }
+
+        _reindexing = true;
+        try
+        {
+            await Facade.ReIndexAsync(_projectRoot);
+            var repos = await Facade.GetRepositoriesAsync();
+            _repo = repos.FirstOrDefault(r => string.Equals(r.ProjectRoot, _projectRoot, StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            _reindexing = false;
+        }
+    }
+
+    private static string FormatAge(DateTimeOffset dt)
+    {
+        var age = DateTimeOffset.UtcNow - dt;
+        return age switch
+        {
+            { TotalSeconds: < 60 } => "just now",
+            { TotalMinutes: < 60 } a => $"{(int)a.TotalMinutes}m ago",
+            { TotalHours: < 24 } a => $"{(int)a.TotalHours}h ago",
+            { TotalDays: < 2 } => "yesterday",
+            var a => $"{(int)a.TotalDays}d ago",
+        };
+    }
+
+    private static string TruncateSig(string sig) =>
+        sig.Length > 80 ? sig[..80] + "…" : sig;
+}

--- a/src/CodeCompress.Web/Components/Pages/Repositories.razor
+++ b/src/CodeCompress.Web/Components/Pages/Repositories.razor
@@ -1,0 +1,125 @@
+@page "/repositories"
+@rendermode InteractiveServer
+@inject IIndexFacade Facade
+
+<PageTitle>Repositories — CodeCompress</PageTitle>
+
+<div class="cc-page">
+    <div class="cc-page-header">
+        <div class="cc-page-header-left">
+            <h1>Repositories</h1>
+            <p class="cc-page-subtitle">All indexed repositories</p>
+        </div>
+    </div>
+
+    <BbDataGrid TData="RepositoryRecord"
+                Items="_repos"
+                IsLoading="_loading"
+                ShowPagination="false"
+                ShowSearch="true"
+                SearchPlaceholder="Filter repositories…"
+                AriaLabel="All indexed repositories"
+                ItemKey="@(r => r.RepoId)">
+        <Columns>
+            <BbDataGridTemplateColumn Title="Name" Sortable="true" SortBy="@(r => (object)r.DisplayName)"
+                                      Filterable="true" FilterBy="@(r => (object)r.DisplayName)">
+                <ChildContent Context="repo">
+                    <a href="/repo/@repo.RepoId" class="cc-table-name" data-testid="repo-name">@repo.DisplayName</a>
+                </ChildContent>
+            </BbDataGridTemplateColumn>
+            <BbDataGridPropertyColumn Property="@(r => r.ProjectRoot)" Title="Path" NoWrap="true" Filterable="true" />
+            <BbDataGridPropertyColumn Property="@(r => r.FileCount)" Title="Files" Sortable="true"
+                                      CellClass="cc-col-right" HeaderClass="cc-col-right" />
+            <BbDataGridPropertyColumn Property="@(r => r.SymbolCount)" Title="Symbols" Sortable="true"
+                                      CellClass="cc-col-right" HeaderClass="cc-col-right" />
+            <BbDataGridTemplateColumn Title="Status">
+                <ChildContent Context="repo">
+                    @{ var status = GetStatus(repo, _reindexing.Contains(repo.ProjectRoot)); }
+                    <span class="cc-badge cc-badge--@status" data-testid="repo-status">
+                        <span class="cc-badge-dot"></span>
+                        @status
+                    </span>
+                </ChildContent>
+            </BbDataGridTemplateColumn>
+            <BbDataGridTemplateColumn Title="Last Indexed" Sortable="true" SortBy="@(r => (object)r.LastIndexed)">
+                <ChildContent Context="repo">
+                    <span data-testid="last-indexed">@FormatAge(repo.LastIndexed)</span>
+                </ChildContent>
+            </BbDataGridTemplateColumn>
+            <BbDataGridTemplateColumn Title="Actions" Width="120px">
+                <ChildContent Context="repo">
+                    <div class="cc-table-actions">
+                        <button class="cc-icon-btn"
+                                title="Re-index"
+                                disabled="@_reindexing.Contains(repo.ProjectRoot)"
+                                @onclick="() => ReIndexAsync(repo.ProjectRoot)"
+                                data-testid="reindex-btn">
+                            <LucideIcon Name="refresh-cw" Size="14" />
+                        </button>
+                        <a href="/repo/@repo.RepoId/graph" class="cc-icon-btn" title="View Graph" data-testid="view-graph-btn">
+                            <LucideIcon Name="git-graph" Size="14" />
+                        </a>
+                        <a href="/repo/@repo.RepoId" class="cc-icon-btn" title="View Details" data-testid="details-btn">
+                            <LucideIcon Name="arrow-right" Size="14" />
+                        </a>
+                    </div>
+                </ChildContent>
+            </BbDataGridTemplateColumn>
+        </Columns>
+        <EmptyTemplate>
+            <BbEmpty Title="No repositories indexed yet"
+                     Description="Run codecompress index --path &lt;path&gt; to add a repository to the index."
+                     Size="EmptySize.Default">
+                <Icon><LucideIcon Name="folder-git-2" Size="40" /></Icon>
+            </BbEmpty>
+        </EmptyTemplate>
+    </BbDataGrid>
+</div>
+
+@code {
+    private IReadOnlyList<RepositoryRecord> _repos = [];
+    private bool _loading = true;
+    private readonly HashSet<string> _reindexing = [];
+
+    protected override async Task OnInitializedAsync()
+    {
+        _repos = await Facade.GetRepositoriesAsync();
+        _loading = false;
+    }
+
+    private async Task ReIndexAsync(string projectRoot)
+    {
+        _reindexing.Add(projectRoot);
+        try
+        {
+            await Facade.ReIndexAsync(projectRoot);
+            _repos = await Facade.GetRepositoriesAsync();
+        }
+        finally
+        {
+            _reindexing.Remove(projectRoot);
+        }
+    }
+
+    private static string GetStatus(RepositoryRecord repo, bool indexing)
+    {
+        if (indexing) return "indexing";
+        if (repo.LastError is not null) return "error";
+        var age = DateTimeOffset.UtcNow - repo.LastIndexed;
+        if (age.TotalDays > 7) return "stale";
+        return "indexed";
+    }
+
+    private static string FormatAge(DateTimeOffset dt)
+    {
+        var age = DateTimeOffset.UtcNow - dt;
+        return age switch
+        {
+            { TotalSeconds: < 60 } => "just now",
+            { TotalMinutes: < 60 } a => $"{(int)a.TotalMinutes}m ago",
+            { TotalHours: < 24 } a => $"{(int)a.TotalHours}h ago",
+            { TotalDays: < 2 } => "yesterday",
+            var a => $"{(int)a.TotalDays}d ago",
+        };
+    }
+}

--- a/src/CodeCompress.Web/Components/Pages/Symbols.razor
+++ b/src/CodeCompress.Web/Components/Pages/Symbols.razor
@@ -1,0 +1,151 @@
+@page "/symbols"
+@rendermode InteractiveServer
+@inject IIndexFacade Facade
+
+<PageTitle>Symbols — CodeCompress</PageTitle>
+
+<div class="cc-page">
+    <div class="cc-page-header">
+        <div class="cc-page-header-left">
+            <h1>Symbols</h1>
+            <p class="cc-page-subtitle">Global symbol search across all indexed repositories</p>
+        </div>
+    </div>
+
+    <BbCard>
+        <BbCardContent>
+            <BbInputGroup>
+                <BbInputGroupAddon>
+                    <LucideIcon Name="search" Size="14" />
+                </BbInputGroupAddon>
+                <BbInputGroupInput @bind-Value="_query"
+                                   Placeholder="Search symbols…"
+                                   UpdateTiming="UpdateTiming.Immediate"
+                                   @onkeydown="OnKeyDown"
+                                   AriaLabel="Symbol search"
+                                   data-testid="symbol-search-input" />
+                <BbInputGroupAddon Align="InputGroupAlign.InlineEnd">
+                    <BbInputGroupButton OnClick="SearchAsync"
+                                        Disabled="_searching || string.IsNullOrWhiteSpace(_query)"
+                                        AriaLabel="Search">
+                        <LucideIcon Name="search" Size="14" />
+                        Search
+                    </BbInputGroupButton>
+                </BbInputGroupAddon>
+            </BbInputGroup>
+        </BbCardContent>
+    </BbCard>
+
+    <BbDataGrid TData="SymbolSearchResult"
+                Items="_results ?? []"
+                IsLoading="_searching"
+                InitialPageSize="25"
+                AriaLabel="Symbol search results">
+        <Columns>
+            <BbDataGridTemplateColumn Title="Symbol" Sortable="true" SortBy="@(r => (object)r.Symbol.Name)">
+                <ChildContent Context="r">
+                    <span class="cc-symbol-name" data-testid="symbol-name">@r.Symbol.Name</span>
+                </ChildContent>
+            </BbDataGridTemplateColumn>
+            <BbDataGridTemplateColumn Title="Kind" Width="72px">
+                <ChildContent Context="r">
+                    <BbBadge Variant="BadgeVariant.Outline" Class="@($"cc-kind-badge cc-kind-badge--{KindCss(r.Symbol.Kind)}")">@KindAbbr(r.Symbol.Kind)</BbBadge>
+                </ChildContent>
+            </BbDataGridTemplateColumn>
+            <BbDataGridTemplateColumn Title="File" Sortable="true" SortBy="@(r => (object)System.IO.Path.GetFileName(r.FilePath))">
+                <ChildContent Context="r">
+                    <span class="cc-table-path" title="@r.FilePath">@System.IO.Path.GetFileName(r.FilePath)</span>
+                </ChildContent>
+            </BbDataGridTemplateColumn>
+            <BbDataGridPropertyColumn Property="@(r => r.Symbol.LineStart)" Title="Line" Sortable="true"
+                                      CellClass="cc-col-right" HeaderClass="cc-col-right" Width="70px" />
+            <BbDataGridTemplateColumn Title="Signature">
+                <ChildContent Context="r">
+                    <span class="cc-symbol-sig" title="@r.Symbol.Signature">@Truncate(r.Symbol.Signature, 60)</span>
+                </ChildContent>
+            </BbDataGridTemplateColumn>
+        </Columns>
+        <EmptyTemplate>
+            @if (_results is null)
+            {
+                <BbEmpty Title="Search for symbols"
+                         Description="Enter a symbol name above to search across all indexed repositories."
+                         Size="EmptySize.Default">
+                    <Icon><LucideIcon Name="braces" Size="40" /></Icon>
+                </BbEmpty>
+            }
+            else
+            {
+                <BbEmpty Title="No symbols found"
+                         Description="@($"No results for \"{_query}\".")"
+                         Size="EmptySize.Default">
+                    <Icon><LucideIcon Name="search-x" Size="40" /></Icon>
+                </BbEmpty>
+            }
+        </EmptyTemplate>
+    </BbDataGrid>
+</div>
+
+@code {
+    private string _query = string.Empty;
+    private bool _searching;
+    private IReadOnlyList<SymbolSearchResult>? _results;
+    private IReadOnlyList<RepositoryRecord> _repos = [];
+
+    protected override async Task OnInitializedAsync()
+    {
+        _repos = await Facade.GetRepositoriesAsync();
+    }
+
+    private async Task SearchAsync()
+    {
+        if (string.IsNullOrWhiteSpace(_query)) return;
+
+        _searching = true;
+        _results = null;
+        try
+        {
+            var allResults = new List<SymbolSearchResult>();
+            foreach (var repo in _repos)
+            {
+                var results = await Facade.SearchSymbolsAsync(repo.ProjectRoot, _query, null, 50);
+                allResults.AddRange(results);
+            }
+            _results = allResults;
+        }
+        finally
+        {
+            _searching = false;
+        }
+    }
+
+    private async Task OnKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Enter") await SearchAsync();
+    }
+
+    private static string KindCss(string kind) => kind.ToLowerInvariant() switch
+    {
+        "function" or "method" => "fn",
+        "class"                => "cls",
+        "interface"            => "ifc",
+        "enum"                 => "enm",
+        "variable"             => "var",
+        "property"             => "prop",
+        _                      => "fn",
+    };
+
+    private static string KindAbbr(string kind) => kind.ToLowerInvariant() switch
+    {
+        "function" or "method" => "fn",
+        "class"                => "cls",
+        "interface"            => "ifc",
+        "enum"                 => "enm",
+        "variable"             => "var",
+        "property"             => "prop",
+        _                      => kind[..Math.Min(3, kind.Length)],
+    };
+
+    private static string Truncate(string s, int max) =>
+        s.Length > max ? s[..max] + "…" : s;
+}

--- a/src/CodeCompress.Web/Components/Routes.razor
+++ b/src/CodeCompress.Web/Components/Routes.razor
@@ -1,0 +1,12 @@
+<Router AppAssembly="typeof(Routes).Assembly">
+    <Found Context="routeData">
+        <RouteView RouteData="routeData" DefaultLayout="typeof(Layout.MainLayout)" />
+        <FocusOnNavigate RouteData="routeData" Selector="h1" />
+    </Found>
+    <NotFound>
+        <PageTitle>Not found</PageTitle>
+        <LayoutView Layout="typeof(Layout.MainLayout)">
+            <p role="alert">Sorry, there's nothing at this address.</p>
+        </LayoutView>
+    </NotFound>
+</Router>

--- a/src/CodeCompress.Web/Components/_Imports.razor
+++ b/src/CodeCompress.Web/Components/_Imports.razor
@@ -9,7 +9,11 @@
 @using BlazorBlueprint.Primitives
 @using BlazorBlueprint.Primitives.Services
 @using BlazorBlueprint.Icons.Lucide
+@using BlazorBlueprint.Icons.Lucide.Components
+@using Microsoft.JSInterop
 @using CodeCompress.Core.Validation
 @using CodeCompress.Web.Components
 @using CodeCompress.Web.Components.Layout
 @using CodeCompress.Web.Services
+@using CodeCompress.Core.Registry
+@using CodeCompress.Core.Models

--- a/src/CodeCompress.Web/Components/_Imports.razor
+++ b/src/CodeCompress.Web/Components/_Imports.razor
@@ -1,0 +1,15 @@
+@using System.Net.Http
+@using System.Net.Http.Json
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using static Microsoft.AspNetCore.Components.Web.RenderMode
+@using Microsoft.AspNetCore.Components.Web.Virtualization
+@using BlazorBlueprint.Components
+@using BlazorBlueprint.Primitives
+@using BlazorBlueprint.Primitives.Services
+@using BlazorBlueprint.Icons.Lucide
+@using CodeCompress.Core.Validation
+@using CodeCompress.Web.Components
+@using CodeCompress.Web.Components.Layout
+@using CodeCompress.Web.Services

--- a/src/CodeCompress.Web/Program.cs
+++ b/src/CodeCompress.Web/Program.cs
@@ -1,0 +1,7 @@
+using CodeCompress.Web;
+
+var port = int.TryParse(Environment.GetEnvironmentVariable("ASPNETCORE_PORT"), out var p) ? p : 7070;
+var bind = Environment.GetEnvironmentVariable("ASPNETCORE_BIND") ?? "localhost";
+
+var app = WebHostFactory.Build(port, bind);
+await app.RunAsync().ConfigureAwait(false);

--- a/src/CodeCompress.Web/Services/IIndexFacade.cs
+++ b/src/CodeCompress.Web/Services/IIndexFacade.cs
@@ -1,0 +1,14 @@
+using CodeCompress.Core.Indexing;
+using CodeCompress.Core.Models;
+using CodeCompress.Core.Registry;
+
+namespace CodeCompress.Web.Services;
+
+public interface IIndexFacade
+{
+    public Task<IReadOnlyList<RepositoryRecord>> GetRepositoriesAsync(CancellationToken ct = default);
+    public Task<IndexResult> ReIndexAsync(string projectRoot, CancellationToken ct = default);
+    public Task<IReadOnlyList<SymbolSearchResult>> SearchSymbolsAsync(string projectRoot, string query, string? kind, int limit, CancellationToken ct = default);
+    public Task<IReadOnlyList<IndexSnapshot>> GetSnapshotsAsync(string projectRoot, CancellationToken ct = default);
+    public Task<IReadOnlyList<FileRecord>> GetFilesAsync(string projectRoot, CancellationToken ct = default);
+}

--- a/src/CodeCompress.Web/Services/IndexFacade.cs
+++ b/src/CodeCompress.Web/Services/IndexFacade.cs
@@ -1,0 +1,117 @@
+using CodeCompress.Core.Indexing;
+using CodeCompress.Core.Models;
+using CodeCompress.Core.Parsers;
+using CodeCompress.Core.Registry;
+using CodeCompress.Core.Storage;
+using CodeCompress.Core.Validation;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
+
+namespace CodeCompress.Web.Services;
+
+public sealed class IndexFacade : IIndexFacade
+{
+    private readonly IRegistryService _registry;
+    private readonly IConnectionFactory _connectionFactory;
+    private readonly IFileHasher _fileHasher;
+    private readonly IChangeTracker _changeTracker;
+    private readonly IEnumerable<ILanguageParser> _parsers;
+    private readonly IPathValidator _pathValidator;
+    private readonly IGitIgnoreFilter _gitIgnoreFilter;
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly ISymbolStore? _storeOverride;
+
+    public IndexFacade(
+        IRegistryService registry,
+        IConnectionFactory connectionFactory,
+        IFileHasher fileHasher,
+        IChangeTracker changeTracker,
+        IEnumerable<ILanguageParser> parsers,
+        IPathValidator pathValidator,
+        IGitIgnoreFilter gitIgnoreFilter,
+        ILoggerFactory loggerFactory,
+        ISymbolStore? storeOverride = null)
+    {
+        ArgumentNullException.ThrowIfNull(registry);
+        ArgumentNullException.ThrowIfNull(connectionFactory);
+        ArgumentNullException.ThrowIfNull(fileHasher);
+        ArgumentNullException.ThrowIfNull(changeTracker);
+        ArgumentNullException.ThrowIfNull(parsers);
+        ArgumentNullException.ThrowIfNull(pathValidator);
+        ArgumentNullException.ThrowIfNull(gitIgnoreFilter);
+        ArgumentNullException.ThrowIfNull(loggerFactory);
+
+        _registry = registry;
+        _connectionFactory = connectionFactory;
+        _fileHasher = fileHasher;
+        _changeTracker = changeTracker;
+        _parsers = parsers;
+        _pathValidator = pathValidator;
+        _gitIgnoreFilter = gitIgnoreFilter;
+        _loggerFactory = loggerFactory;
+        _storeOverride = storeOverride;
+    }
+
+    public Task<IReadOnlyList<RepositoryRecord>> GetRepositoriesAsync(CancellationToken ct = default)
+        => _registry.ListAsync();
+
+    public async Task<IndexResult> ReIndexAsync(string projectRoot, CancellationToken ct = default)
+    {
+        var validatedPath = _pathValidator.ValidatePath(projectRoot, projectRoot);
+        var connection = await _connectionFactory.CreateConnectionAsync(validatedPath).ConfigureAwait(false);
+        await using (connection.ConfigureAwait(false))
+        {
+            var store = new SqliteSymbolStore(connection);
+            var engine = new IndexEngine(
+                _fileHasher,
+                _changeTracker,
+                _parsers,
+                store,
+                _pathValidator,
+                _gitIgnoreFilter,
+                _loggerFactory.CreateLogger<IndexEngine>());
+            return await engine.IndexProjectAsync(validatedPath, cancellationToken: ct).ConfigureAwait(false);
+        }
+    }
+
+    public async Task<IReadOnlyList<SymbolSearchResult>> SearchSymbolsAsync(
+        string projectRoot, string query, string? kind, int limit, CancellationToken ct = default)
+    {
+        var validatedPath = _pathValidator.ValidatePath(projectRoot, projectRoot);
+        return await WithStoreAsync(validatedPath, async (store, repoId) =>
+            await store.SearchSymbolsAsync(repoId, query, kind, limit).ConfigureAwait(false)).ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<IndexSnapshot>> GetSnapshotsAsync(string projectRoot, CancellationToken ct = default)
+    {
+        var validatedPath = _pathValidator.ValidatePath(projectRoot, projectRoot);
+        return await WithStoreAsync(validatedPath, async (store, repoId) =>
+            await store.GetSnapshotsByRepoAsync(repoId).ConfigureAwait(false)).ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<FileRecord>> GetFilesAsync(string projectRoot, CancellationToken ct = default)
+    {
+        var validatedPath = _pathValidator.ValidatePath(projectRoot, projectRoot);
+        return await WithStoreAsync(validatedPath, async (store, repoId) =>
+            await store.GetFilesByRepoAsync(repoId).ConfigureAwait(false)).ConfigureAwait(false);
+    }
+
+    private async Task<TResult> WithStoreAsync<TResult>(
+        string projectRoot,
+        Func<ISymbolStore, string, Task<TResult>> operation)
+    {
+        if (_storeOverride is not null)
+        {
+            var repoId = IndexEngine.ComputeRepoId(projectRoot);
+            return await operation(_storeOverride, repoId).ConfigureAwait(false);
+        }
+
+        SqliteConnection connection = await _connectionFactory.CreateConnectionAsync(projectRoot).ConfigureAwait(false);
+        await using (connection.ConfigureAwait(false))
+        {
+            var store = new SqliteSymbolStore(connection);
+            var repoId = IndexEngine.ComputeRepoId(projectRoot);
+            return await operation(store, repoId).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/CodeCompress.Web/WebHostFactory.cs
+++ b/src/CodeCompress.Web/WebHostFactory.cs
@@ -1,0 +1,34 @@
+using BlazorBlueprint.Components;
+using CodeCompress.Core;
+using CodeCompress.Web.Components;
+using CodeCompress.Web.Services;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CodeCompress.Web;
+
+public static class WebHostFactory
+{
+    public static WebApplication Build(int port, string bindAddress)
+    {
+        var builder = WebApplication.CreateBuilder();
+
+        builder.Services.AddRazorComponents()
+            .AddInteractiveServerComponents();
+
+        builder.Services.AddBlazorBlueprintComponents();
+        builder.Services.AddCodeCompressCore();
+        builder.Services.AddScoped<IIndexFacade, IndexFacade>();
+
+        builder.WebHost.UseUrls($"http://{bindAddress}:{port}");
+
+        var app = builder.Build();
+
+        app.UseStaticFiles();
+        app.UseAntiforgery();
+        app.MapRazorComponents<App>()
+            .AddInteractiveServerRenderMode();
+
+        return app;
+    }
+}

--- a/src/CodeCompress.Web/WebHostFactory.cs
+++ b/src/CodeCompress.Web/WebHostFactory.cs
@@ -16,7 +16,12 @@ public static class WebHostFactory
         builder.Services.AddRazorComponents()
             .AddInteractiveServerComponents();
 
-        builder.Services.AddBlazorBlueprintComponents();
+        builder.Services.AddBlazorBlueprintComponents(configureTheme: options =>
+        {
+            options.DefaultDarkMode = true;
+            options.DetectSystemPreference = false;
+            options.PersistToLocalStorage = true;
+        });
         builder.Services.AddCodeCompressCore();
         builder.Services.AddScoped<IIndexFacade, IndexFacade>();
 

--- a/src/CodeCompress.Web/_Imports.razor
+++ b/src/CodeCompress.Web/_Imports.razor
@@ -1,0 +1,16 @@
+@using System.Net.Http
+@using System.Net.Http.Json
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using static Microsoft.AspNetCore.Components.Web.RenderMode
+@using Microsoft.AspNetCore.Components.Web.Virtualization
+@using BlazorBlueprint.Components
+@using BlazorBlueprint.Primitives
+@using BlazorBlueprint.Primitives.Services
+@using BlazorBlueprint.Icons.Lucide
+@using BlazorBlueprint.Icons.Lucide.Components
+@using CodeCompress.Core.Validation
+@using CodeCompress.Web.Components
+@using CodeCompress.Web.Components.Layout
+@using CodeCompress.Web.Services

--- a/src/CodeCompress.Web/wwwroot/app.css
+++ b/src/CodeCompress.Web/wwwroot/app.css
@@ -1,497 +1,1007 @@
-/* ── Catppuccin Macchiato – default dark theme ────────────────
-   Overrides BlazorBlueprint CSS custom properties.
-   Source: https://catppuccin.com/palette (Macchiato variant)
-   ──────────────────────────────────────────────────────────── */
+/* ── Google Fonts loaded in App.razor ───────────────────────── */
 
+/* ── Catppuccin Latte — default light theme ─────────────────── */
+/* BB ThemeService toggles .dark class; Macchiato overrides below */
 :root {
-  /* Catppuccin Macchiato palette */
-  --cc-base:     #24273a;
-  --cc-mantle:   #1e2030;
-  --cc-crust:    #181926;
-  --cc-surface0: #363a4f;
-  --cc-surface1: #494d64;
-  --cc-overlay0: #6e738d;
-  --cc-text:     #cad3f5;
-  --cc-subtext1: #b8c0e0;
-  --cc-subtext0: #a5adcb;
-  --cc-blue:     #8aadf4;
-  --cc-green:    #a6da95;
-  --cc-red:      #ed8796;
-  --cc-yellow:   #eed49f;
-  --cc-mauve:    #c6a0f6;
-  --cc-peach:    #f5a97f;
+    /* Palette — Latte (light) */
+    --ctp-base:      #eff1f5;
+    --ctp-mantle:    #e6e9ef;
+    --ctp-crust:     #dce0e8;
+    --ctp-surface0:  #ccd0da;
+    --ctp-surface1:  #bcc0cc;
+    --ctp-surface2:  #acb0be;
+    --ctp-overlay0:  #9ca0b0;
+    --ctp-overlay1:  #8c8fa1;
+    --ctp-overlay2:  #7c7f93;
+    --ctp-subtext0:  #6c6f85;
+    --ctp-subtext1:  #5c5f77;
+    --ctp-text:      #4c4f69;
+    --ctp-lavender:  #7287fd;
+    --ctp-blue:      #1e66f5;
+    --ctp-sapphire:  #209fb5;
+    --ctp-sky:       #04a5e5;
+    --ctp-teal:      #179299;
+    --ctp-green:     #40a02b;
+    --ctp-yellow:    #df8e1d;
+    --ctp-peach:     #fe640b;
+    --ctp-maroon:    #e64553;
+    --ctp-red:       #d20f39;
+    --ctp-mauve:     #8839ef;
+    --ctp-pink:      #ea76cb;
+    --ctp-flamingo:  #dd7878;
+    --ctp-rosewater: #dc8a78;
 
-  /* BlazorBlueprint token overrides */
-  --background:            var(--cc-base);
-  --foreground:            var(--cc-text);
-  --card:                  var(--cc-mantle);
-  --card-foreground:       var(--cc-text);
-  --popover:               var(--cc-mantle);
-  --popover-foreground:    var(--cc-text);
-  --primary:               var(--cc-blue);
-  --primary-foreground:    var(--cc-crust);
-  --secondary:             var(--cc-surface0);
-  --secondary-foreground:  var(--cc-text);
-  --muted:                 var(--cc-surface0);
-  --muted-foreground:      var(--cc-subtext0);
-  --accent:                var(--cc-surface1);
-  --accent-foreground:     var(--cc-text);
-  --destructive:           var(--cc-red);
-  --destructive-foreground: var(--cc-crust);
-  --border:                var(--cc-surface0);
-  --input:                 var(--cc-surface0);
-  --ring:                  var(--cc-blue);
-  --radius:                0.5rem;
+    /* Semantic tokens — same names work for both themes via var() chains */
+    --bg-page:            var(--ctp-base);
+    --bg-sidebar:         var(--ctp-mantle);
+    --bg-chrome:          var(--ctp-crust);
+    --bg-card:            var(--ctp-surface0);
+    --bg-card-hover:      var(--ctp-surface1);
+    --bg-input:           var(--ctp-mantle);   /* Latte: mantle for inputs */
+    --border-subtle:      var(--ctp-surface1);
+    --border-strong:      var(--ctp-overlay0);
+    --text-primary:       var(--ctp-text);
+    --text-secondary:     var(--ctp-subtext1);
+    --text-muted:         var(--ctp-subtext0);
+    --text-inverse:       var(--ctp-base);
+    --accent-primary:     var(--ctp-lavender);
+    --accent-interactive: var(--ctp-blue);
+    --accent-success:     var(--ctp-teal);
+    --accent-warning:     var(--ctp-yellow);
+    --accent-error:       var(--ctp-red);
+    --accent-info:        var(--ctp-sapphire);
+    --accent-feature:     var(--ctp-mauve);
+    --chart-1:            var(--ctp-lavender);
+    --chart-2:            var(--ctp-teal);
+    --chart-3:            var(--ctp-peach);
+    --chart-4:            var(--ctp-mauve);
+    --chart-5:            var(--ctp-green);
 
-  /* Typography — system fonts (no CDN) */
-  --font-sans: ui-sans-serif, system-ui, -apple-system, sans-serif;
-  --font-mono: ui-monospace, "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+    /* Shadows — light values */
+    --shadow-sm:    0 1px 3px rgba(76, 79, 105, 0.1);
+    --shadow-md:    0 4px 12px rgba(76, 79, 105, 0.15);
+    --shadow-lg:    0 8px 24px rgba(76, 79, 105, 0.18);
+    --shadow-xl:    0 16px 48px rgba(76, 79, 105, 0.22);
+    --glow-accent:  0 0 20px rgba(114, 135, 253, 0.12);
+    --glow-teal:    0 0 20px rgba(23, 146, 153, 0.12);
+
+    /* Typography */
+    --font-heading: "Syne", sans-serif;
+    --font-body:    "DM Mono", monospace;
+    --font-code:    "JetBrains Mono", monospace;
+
+    /* Type scale */
+    --text-xs:   11px;
+    --text-sm:   13px;
+    --text-base: 14px;
+    --text-md:   16px;
+    --text-lg:   20px;
+    --text-xl:   24px;
+    --text-2xl:  32px;
+    --text-3xl:  48px;
+
+    /* Letter spacing */
+    --tracking-tight:  -0.02em;
+    --tracking-normal:  0;
+    --tracking-wide:    0.04em;
+    --tracking-wider:   0.08em;
+
+    /* Spacing */
+    --space-1:  4px;
+    --space-2:  8px;
+    --space-3:  12px;
+    --space-4:  16px;
+    --space-5:  20px;
+    --space-6:  24px;
+    --space-8:  32px;
+    --space-10: 40px;
+    --space-12: 48px;
+    --space-16: 64px;
+    --space-20: 80px;
+
+    /* Border radius */
+    --radius-sm:   4px;
+    --radius-md:   8px;
+    --radius-lg:   12px;
+    --radius-xl:   16px;
+    --radius-full: 9999px;
+
+    /* BlazorBlueprint token overrides */
+    --background:             var(--bg-page);
+    --foreground:             var(--text-primary);
+    --card:                   var(--bg-card);
+    --card-foreground:        var(--text-primary);
+    --popover:                var(--bg-card);
+    --popover-foreground:     var(--text-primary);
+    --primary:                var(--accent-primary);
+    --primary-foreground:     var(--text-inverse);
+    --secondary:              var(--bg-card);
+    --secondary-foreground:   var(--text-primary);
+    --muted:                  var(--bg-card);
+    --muted-foreground:       var(--text-muted);
+    --accent:                 var(--bg-card-hover);
+    --accent-foreground:      var(--text-primary);
+    --destructive:            var(--accent-error);
+    --destructive-foreground: var(--text-inverse);
+    --border:                 var(--border-subtle);
+    --input:                  var(--bg-input);
+    --ring:                   var(--accent-primary);
+    --radius:                 var(--radius-md);
+    --font-sans:              var(--font-body);
+    --font-mono:              var(--font-code);
 }
 
-/* Dark class re-applies same vars (ThemeService dark-mode compat) */
+/* ── Catppuccin Macchiato — dark theme (.dark class by BB ThemeService) ── */
 .dark {
-  --background:            var(--cc-base);
-  --foreground:            var(--cc-text);
-  --card:                  var(--cc-mantle);
-  --card-foreground:       var(--cc-text);
-  --popover:               var(--cc-mantle);
-  --popover-foreground:    var(--cc-text);
-  --primary:               var(--cc-blue);
-  --primary-foreground:    var(--cc-crust);
-  --secondary:             var(--cc-surface0);
-  --secondary-foreground:  var(--cc-text);
-  --muted:                 var(--cc-surface0);
-  --muted-foreground:      var(--cc-subtext0);
-  --accent:                var(--cc-surface1);
-  --accent-foreground:     var(--cc-text);
-  --destructive:           var(--cc-red);
-  --destructive-foreground: var(--cc-crust);
-  --border:                var(--cc-surface0);
-  --input:                 var(--cc-surface0);
-  --ring:                  var(--cc-blue);
+    --ctp-base:      #24273a;
+    --ctp-mantle:    #1e2030;
+    --ctp-crust:     #181926;
+    --ctp-surface0:  #363a4f;
+    --ctp-surface1:  #494d64;
+    --ctp-surface2:  #5b6078;
+    --ctp-overlay0:  #6e738d;
+    --ctp-overlay1:  #8087a2;
+    --ctp-overlay2:  #939ab7;
+    --ctp-subtext0:  #a5adcb;
+    --ctp-subtext1:  #b8c0e0;
+    --ctp-text:      #cad3f5;
+    --ctp-lavender:  #b7bdf8;
+    --ctp-blue:      #8aadf4;
+    --ctp-sapphire:  #7dc4e4;
+    --ctp-sky:       #91d7e3;
+    --ctp-teal:      #8bd5ca;
+    --ctp-green:     #a6da95;
+    --ctp-yellow:    #eed49f;
+    --ctp-peach:     #f5a97f;
+    --ctp-maroon:    #ee99a0;
+    --ctp-red:       #ed8796;
+    --ctp-mauve:     #c6a0f6;
+    --ctp-pink:      #f5bde6;
+    --ctp-flamingo:  #f0c6c6;
+    --ctp-rosewater: #f4dbd6;
+
+    --bg-input:    var(--ctp-surface0);  /* Dark: surface0 for inputs */
+    --border-subtle: var(--ctp-overlay0);
+    --border-strong: var(--ctp-overlay1);
+    --text-muted:  var(--ctp-overlay1);
+    --text-inverse: var(--ctp-crust);
+    --shadow-sm:   0 1px 3px rgba(24, 25, 38, 0.4);
+    --shadow-md:   0 4px 12px rgba(24, 25, 38, 0.5);
+    --shadow-lg:   0 8px 24px rgba(24, 25, 38, 0.6);
+    --shadow-xl:   0 16px 48px rgba(24, 25, 38, 0.7);
+    --glow-accent: 0 0 20px rgba(183, 189, 248, 0.15);
+    --glow-teal:   0 0 20px rgba(139, 213, 202, 0.12);
+
+    /* BB dark overrides */
+    --background:             var(--bg-page);
+    --foreground:             var(--text-primary);
+    --card:                   var(--bg-card);
+    --card-foreground:        var(--text-primary);
+    --popover:                var(--bg-card);
+    --popover-foreground:     var(--text-primary);
+    --primary:                var(--accent-primary);
+    --primary-foreground:     var(--text-inverse);
+    --secondary:              var(--bg-card);
+    --secondary-foreground:   var(--text-primary);
+    --muted:                  var(--bg-card);
+    --muted-foreground:       var(--text-muted);
+    --accent:                 var(--bg-card-hover);
+    --accent-foreground:      var(--text-primary);
+    --destructive:            var(--accent-error);
+    --destructive-foreground: var(--text-inverse);
+    --border:                 var(--border-subtle);
+    --input:                  var(--bg-input);
+    --ring:                   var(--accent-primary);
 }
 
-/* ── Layout shell ─────────────────────────────────────────── */
-
-*, *::before, *::after {
-  box-sizing: border-box;
-}
+/* ── Reset ───────────────────────────────────────────────────── */
+*, *::before, *::after { box-sizing: border-box; }
 
 html, body {
-  margin: 0;
-  height: 100%;
-  background: var(--background);
-  color: var(--foreground);
-  font-family: var(--font-sans);
-  font-size: 14px;
-  line-height: 1.5;
+    margin: 0;
+    height: 100%;
+    background: var(--bg-page);
+    color: var(--text-primary);
+    font-family: var(--font-body);
+    font-size: var(--text-base);
+    line-height: 1.6;
 }
 
+/* ── Shell ───────────────────────────────────────────────────── */
 .cc-shell {
-  display: flex;
-  flex-direction: column;
-  height: 100vh;
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
 }
 
-/* topbar */
+/* ── Topbar ──────────────────────────────────────────────────── */
 .cc-topbar {
-  height: 48px;
-  background: var(--cc-crust);
-  border-bottom: 1px solid var(--border);
-  display: flex;
-  align-items: center;
-  padding: 0 1rem;
-  flex-shrink: 0;
+    height: 48px;
+    background: var(--bg-chrome);
+    border-bottom: 1px solid var(--border-subtle);
+    display: grid;
+    grid-template-columns: 220px 1fr auto;
+    align-items: center;
+    padding: 0 var(--space-4);
+    flex-shrink: 0;
+    gap: var(--space-4);
 }
 
 .cc-brand {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  color: var(--foreground);
-  text-decoration: none;
-  font-weight: 600;
-  font-size: 15px;
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    color: var(--text-primary);
+    text-decoration: none;
+    font-family: var(--font-heading);
+    font-weight: 600;
+    font-size: var(--text-md);
+    white-space: nowrap;
 }
 
 .cc-brand-icon {
-  color: var(--cc-blue);
-  font-size: 18px;
+    color: var(--accent-primary);
+    font-size: 20px;
+    line-height: 1;
 }
 
-/* body = sidebar + content */
+.cc-topbar-center {
+    display: flex;
+    justify-content: center;
+}
+
+.cc-topbar-search {
+    position: relative;
+    width: 320px;
+    display: flex;
+    align-items: center;
+}
+
+.cc-topbar-search-icon {
+    position: absolute;
+    left: var(--space-3);
+    color: var(--text-muted);
+    pointer-events: none;
+    display: flex;
+    align-items: center;
+}
+
+.cc-topbar-search-input {
+    width: 100%;
+    height: 32px;
+    background: var(--bg-card);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-full);
+    padding: 0 var(--space-4) 0 var(--space-8);
+    color: var(--text-primary);
+    font-family: var(--font-body);
+    font-size: var(--text-sm);
+    outline: none;
+    transition: border-color 150ms ease, box-shadow 150ms ease;
+}
+
+.cc-topbar-search-input::placeholder { color: var(--text-muted); }
+
+.cc-topbar-search-input:focus {
+    border-color: var(--accent-primary);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent-primary) 20%, transparent);
+}
+
+.cc-topbar-right {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+}
+
+.cc-theme-toggle {
+    width: 32px;
+    height: 32px;
+    border-radius: var(--radius-full);
+    border: 1px solid var(--border-subtle);
+    background: transparent;
+    color: var(--text-muted);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 150ms ease, color 150ms ease;
+    padding: 0;
+}
+
+.cc-theme-toggle:hover {
+    background: var(--bg-card);
+    color: var(--text-primary);
+}
+
+/* ── Body layout ─────────────────────────────────────────────── */
 .cc-body {
-  display: flex;
-  flex: 1;
-  overflow: hidden;
+    display: flex;
+    flex: 1;
+    overflow: hidden;
 }
 
+/* ── Sidebar ─────────────────────────────────────────────────── */
 .cc-sidebar {
-  width: 220px;
-  background: var(--cc-mantle);
-  border-right: 1px solid var(--border);
-  padding: 0.75rem 0;
-  flex-shrink: 0;
-  overflow-y: auto;
+    width: 220px;
+    background: var(--bg-sidebar);
+    border-right: 1px solid var(--border-subtle);
+    padding: var(--space-3) 0;
+    flex-shrink: 0;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
 }
 
-.cc-content {
-  flex: 1;
-  overflow-y: auto;
-  padding: 1.5rem;
-  max-width: 1400px;
-}
-
-/* ── Navigation ───────────────────────────────────────────── */
-
+/* ── Navigation ──────────────────────────────────────────────── */
 .cc-nav {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  padding: 0 0.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.cc-nav-section-label {
+    font-size: var(--text-xs);
+    font-family: var(--font-body);
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+    color: var(--text-muted);
+    padding: var(--space-4) var(--space-4) var(--space-1);
+    margin: 0;
 }
 
 .cc-nav-item {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem 0.75rem;
-  border-radius: var(--radius);
-  color: var(--cc-subtext1);
-  text-decoration: none;
-  font-size: 13px;
-  transition: background 0.15s, color 0.15s;
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: 0 var(--space-4);
+    height: 36px;
+    border-left: 3px solid transparent;
+    color: var(--text-secondary);
+    text-decoration: none;
+    font-size: var(--text-sm);
+    font-family: var(--font-body);
+    transition: background 150ms ease, color 150ms ease;
 }
 
 .cc-nav-item:hover {
-  background: var(--cc-surface0);
-  color: var(--foreground);
+    background: color-mix(in srgb, var(--bg-card) 60%, transparent);
+    color: var(--text-primary);
 }
 
 .cc-nav-item.active {
-  background: var(--cc-surface0);
-  color: var(--cc-blue);
-  font-weight: 500;
+    background: var(--bg-card);
+    border-left-color: var(--accent-primary);
+    color: var(--text-primary);
 }
 
-/* ── Page ─────────────────────────────────────────────────── */
+/* ── Content area ────────────────────────────────────────────── */
+.cc-content {
+    flex: 1;
+    overflow-y: auto;
+    padding: var(--space-6) var(--space-8);
+    max-width: 1400px;
+}
 
+/* ── Page structure ──────────────────────────────────────────── */
 .cc-page {
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-6);
 }
 
 .cc-page-header {
-  border-bottom: 1px solid var(--border);
-  padding-bottom: 1rem;
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    padding-bottom: var(--space-5);
+    border-bottom: 1px solid var(--border-subtle);
 }
 
+.cc-page-header-left { display: flex; flex-direction: column; gap: 4px; }
+
 .cc-page-header h1 {
-  margin: 0 0 0.25rem;
-  font-size: 20px;
-  font-weight: 600;
+    margin: 0;
+    font-family: var(--font-heading);
+    font-size: var(--text-xl);
+    font-weight: 700;
+    color: var(--text-primary);
+    letter-spacing: var(--tracking-tight);
 }
 
 .cc-page-subtitle {
-  margin: 0;
-  color: var(--cc-subtext0);
-  font-size: 13px;
+    margin: 0;
+    color: var(--text-muted);
+    font-size: var(--text-sm);
 }
 
-/* ── Repo Grid ────────────────────────────────────────────── */
-
-.cc-repo-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
-  gap: 1rem;
+.cc-page-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
 }
 
-.cc-repo-card {
-  background: var(--card);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 1rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
+/* ── Stat cards ──────────────────────────────────────────────── */
+.cc-stats-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: var(--space-4);
 }
 
-.cc-repo-card-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.5rem;
+.cc-stat-card {
+    position: relative;
+    overflow: hidden;
+    transition: transform 200ms ease-out, box-shadow 200ms ease-out;
+    cursor: default;
 }
 
-.cc-repo-name {
-  font-weight: 600;
-  font-size: 15px;
-  color: var(--cc-blue);
-  text-decoration: none;
+.cc-stat-card:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-lg);
 }
 
-.cc-repo-name:hover {
-  text-decoration: underline;
+.cc-stat-card-label {
+    font-family: var(--font-body);
+    font-size: var(--text-xs);
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+    color: var(--text-muted);
+    margin: 0 0 var(--space-2);
 }
 
-.cc-repo-path {
-  margin: 0;
-  font-size: 11px;
-  color: var(--cc-subtext0);
-  font-family: var(--font-mono);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+.cc-stat-card-value {
+    font-family: var(--font-body);
+    font-size: var(--text-3xl);
+    font-weight: 800;
+    color: var(--text-primary);
+    letter-spacing: var(--tracking-tight);
+    line-height: 1.0;
+    margin: 0 0 var(--space-2);
 }
 
-.cc-repo-stats {
-  display: flex;
-  gap: 1rem;
-  font-size: 12px;
-  color: var(--cc-subtext1);
+.cc-stat-card-delta {
+    font-family: var(--font-body);
+    font-size: var(--text-sm);
+    color: var(--text-muted);
+    margin: 0;
 }
 
-.cc-repo-stats b {
-  color: var(--foreground);
+/* Bottom accent strip per card type */
+.cc-stat-card::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
 }
 
-.cc-repo-error {
-  margin: 0;
-  font-size: 12px;
-  color: var(--cc-red);
+.cc-stat-card--repos::after    { background: var(--ctp-lavender); }
+.cc-stat-card--files::after    { background: var(--ctp-teal); }
+.cc-stat-card--symbols::after  { background: var(--ctp-peach); }
+.cc-stat-card--lastrun::after  { background: var(--ctp-blue); }
+
+/* ── Status indicator dot on last-run card ───────────────────── */
+.cc-status-dot {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: var(--radius-full);
+    margin-right: var(--space-1);
+    vertical-align: middle;
 }
 
-.cc-repo-actions {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  margin-top: 0.25rem;
+.cc-status-dot--success { background: var(--accent-success); }
+.cc-status-dot--error   { background: var(--accent-error); }
+.cc-status-dot--warning { background: var(--accent-warning); }
+
+/* ── Utility ─────────────────────────────────────────────────── */
+.cc-col-right { text-align: right; }
+
+/* ── Data table ──────────────────────────────────────────────── */
+.cc-section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: var(--space-3);
 }
 
-/* ── Stat row (repo detail) ───────────────────────────────── */
-
-.cc-stat-row {
-  display: flex;
-  gap: 1.5rem;
+.cc-section-header h2 {
+    margin: 0;
+    font-family: var(--font-heading);
+    font-size: var(--text-lg);
+    font-weight: 600;
+    color: var(--text-primary);
 }
 
-.cc-stat {
-  background: var(--card);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 0.75rem 1.25rem;
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
+.cc-table-container {
+    background: var(--bg-card);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-lg);
+    overflow: hidden;
 }
 
-.cc-stat-value {
-  font-size: 22px;
-  font-weight: 700;
-  color: var(--cc-blue);
+.cc-table {
+    width: 100%;
+    border-collapse: collapse;
 }
 
-.cc-stat-label {
-  font-size: 11px;
-  color: var(--cc-subtext0);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
+.cc-table thead tr {
+    background: var(--bg-chrome);
+    border-bottom: 1px solid var(--border-subtle);
 }
 
-/* ── Section ──────────────────────────────────────────────── */
-
-.cc-section {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
+.cc-table thead th {
+    height: 40px;
+    padding: 0 var(--space-4);
+    font-family: var(--font-body);
+    font-size: var(--text-xs);
+    font-weight: 400;
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+    color: var(--text-muted);
+    text-align: left;
+    white-space: nowrap;
 }
 
-.cc-section h2 {
-  margin: 0;
-  font-size: 15px;
-  font-weight: 600;
+.cc-table th.cc-col-right,
+.cc-table td.cc-col-right { text-align: right; }
+
+.cc-table tbody tr {
+    height: 48px;
+    border-bottom: 1px solid var(--border-subtle);
+    transition: background 100ms linear;
 }
 
-.cc-section-actions {
-  display: flex;
-  gap: 0.5rem;
+.cc-table tbody tr:last-child { border-bottom: none; }
+
+.cc-table tbody tr:hover { background: var(--bg-card-hover); }
+
+.cc-table tbody td {
+    padding: 0 var(--space-4);
+    font-family: var(--font-body);
+    font-size: var(--text-sm);
+    color: var(--text-secondary);
 }
 
-/* ── Search ───────────────────────────────────────────────── */
+.cc-table-name {
+    font-family: var(--font-code);
+    color: var(--accent-interactive);
+    text-decoration: none;
+    font-weight: 500;
+}
 
+.cc-table-name:hover { text-decoration: underline; }
+
+.cc-table-path {
+    font-family: var(--font-code);
+    font-size: 12px;
+    color: var(--text-muted);
+    max-width: 280px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    display: block;
+}
+
+.cc-table-num {
+    font-family: var(--font-body);
+    color: var(--text-primary);
+    font-weight: 500;
+}
+
+.cc-table-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+}
+
+/* ── Icon button ─────────────────────────────────────────────── */
+.cc-icon-btn {
+    width: 28px;
+    height: 28px;
+    border-radius: var(--radius-md);
+    border: none;
+    background: transparent;
+    color: var(--text-muted);
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    text-decoration: none;
+    transition: background 150ms ease, color 150ms ease;
+    padding: 0;
+}
+
+.cc-icon-btn:hover {
+    background: var(--bg-card-hover);
+    color: var(--text-primary);
+}
+
+.cc-icon-btn--danger:hover {
+    background: color-mix(in srgb, var(--accent-error) 15%, transparent);
+    color: var(--accent-error);
+}
+
+/* ── Status badge ────────────────────────────────────────────── */
+.cc-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    font-family: var(--font-body);
+    font-size: var(--text-xs);
+    font-weight: 500;
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+    padding: 2px var(--space-2);
+    border-radius: var(--radius-full);
+    border: 1px solid;
+    white-space: nowrap;
+}
+
+.cc-badge-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.cc-badge--indexed {
+    background: color-mix(in srgb, var(--ctp-teal) 15%, transparent);
+    color: var(--ctp-teal);
+    border-color: color-mix(in srgb, var(--ctp-teal) 40%, transparent);
+}
+.cc-badge--indexed .cc-badge-dot { background: var(--ctp-teal); }
+
+.cc-badge--stale {
+    background: color-mix(in srgb, var(--ctp-yellow) 15%, transparent);
+    color: var(--ctp-yellow);
+    border-color: color-mix(in srgb, var(--ctp-yellow) 40%, transparent);
+}
+.cc-badge--stale .cc-badge-dot { background: var(--ctp-yellow); }
+
+.cc-badge--indexing {
+    background: color-mix(in srgb, var(--ctp-blue) 15%, transparent);
+    color: var(--ctp-blue);
+    border-color: color-mix(in srgb, var(--ctp-blue) 40%, transparent);
+}
+.cc-badge--indexing .cc-badge-dot {
+    background: var(--ctp-blue);
+    animation: badge-pulse 1.2s ease-in-out infinite;
+}
+
+.cc-badge--error {
+    background: color-mix(in srgb, var(--ctp-red) 15%, transparent);
+    color: var(--ctp-red);
+    border-color: color-mix(in srgb, var(--ctp-red) 40%, transparent);
+}
+.cc-badge--error .cc-badge-dot { background: var(--ctp-red); }
+
+.cc-badge--untracked {
+    background: var(--bg-card-hover);
+    color: var(--text-muted);
+    border-color: var(--border-subtle);
+}
+.cc-badge--untracked .cc-badge-dot { background: var(--text-muted); }
+
+@keyframes badge-pulse {
+    0%, 100% { transform: scale(1); }
+    50%       { transform: scale(1.4); }
+}
+
+/* Symbol kind badges */
+.cc-kind-badge {
+    font-family: var(--font-body);
+    font-size: 10px;
+    font-weight: 500;
+    letter-spacing: var(--tracking-wide);
+    padding: 1px 5px;
+    border-radius: var(--radius-sm);
+    border: 1px solid;
+    white-space: nowrap;
+}
+
+.cc-kind-badge--fn   { background: color-mix(in srgb, var(--ctp-blue) 15%, transparent); color: var(--ctp-blue); border-color: color-mix(in srgb, var(--ctp-blue) 35%, transparent); }
+.cc-kind-badge--cls  { background: color-mix(in srgb, var(--ctp-peach) 15%, transparent); color: var(--ctp-peach); border-color: color-mix(in srgb, var(--ctp-peach) 35%, transparent); }
+.cc-kind-badge--ifc  { background: color-mix(in srgb, var(--ctp-lavender) 15%, transparent); color: var(--ctp-lavender); border-color: color-mix(in srgb, var(--ctp-lavender) 35%, transparent); }
+.cc-kind-badge--enm  { background: color-mix(in srgb, var(--ctp-green) 15%, transparent); color: var(--ctp-green); border-color: color-mix(in srgb, var(--ctp-green) 35%, transparent); }
+.cc-kind-badge--var  { background: color-mix(in srgb, var(--ctp-teal) 15%, transparent); color: var(--ctp-teal); border-color: color-mix(in srgb, var(--ctp-teal) 35%, transparent); }
+.cc-kind-badge--prop { background: color-mix(in srgb, var(--ctp-mauve) 15%, transparent); color: var(--ctp-mauve); border-color: color-mix(in srgb, var(--ctp-mauve) 35%, transparent); }
+
+/* ── Search bar ──────────────────────────────────────────────── */
 .cc-search-bar {
-  display: flex;
-  gap: 0.5rem;
-  align-items: center;
+    display: flex;
+    gap: var(--space-2);
+    align-items: center;
+    margin-bottom: var(--space-4);
 }
 
 .cc-search-input {
-  flex: 1;
-  background: var(--input);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 0.4rem 0.75rem;
-  color: var(--foreground);
-  font-family: var(--font-sans);
-  font-size: 13px;
-  outline: none;
-  transition: border-color 0.15s;
+    flex: 1;
+    height: 36px;
+    background: var(--bg-input);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-full);
+    padding: 0 var(--space-4);
+    color: var(--text-primary);
+    font-family: var(--font-body);
+    font-size: var(--text-sm);
+    outline: none;
+    transition: border-color 150ms ease, box-shadow 150ms ease;
 }
 
 .cc-search-input:focus {
-  border-color: var(--ring);
+    border-color: var(--accent-primary);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent-primary) 20%, transparent);
 }
 
-.cc-search-input::placeholder {
-  color: var(--muted-foreground);
-}
+.cc-search-input::placeholder { color: var(--text-muted); }
 
-/* ── Symbol list ──────────────────────────────────────────── */
-
+/* ── Symbol list ─────────────────────────────────────────────── */
 .cc-symbol-list {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    background: var(--bg-card);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-lg);
+    overflow: hidden;
 }
 
 .cc-symbol-row {
-  display: flex;
-  align-items: center;
-  gap: 0.6rem;
-  padding: 0.35rem 0.5rem;
-  border-radius: calc(var(--radius) - 2px);
-  font-size: 13px;
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    padding: var(--space-2) var(--space-4);
+    font-size: var(--text-sm);
+    border-bottom: 1px solid var(--border-subtle);
+    transition: background 100ms linear;
 }
 
-.cc-symbol-row:hover {
-  background: var(--cc-surface0);
-}
+.cc-symbol-row:last-child { border-bottom: none; }
 
-.cc-kind-badge {
-  flex-shrink: 0;
-  font-size: 10px;
-}
+.cc-symbol-row:hover { background: var(--bg-card-hover); }
 
 .cc-symbol-name {
-  font-family: var(--font-mono);
-  font-weight: 600;
-  color: var(--cc-blue);
-  flex-shrink: 0;
+    font-family: var(--font-code);
+    font-weight: 600;
+    color: var(--accent-interactive);
+    flex-shrink: 0;
 }
 
 .cc-symbol-sig {
-  color: var(--cc-subtext0);
-  font-family: var(--font-mono);
-  font-size: 11px;
-  flex: 1;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+    color: var(--text-muted);
+    font-family: var(--font-code);
+    font-size: 11px;
+    flex: 1;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .cc-symbol-path {
-  font-family: var(--font-mono);
-  font-size: 11px;
-  color: var(--cc-overlay0);
-  flex-shrink: 0;
+    font-family: var(--font-code);
+    font-size: 11px;
+    color: var(--ctp-overlay0);
+    flex-shrink: 0;
 }
 
-/* ── Snapshots ────────────────────────────────────────────── */
+/* ── Section ─────────────────────────────────────────────────── */
+.cc-section {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+}
 
+.cc-section h2 {
+    margin: 0;
+    font-family: var(--font-heading);
+    font-size: var(--text-lg);
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+/* ── Stat row (repo detail) ──────────────────────────────────── */
+.cc-stat-row {
+    display: flex;
+    gap: var(--space-4);
+    flex-wrap: wrap;
+}
+
+.cc-stat {
+    background: var(--bg-card);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-lg);
+    padding: var(--space-3) var(--space-5);
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 120px;
+}
+
+.cc-stat-value {
+    font-family: var(--font-heading);
+    font-size: 22px;
+    font-weight: 700;
+    color: var(--accent-primary);
+    letter-spacing: var(--tracking-tight);
+}
+
+.cc-stat-label {
+    font-family: var(--font-body);
+    font-size: var(--text-xs);
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-wide);
+}
+
+/* ── Snapshots ───────────────────────────────────────────────── */
 .cc-snapshot-list {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    background: var(--bg-card);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-lg);
+    overflow: hidden;
 }
 
 .cc-snapshot-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0.4rem 0.5rem;
-  border-radius: calc(var(--radius) - 2px);
-  font-size: 13px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--space-2) var(--space-4);
+    font-size: var(--text-sm);
+    border-bottom: 1px solid var(--border-subtle);
+    transition: background 100ms linear;
 }
 
-.cc-snapshot-row:hover {
-  background: var(--cc-surface0);
-}
+.cc-snapshot-row:last-child { border-bottom: none; }
+.cc-snapshot-row:hover { background: var(--bg-card-hover); }
 
-.cc-snapshot-label {
-  font-family: var(--font-mono);
-  font-weight: 500;
-}
+.cc-snapshot-label { font-family: var(--font-code); font-weight: 500; color: var(--text-primary); }
+.cc-snapshot-date  { color: var(--text-muted); font-size: 12px; }
 
-.cc-snapshot-date {
-  color: var(--cc-subtext0);
-  font-size: 12px;
-}
-
-/* ── Breadcrumb ───────────────────────────────────────────── */
-
+/* ── Breadcrumb ──────────────────────────────────────────────── */
 .cc-breadcrumb {
-  color: var(--cc-subtext1);
-  text-decoration: none;
-  font-size: 13px;
+    color: var(--text-secondary);
+    text-decoration: none;
+    font-size: var(--text-sm);
+    font-family: var(--font-body);
 }
 
-.cc-breadcrumb:hover {
-  color: var(--foreground);
-  text-decoration: underline;
-}
+.cc-breadcrumb:hover { color: var(--text-primary); text-decoration: underline; }
+.cc-breadcrumb-sep   { color: var(--ctp-overlay0); margin: 0 var(--space-1); }
 
-.cc-breadcrumb-sep {
-  color: var(--cc-overlay0);
-  margin: 0 0.3rem;
-}
-
-/* ── Utility ──────────────────────────────────────────────── */
-
+/* ── Empty / loading states ──────────────────────────────────── */
 .cc-loading,
 .cc-empty {
-  color: var(--muted-foreground);
-  font-size: 13px;
-  padding: 2rem 0;
-  text-align: center;
+    color: var(--text-muted);
+    font-size: var(--text-sm);
+    padding: var(--space-8) 0;
+    text-align: center;
+    font-family: var(--font-body);
 }
 
 .cc-empty-inline {
-  color: var(--muted-foreground);
-  font-size: 13px;
-  margin: 0;
+    color: var(--text-muted);
+    font-size: var(--text-sm);
+    margin: 0;
+    font-family: var(--font-body);
 }
 
+/* ── Empty state panel ───────────────────────────────────────── */
+.cc-empty-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: var(--space-16) var(--space-8);
+    gap: var(--space-4);
+    text-align: center;
+}
+
+.cc-empty-state-icon  { color: var(--text-muted); }
+.cc-empty-state h3    { margin: 0; font-family: var(--font-heading); font-size: var(--text-lg); font-weight: 500; color: var(--text-secondary); }
+.cc-empty-state p     { margin: 0; font-size: var(--text-sm); color: var(--text-muted); max-width: 320px; }
+
+/* ── Error state ─────────────────────────────────────────────── */
 .cc-error {
-  background: color-mix(in srgb, var(--cc-red) 10%, transparent);
-  border: 1px solid var(--cc-red);
-  border-radius: var(--radius);
-  padding: 1rem;
-  color: var(--cc-red);
+    background: color-mix(in srgb, var(--ctp-red) 10%, transparent);
+    border: 1px solid var(--ctp-red);
+    border-radius: var(--radius-lg);
+    padding: var(--space-5) var(--space-6);
+    color: var(--ctp-red);
 }
 
+.cc-error h2 { margin: 0 0 var(--space-2); font-family: var(--font-heading); }
+.cc-error p  { margin: 0; font-size: var(--text-sm); }
+
+/* ── Repo path display ───────────────────────────────────────── */
+.cc-repo-path-display {
+    font-family: var(--font-code);
+    font-size: var(--text-sm);
+    color: var(--text-muted);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+/* ── Coming-soon stub ────────────────────────────────────────── */
+.cc-coming-soon {
+    background: var(--bg-card);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-lg);
+    padding: var(--space-12) var(--space-8);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-4);
+    text-align: center;
+    color: var(--text-muted);
+}
+
+.cc-coming-soon h3  { margin: 0; font-family: var(--font-heading); font-size: var(--text-lg); color: var(--text-secondary); font-weight: 500; }
+.cc-coming-soon p   { margin: 0; font-size: var(--text-sm); max-width: 360px; }
+
+/* ── Graph page ──────────────────────────────────────────────── */
+.cc-graph-canvas-placeholder {
+    background: var(--bg-card);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-lg);
+    flex: 1;
+    min-height: 500px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+    gap: var(--space-4);
+    color: var(--text-muted);
+}
+
+/* ── Link button ─────────────────────────────────────────────── */
 .cc-link-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.3rem;
-  padding: 0.3rem 0.6rem;
-  border-radius: var(--radius);
-  color: var(--cc-subtext1);
-  text-decoration: none;
-  font-size: 12px;
-  border: 1px solid var(--border);
-  transition: background 0.15s, color 0.15s;
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    padding: 0 var(--space-3);
+    height: 28px;
+    border-radius: var(--radius-md);
+    color: var(--text-secondary);
+    text-decoration: none;
+    font-size: var(--text-xs);
+    border: 1px solid var(--border-subtle);
+    font-family: var(--font-body);
+    transition: background 150ms ease, color 150ms ease;
 }
 
-.cc-link-btn:hover {
-  background: var(--cc-surface0);
-  color: var(--foreground);
-}
+.cc-link-btn:hover { background: var(--bg-card-hover); color: var(--text-primary); }
 
+/* ── Code inline ─────────────────────────────────────────────── */
 code {
-  font-family: var(--font-mono);
-  font-size: 0.9em;
-  background: var(--cc-surface0);
-  padding: 0.1em 0.3em;
-  border-radius: calc(var(--radius) / 2);
+    font-family: var(--font-code);
+    font-size: 0.9em;
+    background: var(--bg-card);
+    padding: 0.1em 0.3em;
+    border-radius: var(--radius-sm);
+    color: var(--ctp-peach);
+}
+
+/* ── Responsive ──────────────────────────────────────────────── */
+@media (max-width: 1280px) {
+    .cc-stats-grid { grid-template-columns: repeat(2, 1fr); }
+}
+
+@media (max-width: 768px) {
+    .cc-stats-grid { grid-template-columns: 1fr; }
+    .cc-topbar { grid-template-columns: 1fr auto; }
+    .cc-topbar-center { display: none; }
+    .cc-sidebar { display: none; }
+}
+
+/* ── Reduced motion ──────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        transition-duration: 0.01ms !important;
+    }
 }

--- a/src/CodeCompress.Web/wwwroot/app.css
+++ b/src/CodeCompress.Web/wwwroot/app.css
@@ -1,0 +1,497 @@
+/* ── Catppuccin Macchiato – default dark theme ────────────────
+   Overrides BlazorBlueprint CSS custom properties.
+   Source: https://catppuccin.com/palette (Macchiato variant)
+   ──────────────────────────────────────────────────────────── */
+
+:root {
+  /* Catppuccin Macchiato palette */
+  --cc-base:     #24273a;
+  --cc-mantle:   #1e2030;
+  --cc-crust:    #181926;
+  --cc-surface0: #363a4f;
+  --cc-surface1: #494d64;
+  --cc-overlay0: #6e738d;
+  --cc-text:     #cad3f5;
+  --cc-subtext1: #b8c0e0;
+  --cc-subtext0: #a5adcb;
+  --cc-blue:     #8aadf4;
+  --cc-green:    #a6da95;
+  --cc-red:      #ed8796;
+  --cc-yellow:   #eed49f;
+  --cc-mauve:    #c6a0f6;
+  --cc-peach:    #f5a97f;
+
+  /* BlazorBlueprint token overrides */
+  --background:            var(--cc-base);
+  --foreground:            var(--cc-text);
+  --card:                  var(--cc-mantle);
+  --card-foreground:       var(--cc-text);
+  --popover:               var(--cc-mantle);
+  --popover-foreground:    var(--cc-text);
+  --primary:               var(--cc-blue);
+  --primary-foreground:    var(--cc-crust);
+  --secondary:             var(--cc-surface0);
+  --secondary-foreground:  var(--cc-text);
+  --muted:                 var(--cc-surface0);
+  --muted-foreground:      var(--cc-subtext0);
+  --accent:                var(--cc-surface1);
+  --accent-foreground:     var(--cc-text);
+  --destructive:           var(--cc-red);
+  --destructive-foreground: var(--cc-crust);
+  --border:                var(--cc-surface0);
+  --input:                 var(--cc-surface0);
+  --ring:                  var(--cc-blue);
+  --radius:                0.5rem;
+
+  /* Typography — system fonts (no CDN) */
+  --font-sans: ui-sans-serif, system-ui, -apple-system, sans-serif;
+  --font-mono: ui-monospace, "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+}
+
+/* Dark class re-applies same vars (ThemeService dark-mode compat) */
+.dark {
+  --background:            var(--cc-base);
+  --foreground:            var(--cc-text);
+  --card:                  var(--cc-mantle);
+  --card-foreground:       var(--cc-text);
+  --popover:               var(--cc-mantle);
+  --popover-foreground:    var(--cc-text);
+  --primary:               var(--cc-blue);
+  --primary-foreground:    var(--cc-crust);
+  --secondary:             var(--cc-surface0);
+  --secondary-foreground:  var(--cc-text);
+  --muted:                 var(--cc-surface0);
+  --muted-foreground:      var(--cc-subtext0);
+  --accent:                var(--cc-surface1);
+  --accent-foreground:     var(--cc-text);
+  --destructive:           var(--cc-red);
+  --destructive-foreground: var(--cc-crust);
+  --border:                var(--cc-surface0);
+  --input:                 var(--cc-surface0);
+  --ring:                  var(--cc-blue);
+}
+
+/* ── Layout shell ─────────────────────────────────────────── */
+
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+html, body {
+  margin: 0;
+  height: 100%;
+  background: var(--background);
+  color: var(--foreground);
+  font-family: var(--font-sans);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.cc-shell {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+/* topbar */
+.cc-topbar {
+  height: 48px;
+  background: var(--cc-crust);
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  padding: 0 1rem;
+  flex-shrink: 0;
+}
+
+.cc-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--foreground);
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 15px;
+}
+
+.cc-brand-icon {
+  color: var(--cc-blue);
+  font-size: 18px;
+}
+
+/* body = sidebar + content */
+.cc-body {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+}
+
+.cc-sidebar {
+  width: 220px;
+  background: var(--cc-mantle);
+  border-right: 1px solid var(--border);
+  padding: 0.75rem 0;
+  flex-shrink: 0;
+  overflow-y: auto;
+}
+
+.cc-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1.5rem;
+  max-width: 1400px;
+}
+
+/* ── Navigation ───────────────────────────────────────────── */
+
+.cc-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 0 0.5rem;
+}
+
+.cc-nav-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--radius);
+  color: var(--cc-subtext1);
+  text-decoration: none;
+  font-size: 13px;
+  transition: background 0.15s, color 0.15s;
+}
+
+.cc-nav-item:hover {
+  background: var(--cc-surface0);
+  color: var(--foreground);
+}
+
+.cc-nav-item.active {
+  background: var(--cc-surface0);
+  color: var(--cc-blue);
+  font-weight: 500;
+}
+
+/* ── Page ─────────────────────────────────────────────────── */
+
+.cc-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.cc-page-header {
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 1rem;
+}
+
+.cc-page-header h1 {
+  margin: 0 0 0.25rem;
+  font-size: 20px;
+  font-weight: 600;
+}
+
+.cc-page-subtitle {
+  margin: 0;
+  color: var(--cc-subtext0);
+  font-size: 13px;
+}
+
+/* ── Repo Grid ────────────────────────────────────────────── */
+
+.cc-repo-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 1rem;
+}
+
+.cc-repo-card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.cc-repo-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.cc-repo-name {
+  font-weight: 600;
+  font-size: 15px;
+  color: var(--cc-blue);
+  text-decoration: none;
+}
+
+.cc-repo-name:hover {
+  text-decoration: underline;
+}
+
+.cc-repo-path {
+  margin: 0;
+  font-size: 11px;
+  color: var(--cc-subtext0);
+  font-family: var(--font-mono);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.cc-repo-stats {
+  display: flex;
+  gap: 1rem;
+  font-size: 12px;
+  color: var(--cc-subtext1);
+}
+
+.cc-repo-stats b {
+  color: var(--foreground);
+}
+
+.cc-repo-error {
+  margin: 0;
+  font-size: 12px;
+  color: var(--cc-red);
+}
+
+.cc-repo-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.25rem;
+}
+
+/* ── Stat row (repo detail) ───────────────────────────────── */
+
+.cc-stat-row {
+  display: flex;
+  gap: 1.5rem;
+}
+
+.cc-stat {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 0.75rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.cc-stat-value {
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--cc-blue);
+}
+
+.cc-stat-label {
+  font-size: 11px;
+  color: var(--cc-subtext0);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+/* ── Section ──────────────────────────────────────────────── */
+
+.cc-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.cc-section h2 {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.cc-section-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+/* ── Search ───────────────────────────────────────────────── */
+
+.cc-search-bar {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.cc-search-input {
+  flex: 1;
+  background: var(--input);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 0.4rem 0.75rem;
+  color: var(--foreground);
+  font-family: var(--font-sans);
+  font-size: 13px;
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.cc-search-input:focus {
+  border-color: var(--ring);
+}
+
+.cc-search-input::placeholder {
+  color: var(--muted-foreground);
+}
+
+/* ── Symbol list ──────────────────────────────────────────── */
+
+.cc-symbol-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.cc-symbol-row {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.35rem 0.5rem;
+  border-radius: calc(var(--radius) - 2px);
+  font-size: 13px;
+}
+
+.cc-symbol-row:hover {
+  background: var(--cc-surface0);
+}
+
+.cc-kind-badge {
+  flex-shrink: 0;
+  font-size: 10px;
+}
+
+.cc-symbol-name {
+  font-family: var(--font-mono);
+  font-weight: 600;
+  color: var(--cc-blue);
+  flex-shrink: 0;
+}
+
+.cc-symbol-sig {
+  color: var(--cc-subtext0);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.cc-symbol-path {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--cc-overlay0);
+  flex-shrink: 0;
+}
+
+/* ── Snapshots ────────────────────────────────────────────── */
+
+.cc-snapshot-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.cc-snapshot-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.4rem 0.5rem;
+  border-radius: calc(var(--radius) - 2px);
+  font-size: 13px;
+}
+
+.cc-snapshot-row:hover {
+  background: var(--cc-surface0);
+}
+
+.cc-snapshot-label {
+  font-family: var(--font-mono);
+  font-weight: 500;
+}
+
+.cc-snapshot-date {
+  color: var(--cc-subtext0);
+  font-size: 12px;
+}
+
+/* ── Breadcrumb ───────────────────────────────────────────── */
+
+.cc-breadcrumb {
+  color: var(--cc-subtext1);
+  text-decoration: none;
+  font-size: 13px;
+}
+
+.cc-breadcrumb:hover {
+  color: var(--foreground);
+  text-decoration: underline;
+}
+
+.cc-breadcrumb-sep {
+  color: var(--cc-overlay0);
+  margin: 0 0.3rem;
+}
+
+/* ── Utility ──────────────────────────────────────────────── */
+
+.cc-loading,
+.cc-empty {
+  color: var(--muted-foreground);
+  font-size: 13px;
+  padding: 2rem 0;
+  text-align: center;
+}
+
+.cc-empty-inline {
+  color: var(--muted-foreground);
+  font-size: 13px;
+  margin: 0;
+}
+
+.cc-error {
+  background: color-mix(in srgb, var(--cc-red) 10%, transparent);
+  border: 1px solid var(--cc-red);
+  border-radius: var(--radius);
+  padding: 1rem;
+  color: var(--cc-red);
+}
+
+.cc-link-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.3rem 0.6rem;
+  border-radius: var(--radius);
+  color: var(--cc-subtext1);
+  text-decoration: none;
+  font-size: 12px;
+  border: 1px solid var(--border);
+  transition: background 0.15s, color 0.15s;
+}
+
+.cc-link-btn:hover {
+  background: var(--cc-surface0);
+  color: var(--foreground);
+}
+
+code {
+  font-family: var(--font-mono);
+  font-size: 0.9em;
+  background: var(--cc-surface0);
+  padding: 0.1em 0.3em;
+  border-radius: calc(var(--radius) / 2);
+}

--- a/tests/CodeCompress.Server.Tests/Tools/RegistryToolsTests.cs
+++ b/tests/CodeCompress.Server.Tests/Tools/RegistryToolsTests.cs
@@ -34,8 +34,8 @@ internal sealed class RegistryToolsTests
     {
         var repos = new List<RepositoryRecord>
         {
-            new("/home/user/projectA", "projectA", 10, 50, DateTimeOffset.UtcNow, null),
-            new("/home/user/projectB", "projectB", 5, 20, DateTimeOffset.UtcNow, null),
+            new("id1", "/home/user/projectA", "projectA", 10, 50, DateTimeOffset.UtcNow, null),
+            new("id2", "/home/user/projectB", "projectB", 5, 20, DateTimeOffset.UtcNow, null),
         };
         _registryService.ListAsync().Returns(repos);
 
@@ -51,7 +51,7 @@ internal sealed class RegistryToolsTests
         var lastIndexed = new DateTimeOffset(2026, 4, 30, 12, 0, 0, TimeSpan.Zero);
         var repos = new List<RepositoryRecord>
         {
-            new("/home/user/my-project", "my-project", 7, 99, lastIndexed, null),
+            new("id1", "/home/user/my-project", "my-project", 7, 99, lastIndexed, null),
         };
         _registryService.ListAsync().Returns(repos);
 
@@ -71,7 +71,7 @@ internal sealed class RegistryToolsTests
     {
         var repos = new List<RepositoryRecord>
         {
-            new("/home/user/broken", "broken", 0, 0, DateTimeOffset.UtcNow, "Index corruption detected"),
+            new("id1", "/home/user/broken", "broken", 0, 0, DateTimeOffset.UtcNow, "Index corruption detected"),
         };
         _registryService.ListAsync().Returns(repos);
 

--- a/tests/CodeCompress.Web.Tests/CodeCompress.Web.Tests.csproj
+++ b/tests/CodeCompress.Web.Tests/CodeCompress.Web.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <IsTestProject>true</IsTestProject>
+    <!-- bunit's HtmlSanitizer dep pins AngleSharp but a newer version resolves — suppress the warning -->
+    <!-- CA2007: test assertions don't need ConfigureAwait -->
+    <NoWarn>NU1608;CA2007</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\CodeCompress.Web\CodeCompress.Web.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="TUnit" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="bunit" />
+  </ItemGroup>
+
+</Project>

--- a/tests/CodeCompress.Web.Tests/DashboardTests.cs
+++ b/tests/CodeCompress.Web.Tests/DashboardTests.cs
@@ -1,3 +1,4 @@
+using BlazorBlueprint.Components;
 using Bunit;
 using CodeCompress.Core.Registry;
 using CodeCompress.Web.Components.Pages;
@@ -9,6 +10,12 @@ namespace CodeCompress.Web.Tests;
 
 internal sealed class DashboardTests : BunitContext
 {
+    [Before(Test)]
+    public void Setup()
+    {
+        Services.AddBlazorBlueprintComponents();
+    }
+
     [Test]
     public async Task Dashboard_ShowsRepositoryNamesFromFacade()
     {
@@ -45,9 +52,9 @@ internal sealed class DashboardTests : BunitContext
         Services.AddSingleton(facade);
 
         var cut = Render<Dashboard>();
-        await cut.WaitForStateAsync(() => cut.FindAll("[data-testid='file-count']").Count > 0, TimeSpan.FromSeconds(3));
+        await cut.WaitForStateAsync(() => cut.FindAll("[data-testid='stat-files']").Count > 0, TimeSpan.FromSeconds(3));
 
-        await Assert.That(cut.Find("[data-testid='file-count']").TextContent).Contains("42");
-        await Assert.That(cut.Find("[data-testid='symbol-count']").TextContent).Contains("789");
+        await Assert.That(cut.Find("[data-testid='stat-files']").TextContent).Contains("42");
+        await Assert.That(cut.Find("[data-testid='stat-symbols']").TextContent).Contains("789");
     }
 }

--- a/tests/CodeCompress.Web.Tests/DashboardTests.cs
+++ b/tests/CodeCompress.Web.Tests/DashboardTests.cs
@@ -1,0 +1,53 @@
+using Bunit;
+using CodeCompress.Core.Registry;
+using CodeCompress.Web.Components.Pages;
+using CodeCompress.Web.Services;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace CodeCompress.Web.Tests;
+
+internal sealed class DashboardTests : BunitContext
+{
+    [Test]
+    public async Task Dashboard_ShowsRepositoryNamesFromFacade()
+    {
+        var facade = Substitute.For<IIndexFacade>();
+        facade.GetRepositoriesAsync(Arg.Any<CancellationToken>())
+            .Returns([new RepositoryRecord("abc123", "C:/project", "MyApp", 50, 500, DateTimeOffset.UtcNow, null)]);
+        Services.AddSingleton(facade);
+
+        var cut = Render<Dashboard>();
+        await cut.WaitForStateAsync(() => cut.FindAll("[data-testid='repo-name']").Count > 0, TimeSpan.FromSeconds(3));
+
+        await Assert.That(cut.Find("[data-testid='repo-name']").TextContent).IsEqualTo("MyApp");
+    }
+
+    [Test]
+    public async Task Dashboard_ShowsEmptyStateWhenNoRepositories()
+    {
+        var facade = Substitute.For<IIndexFacade>();
+        facade.GetRepositoriesAsync(Arg.Any<CancellationToken>()).Returns([]);
+        Services.AddSingleton(facade);
+
+        var cut = Render<Dashboard>();
+        await cut.WaitForStateAsync(() => cut.FindAll("[data-testid='empty-state']").Count > 0, TimeSpan.FromSeconds(3));
+
+        await Assert.That(cut.FindAll("[data-testid='empty-state']").Count).IsGreaterThan(0);
+    }
+
+    [Test]
+    public async Task Dashboard_ShowsFileAndSymbolCounts()
+    {
+        var facade = Substitute.For<IIndexFacade>();
+        facade.GetRepositoriesAsync(Arg.Any<CancellationToken>())
+            .Returns([new RepositoryRecord("abc123", "C:/project", "MyApp", 42, 789, DateTimeOffset.UtcNow, null)]);
+        Services.AddSingleton(facade);
+
+        var cut = Render<Dashboard>();
+        await cut.WaitForStateAsync(() => cut.FindAll("[data-testid='file-count']").Count > 0, TimeSpan.FromSeconds(3));
+
+        await Assert.That(cut.Find("[data-testid='file-count']").TextContent).Contains("42");
+        await Assert.That(cut.Find("[data-testid='symbol-count']").TextContent).Contains("789");
+    }
+}

--- a/tests/CodeCompress.Web.Tests/IndexFacadeTests.cs
+++ b/tests/CodeCompress.Web.Tests/IndexFacadeTests.cs
@@ -1,0 +1,108 @@
+using CodeCompress.Core.Indexing;
+using CodeCompress.Core.Models;
+using CodeCompress.Core.Registry;
+using CodeCompress.Core.Storage;
+using CodeCompress.Core.Validation;
+using CodeCompress.Web.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace CodeCompress.Web.Tests;
+
+internal sealed class IndexFacadeTests
+{
+    [Test]
+    public async Task GetRepositoriesAsync_ReturnsListFromRegistry()
+    {
+        var registry = Substitute.For<IRegistryService>();
+        var expected = new List<RepositoryRecord>
+        {
+            new("abc123", "C:/proj", "MyProject", 10, 100, DateTimeOffset.UtcNow, null),
+        };
+        registry.ListAsync().Returns(expected);
+
+        var facade = CreateFacade(registry: registry);
+        var result = await facade.GetRepositoriesAsync();
+
+        await Assert.That(result).IsEquivalentTo(expected);
+    }
+
+    [Test]
+    public async Task SearchSymbolsAsync_InvalidPath_ThrowsArgumentException()
+    {
+        var pathValidator = Substitute.For<IPathValidator>();
+        pathValidator
+            .ValidatePath(Arg.Any<string>(), Arg.Any<string>())
+            .Throws(new ArgumentException("Path outside root"));
+
+        var facade = CreateFacade(pathValidator: pathValidator);
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => facade.SearchSymbolsAsync("../evil", "query", null, 20));
+    }
+
+    [Test]
+    public async Task GetSnapshotsAsync_ReturnsSnapshotsForProject()
+    {
+        var registry = Substitute.For<IRegistryService>();
+        registry.ListAsync().Returns([]);
+
+        var store = Substitute.For<ISymbolStore>();
+        var snapshots = new List<IndexSnapshot>
+        {
+            new(1L, "repo1", "before-refactor", DateTimeOffset.UtcNow.ToUnixTimeSeconds(), "{}"),
+        };
+        store.GetSnapshotsByRepoAsync(Arg.Any<string>()).Returns(snapshots);
+
+        var facade = CreateFacadeWithStore(registry, store);
+        var result = await facade.GetSnapshotsAsync("C:/proj");
+
+        await Assert.That(result).IsEquivalentTo(snapshots);
+    }
+
+    private static IndexFacade CreateFacade(
+        IRegistryService? registry = null,
+        IPathValidator? pathValidator = null)
+    {
+        registry ??= Substitute.For<IRegistryService>();
+        if (pathValidator is null)
+        {
+            pathValidator = Substitute.For<IPathValidator>();
+            pathValidator
+                .ValidatePath(Arg.Any<string>(), Arg.Any<string>())
+                .Returns(x => (string)x[0]);
+        }
+
+        return new IndexFacade(
+            registry,
+            Substitute.For<IConnectionFactory>(),
+            Substitute.For<IFileHasher>(),
+            Substitute.For<IChangeTracker>(),
+            [],
+            pathValidator,
+            Substitute.For<IGitIgnoreFilter>(),
+            NullLoggerFactory.Instance);
+    }
+
+    private static IndexFacade CreateFacadeWithStore(
+        IRegistryService registry,
+        ISymbolStore store)
+    {
+        var pathValidator = Substitute.For<IPathValidator>();
+        pathValidator
+            .ValidatePath(Arg.Any<string>(), Arg.Any<string>())
+            .Returns(x => (string)x[0]);
+
+        return new IndexFacade(
+            registry,
+            Substitute.For<IConnectionFactory>(),
+            Substitute.For<IFileHasher>(),
+            Substitute.For<IChangeTracker>(),
+            [],
+            pathValidator,
+            Substitute.For<IGitIgnoreFilter>(),
+            NullLoggerFactory.Instance,
+            store);
+    }
+}


### PR DESCRIPTION
Closes #185

## Summary

- Implements the Blazor Server web dashboard serving all indexed repositories, symbol search, repo detail, and dependency graph placeholder pages
- Migrates all pages from raw HTML to **BlazorBlueprint v3** components (`BbCard`, `BbDataGrid`, `BbInputGroup`, `BbAlert`, `BbBreadcrumb`, `BbEmpty`, `BbBadge`, `BbButton`)
- Adds **Catppuccin** Macchiato (dark) / Latte (light) palette with `IThemeService`-driven theme toggle — no JSInterop required
- Adds Playwright CLI skill for browser-based visual verification

## Pages implemented

| Page | Route | Status |
|------|-------|--------|
| Dashboard | `/` | Full — stat cards + repo data grid with re-index actions |
| Repositories | `/repositories` | Full — filterable/sortable data grid |
| Symbols | `/symbols` | Full — global symbol search across all repos |
| Files | `/files` | Full — paginated file browser with extension badges |
| Repo Detail | `/repo/{RepoId}` | Full — breadcrumb, stats, symbol search, snapshots |
| Dependency Graph | `/repo/{RepoId}/graph` | Placeholder — canvas delivered by GH-193 |
| Index Jobs | `/index-jobs` | Placeholder — delivered by GH-194 |
| Configuration | `/configuration` | Placeholder |

## Notable implementation decisions

- `BbDataGrid` requires `TData : class` — value tuples are structs, so `Files.razor` uses a `private sealed record FileEntry(FileRecord, string)` as the grid item type
- BB components (`BbEmpty`, `BbAlert`, `BbCard`, `BbBreadcrumbPage`) do not have `AdditionalAttributes`/CaptureUnmatchedValues — `data-testid` attributes are placed only on native HTML elements inside template columns
- `BbAlert` named slots: `BbAlertTitle`/`BbAlertDescription` must be wrapped in `<ChildContent>`, not placed as bare children
- Route parameter interpolation in BB component attributes requires `@($"...")` string interpolation — mixed literal/C# syntax like `"/repo/@RepoId"` is not supported

## Test plan

- [x] All 6 public routes return HTTP 200 (verified via curl)
- [x] Dashboard renders stat cards and repo data grid
- [x] Repositories page shows filterable grid with INDEXED status badge
- [x] Symbols page loads without runtime errors (previous `data-testid` on `BbEmpty` caused 500)
- [x] Files page displays paginated file list with extension badges
- [x] Repo detail page shows breadcrumb, stat row, symbol search
- [x] Graph page shows placeholder with file count in description
- [x] Dark/light theme toggle works via `IThemeService`
- [x] Build passes with zero warnings/errors (`TreatWarningsAsErrors true`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)