### PR TITLE
chore: bump packages to latest, drop web packages, refresh agent docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **BREAKING:** Tools no longer accept arbitrary absolute paths. A `path` argument that resolves outside the boundary root (launch working directory or `CODECOMPRESS_ROOT`) is rejected. Workflows that previously passed paths to unrelated repositories must launch the server from a common parent directory or configure `CODECOMPRESS_ROOT` / `CODECOMPRESS_ALLOWED_ROOTS` (#198)
+- **Web dashboard on hold** — `CodeCompress.Web` and `CodeCompress.Web.Tests` are excluded from the solution build. The `codecompress web` CLI subcommand is removed. Project files are preserved in the repo for future resumption (#200)
+- **Package bumps** — ModelContextProtocol 1.3.0, Microsoft.Data.Sqlite / Extensions.* 10.0.8, System.CommandLine 2.0.8, YamlDotNet 18.0.0, SonarAnalyzer.CSharp 10.27.0, TUnit 1.49.0, Verify 31.19.0
 
 ## [0.14.0] - 2026-04-11
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,38 +197,6 @@ MCP tool parameters (`path`, `query`) are **untrusted inputs** from AI agents.
 - **global.json:** Pins .NET SDK 10.0.100 with `rollForward: latestFeature`
 - **SonarAnalyzer.CSharp:** Applied to all projects via `Directory.Build.props`
 
-## Web Dashboard (CodeCompress.Web)
-
-The Blazor Server dashboard lives in `src/CodeCompress.Web/`. It uses **BlazorBlueprint v3** as the component library and **Catppuccin** (Macchiato dark / Latte light) for the color palette via `IThemeService`.
-
-### BlazorBlueprint Components — Mandatory
-
-**Always use BB components over raw HTML.** This is enforced during code review.
-
-| Need | Use | Do NOT use |
-|------|-----|------------|
-| Card / panel | `BbCard`, `BbCardHeader`, `BbCardTitle`, `BbCardDescription`, `BbCardContent`, `BbCardAction` | `<div class="card">` |
-| Data table | `BbDataGrid<TData>` + `BbDataGridPropertyColumn` / `BbDataGridTemplateColumn` | `<table>` |
-| Alert / banner | `BbAlert` + `BbAlertTitle` + `BbAlertDescription` (inside `<ChildContent>`) | `<div class="alert">` |
-| Empty state | `BbEmpty` | custom empty divs |
-| Search input | `BbInputGroup` + `BbInputGroupAddon` + `BbInputGroupInput` + `BbInputGroupButton` | raw `<input>` + `<button>` |
-| Breadcrumb | `BbBreadcrumb` → `BbBreadcrumbList` → `BbBreadcrumbItem` → `BbBreadcrumbLink` / `BbBreadcrumbPage` | `<nav>` with raw links |
-| Badge / tag | `BbBadge` | `<span class="badge">` |
-| Button | `BbButton` | `<button>` (except inside template columns or icon-only action rows) |
-
-**Known BB component constraints:**
-
-- `BbEmpty`, `BbAlert`, `BbCard`, `BbBreadcrumbPage` do **not** have `AdditionalAttributes` (CaptureUnmatchedValues) — passing `data-testid` or any unknown HTML attribute causes a runtime `InvalidOperationException`. Place `data-testid` only on native HTML elements (`<div>`, `<span>`, `<a>`, `<button>`).
-- `BbDataGrid` requires `TData : class` — use a `private sealed record` instead of a value tuple when the type would otherwise be a struct.
-- `BbAlert` child content: `BbAlertTitle` and `BbAlertDescription` must be inside `<ChildContent>...</ChildContent>`, not as bare children.
-- Razor `Class` attribute interpolation: use `Class="@($"base-class modifier--{method()}")"` — never mix C# and literal text like `Class="base modifier--@method()"`.
-- `BbInputGroupInput` uses `UpdateTiming` enum: `Immediate`, `OnChange`, `Debounced` — `OnInput` does not exist.
-- `BbBreadcrumbLink Href` with route params: use `Href="@($"/repo/{RepoId}")"` — not `Href="/repo/@RepoId"`.
-
-### Theme
-
-Theme toggling is handled by `IThemeService` (injected via DI). Do **not** use JSInterop for theme switching — BB's `ThemeService` handles it. The `ThemeToggle.razor` component calls `ThemeService.ToggleAsync()`.
-
 ## Code Style
 
 Enforced via `.editorconfig`:
@@ -254,17 +222,17 @@ Enforced via `.editorconfig`:
 
 | Package | Version | Purpose |
 |---------|---------|---------|
-| `ModelContextProtocol` | 1.2.0 | MCP SDK — server hosting, tool/prompt registration |
-| `Microsoft.Data.Sqlite` | 10.0.3 | SQLite access with FTS5 |
-| `Microsoft.Extensions.FileSystemGlobbing` | 10.0.3 | Glob pattern matching for file discovery |
-| `Microsoft.Extensions.Hosting` | 10.0.3 | Generic host for DI, logging |
+| `ModelContextProtocol` | 1.3.0 | MCP SDK — server hosting, tool/prompt registration |
+| `Microsoft.Data.Sqlite` | 10.0.8 | SQLite access with FTS5 |
+| `Microsoft.Extensions.FileSystemGlobbing` | 10.0.8 | Glob pattern matching for file discovery |
+| `Microsoft.Extensions.Hosting` | 10.0.8 | Generic host for DI, logging |
 | `TreeSitter.DotNet` | 1.3.0 | Tree-sitter bindings — AST parsing for C#, Java, Go, TypeScript/JavaScript, Rust, Python |
-| `System.CommandLine` | 2.0.5 | CLI argument parsing (CodeCompress.Cli) |
-| `YamlDotNet` | 16.3.0 | YAML config file parsing |
-| `TUnit` | 1.19.11 | Testing framework |
+| `System.CommandLine` | 2.0.8 | CLI argument parsing (CodeCompress.Cli) |
+| `YamlDotNet` | 18.0.0 | YAML config file parsing |
+| `TUnit` | 1.49.0 | Testing framework |
 | `NSubstitute` | 5.3.0 | Mocking |
-| `Verify` | 31.13.2 | Snapshot testing |
-| `SonarAnalyzer.CSharp` | 10.20.0.135146 | Static analysis |
+| `Verify` | 31.19.0 | Snapshot testing |
+| `SonarAnalyzer.CSharp` | 10.27.0.140913 | Static analysis |
 
 ## Project Skills & References
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,22 +5,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="ModelContextProtocol" Version="1.2.0" />
+    <PackageVersion Include="ModelContextProtocol" Version="1.3.0" />
     <PackageVersion Include="TreeSitter.DotNet" Version="1.3.0" />
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
-    <PackageVersion Include="System.CommandLine" Version="2.0.5" />
-    <PackageVersion Include="YamlDotNet" Version="16.3.0" />
-    <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.20.0.135146" />
-    <PackageVersion Include="TUnit" Version="1.19.11" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.8" />
+    <PackageVersion Include="YamlDotNet" Version="18.0.0" />
+    <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.27.0.140913" />
+    <PackageVersion Include="TUnit" Version="1.49.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
-    <PackageVersion Include="Verify" Version="31.13.2" />
-    <PackageVersion Include="BlazorBlueprint.Components" Version="3.10.0" />
-    <PackageVersion Include="BlazorBlueprint.Primitives" Version="3.10.0" />
-    <PackageVersion Include="Z.Blazor.Diagrams" Version="3.0.4.1" />
-    <PackageVersion Include="Z.Blazor.Diagrams.Algorithms" Version="3.0.4.1" />
-    <PackageVersion Include="bunit" Version="2.7.2" />
+    <PackageVersion Include="Verify" Version="31.19.0" />
   </ItemGroup>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -165,24 +165,6 @@ codecompress search --path /path/to/project --query "MyClass"
 
 The CLI and MCP server share the same index database — you can use both interchangeably. Run `codecompress --help` for all commands, or `codecompress agent-instructions` to generate a ready-to-paste instruction block for AI agents.
 
-### Option C: Web Dashboard (local UI)
-
-Launch a dark-mode Blazor dashboard to browse indexed repositories, search symbols, and trigger re-indexes from a browser:
-
-```bash
-codecompress web
-```
-
-Opens on `http://localhost:7070` by default. Options:
-
-```bash
-codecompress web --port 8080        # custom port
-codecompress web --open             # open browser automatically
-codecompress web --bind 0.0.0.0    # bind to all interfaces (LAN access)
-```
-
-The dashboard reads the same global `~/.code-compress/index.db` as the MCP server and CLI — no separate setup required.
-
 To update: `dotnet tool update -g CodeCompress`
 
 ### 2. Index your project
@@ -387,19 +369,33 @@ CodeCompress is a code intelligence tool that provides compressed, symbol-level 
 to the indexed codebase. Use it as your PRIMARY tool for code discovery instead of reading
 raw files — it saves 80-90% tokens.
 
+## Access Boundary
+
+All paths are scoped to the server's launch directory (or `CODECOMPRESS_ROOT`). Out-of-bounds
+paths are rejected with `INVALID_PATH`. Use `CODECOMPRESS_ALLOWED_ROOTS` for multi-repo workflows.
+
 ## Workflow
 
 1. **Index first** — `index_project` (MCP) or `codecompress index --path <root>` (CLI).
    Builds/updates the symbol database. Incremental — only changed files are re-parsed.
 2. **Assemble context** — `assemble_context` / `codecompress assemble` for one-shot task context.
-   Combines search + source retrieval + file overview within a token budget.
+   Combines search + source retrieval + overview in a single call — replaces 5-10 round-trips.
 3. **Get an overview** — `project_outline` / `codecompress outline` for the full codebase structure.
+   `topic_outline` / `codecompress topic-outline` to scope the overview to a specific topic.
 4. **Search** — `search_symbols` / `codecompress search` for FTS5 full-text symbol search.
-   `search_text` / `codecompress search-text` for raw file content search.
+   `search_text` / `codecompress search-text` for raw file content (literals, comments, config).
 5. **Read symbols** — `get_symbol` / `codecompress get-symbol` to retrieve exact source code.
    `expand_symbol` / `codecompress expand-symbol` for a single method (~60% fewer tokens).
+   `get_hot_path` / `codecompress get-hot-path` for lines matching specific identifiers (10-40x savings).
+   `get_symbols` / `codecompress get-symbols` to batch-retrieve up to 50 symbols at once.
+   `get_module_api` / `codecompress get-module-api` for the public API surface of a file.
 6. **Find references** — `find_references` / `codecompress find-references` to trace usage.
-7. **Dependencies** — `dependency_graph` / `codecompress deps` for import relationships.
+7. **Dependencies** — `dependency_graph` / `codecompress deps` for file import relationships.
+   `blast_radius` / `codecompress blast-radius` for reverse impact analysis.
+   `project_dependencies` / `codecompress project-deps` for inter-project (.NET solution) deps.
+8. **Change tracking** — `snapshot_create` / `codecompress snapshot` to baseline the index.
+   `changes_since` / `codecompress changes` for a symbol-level diff since the snapshot.
+9. **Registry** — `list_repos` / `codecompress list` to see all indexed projects and their status.
 
 ## Tips
 
@@ -500,9 +496,6 @@ codecompress changes --path /path/to/project --label before-refactor
 
 # Delete index to force full re-index
 codecompress invalidate-cache --path /path/to/project
-
-# Launch the web dashboard
-codecompress web [--port 7070] [--bind localhost] [--open]
 ```
 
 ### JSON Output
@@ -545,7 +538,6 @@ This outputs a markdown block you can paste into `CLAUDE.md`, system prompts, or
 | `deps` | `dependency_graph` | File-level dependency graph |
 | `project-deps` | `project_dependencies` | Inter-project dependencies (.NET) |
 | `invalidate-cache` | `invalidate_cache` | Force full re-index |
-| `web` | — | Launch the local Blazor web dashboard |
 
 ## License
 

--- a/src/CodeCompress.Cli/Program.cs
+++ b/src/CodeCompress.Cli/Program.cs
@@ -1775,33 +1775,60 @@ agentInstructionsCommand.SetAction(_ =>
         dotnet tool install -g CodeCompress
         ```
 
+        ## Access Boundary
+
+        The CLI (and the MCP server) are scoped to a boundary root — the directory from which the
+        server was launched, or the value of the `CODECOMPRESS_ROOT` environment variable. All
+        `--path` arguments must resolve within that boundary. Out-of-bounds paths are rejected with
+        INVALID_PATH. Use `CODECOMPRESS_ALLOWED_ROOTS` (OS path-separator-delimited) to add trusted
+        roots for multi-repo workflows.
+
         ## Workflow
 
         1. `codecompress index --path <project-root>` — MUST be called first. Builds/updates the
            symbol database. Incremental — only changed files are re-parsed.
-        2. `codecompress outline --path <project-root>` — Get a compressed overview of the entire
-           codebase (symbols grouped by file). Use --path-filter to scope to a subdirectory.
-        3. `codecompress search --path <project-root> --query <term>` — Find specific symbols using
-           FTS5 full-text search. Faster than grep.
-        4. `codecompress get-symbol --path <project-root> --name <Name>` — Retrieve exact source
-           code by symbol name. Accepts unqualified names (auto-resolved) or Parent:Child format.
-        5. `codecompress expand-symbol --path <project-root> --name <Parent:Method>` — Get a single
+        2. `codecompress assemble --path <project-root> --query <term> [--budget <tokens>]` — One-shot:
+           search symbols, retrieve source, and include a file overview in a single call. Collapses
+           5-10 round-trips into 1. Use as the default starting point for task-specific context.
+        3. `codecompress outline --path <project-root>` — Full codebase overview (symbols grouped by
+           file). Add `--path-filter src/` to scope to a subdirectory.
+        4. `codecompress topic-outline --path <project-root> --topic <term>` — Search for a topic
+           and return matching symbols in outline format. Good for thematic exploration.
+        5. `codecompress search --path <project-root> --query <term>` — FTS5 symbol search. Faster
+           than grep. Auto-retries with contains-match on zero results.
+        6. `codecompress search-text --path <project-root> --query <term>` — Search raw file contents
+           for string literals, comments, config values, or non-symbol patterns.
+        7. `codecompress get-symbol --path <project-root> --name <Name>` — Retrieve exact source code
+           by symbol name. Accepts unqualified names (auto-resolved) or Parent:Child format.
+        8. `codecompress expand-symbol --path <project-root> --name <Parent:Method>` — Extract a single
            method without loading the parent class (~60% fewer tokens than get-symbol on parent).
-        6. `codecompress get-hot-path --path <project-root> --name <Name> --identifiers <id1,id2>` — Return
-           only lines in a symbol that contain specific identifiers plus context. Use when tracing a variable
-           or condition within a large function — 10-40x fewer tokens than get-symbol. Identifiers matched
-           as whole words. Add `--context-lines N` to control surrounding line count (0-10, default 3).
-        7. `codecompress get-symbols --path <project-root> --names <N1,N2,N3>` — Batch retrieve
-           multiple symbols in one call (max 50). Far more efficient than repeated get-symbol.
-        7. `codecompress search-text --path <project-root> --query <term>` — Search raw file contents
-           for string literals, comments, or non-symbol patterns.
-        8. `codecompress deps --path <project-root>` — Understand import/dependency relationships.
-           Add `--edge-kind imports|calls|implements|inherits|references` to filter by edge type.
-        9. `codecompress blast-radius --path <project-root> --file <rel-path>` — Find all files
-           affected if a given file changes (reverse BFS). Use `--symbol <name>` for symbol input.
-        10. `codecompress unused-symbols --path <project-root>` — Best-effort dead code detection.
+        9. `codecompress get-hot-path --path <project-root> --name <Name> --identifiers <id1,id2>` —
+           Return only lines in a symbol that contain specific identifiers plus surrounding context.
+           10-40x fewer tokens than get-symbol. Add `--context-lines N` (0-10, default 3).
+        10. `codecompress get-symbols --path <project-root> --names <N1,N2,N3>` — Batch retrieve up
+            to 50 symbols in one call. Far more efficient than repeated get-symbol.
+        11. `codecompress get-module-api --path <project-root> --module <rel-path>` — Public API
+            surface of a single file — signatures, visibility, and dependencies.
+        12. `codecompress find-references --path <project-root> --name <Name>` — All locations where
+            a symbol is referenced across the codebase.
+        13. `codecompress deps --path <project-root>` — File-level import/dependency relationships.
+            Add `--edge-kind imports|calls|implements|inherits|references` to filter by edge type.
+        14. `codecompress blast-radius --path <project-root> --file <rel-path>` — Reverse BFS: all
+            files that would break if the given file changes. Use `--symbol <name>` for symbol input.
+        15. `codecompress project-deps --path <project-root>` — Inter-project dependencies in .NET
+            solutions. Shows which projects reference which.
+        16. `codecompress unused-symbols --path <project-root>` — Best-effort dead code detection.
             Returns public symbols with no incoming dependency edges.
-        11. `codecompress file-tree --path <project-root>` — Quick directory structure (no index required).
+        17. `codecompress file-tree --path <project-root>` — Annotated directory tree with file and
+            line counts. Does NOT require `index` to be run first.
+        18. `codecompress snapshot --path <project-root> --label <name>` — Create a named baseline
+            of the current index state for change tracking.
+        19. `codecompress changes --path <project-root> --label <name>` — Symbol-level diff since a
+            named snapshot: new, modified, and deleted symbols.
+        20. `codecompress list` — List all projects in the global registry with file/symbol counts
+            and last-indexed times. No `--path` required.
+        21. `codecompress invalidate-cache --path <project-root>` — Delete all indexed data for a
+            project, forcing a full re-parse on the next `index` call.
 
         ## JSON Output (--json)
 
@@ -1809,6 +1836,7 @@ agentInstructionsCommand.SetAction(_ =>
 
         Key response shapes:
         - index: {repo_id, project_root, files_indexed, files_unchanged, symbols_found, duration_ms}
+        - assemble: {overview, symbols: [{name, kind, source}], token_estimate}
         - search: [{name, kind, parent, file, line, signature, snippet, rank}]
         - get-symbol: {id, file_id, name, kind, signature, parent_symbol, line_start, line_end, ...}
         - search-text: [{file_path, snippet, rank}]
@@ -1827,9 +1855,10 @@ agentInstructionsCommand.SetAction(_ =>
 
         ## Performance Tips
 
+        - Start with `assemble` — it collapses search + retrieval into one call.
         - Use `get-symbols` for batches — single call vs N separate get-symbol calls.
         - Use `expand-symbol` for one method in a large class — ~60% fewer tokens.
-        - Use `get-hot-path` to trace a specific variable or condition — 10-40x fewer tokens than expand-symbol.
+        - Use `get-hot-path` to trace a specific variable or condition — 10-40x fewer tokens.
         - Use `search` (not search-text) for finding classes/functions — structured results.
         - Use `outline --path-filter src/` to scope — faster than full outline + client filtering.
         - Symbol names accept unqualified names (e.g., 'MyMethod') — auto-resolved if unique.


### PR DESCRIPTION
## Summary

### Package changes
- Removed web-only packages from `Directory.Packages.props`: `BlazorBlueprint.Components`, `BlazorBlueprint.Primitives`, `Z.Blazor.Diagrams`, `Z.Blazor.Diagrams.Algorithms`, `bunit` — none referenced by any project in the solution
- Bumped all packages with available updates (all 1,329 tests pass after upgrade):

| Package | Before | After | Risk |
|---|---|---|---|
| ModelContextProtocol | 1.2.0 | 1.3.0 | Low — `ClientTransportClosedException` is now `IOException`; stdio transport unaffected |
| Microsoft.Data.Sqlite / Extensions.* | 10.0.3 | 10.0.8 | None — .NET 10 servicing patches |
| System.CommandLine | 2.0.5 | 2.0.8 | None — patch releases |
| YamlDotNet | 16.3.0 | 18.0.0 | Low — no custom type inspectors in this project |
| SonarAnalyzer.CSharp | 10.20.0 | 10.27.0 | Low — new rules; build verified clean |
| TUnit | 1.19.11 | 1.49.0 | Low — obsolete API removals in v1.27; build + tests verified clean |
| Verify | 31.13.2 | 31.19.0 | Low — pre-v30 obsolete removals; verified clean |

### Documentation
- Removed the `## Web Dashboard (CodeCompress.Web)` section from `CLAUDE.md`
- Updated the `Key NuGet Packages` table in `CLAUDE.md` to current versions
- Removed the "Option C: Web Dashboard" section and `codecompress web` references from `README.md`
- Fixed duplicate step `7.` numbering in the `agent-instructions` CLI output
- Added all previously undocumented commands to agent instructions: `assemble`, `topic-outline`, `get-module-api`, `find-references`, `project-deps`, `snapshot`, `changes`, `list`, `invalidate-cache`
- Added access boundary documentation to agent instructions and README agent config block
- Updated README inline agent configuration block to cover all tools and new MCP/CLI parity

## Notes for future release evaluation

The following findings from the version research may warrant work before the next release:

- **ModelContextProtocol 1.3.0 — `ClientTransportClosedException`**: Any code that catches `InvalidOperationException` around MCP client creation should be updated to catch `IOException`. Not impactful today (no client-side MCP code in this project) but worth noting if client usage is added.
- **YamlDotNet 18.0.0 — `ITypeInspector` interface**: Two new required methods (`HasParseMethod`, `Parse`) must be implemented by any custom `ITypeInspector`. CodeCompress has no custom type inspectors, so no action needed now.
- **TUnit 1.49.0 — `.Should()` beta syntax**: Optional new fluent assertion syntax available as an alternative to `await Assert.That(...)`. Not a breaking change but worth evaluating for consistency.

## Test plan

- [x] `dotnet build CodeCompress.slnx` — 0 errors, 0 warnings
- [x] `dotnet test CodeCompress.slnx` — 1,329 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)